### PR TITLE
Add GitHub Actions CI pipeline for push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
 
       - name: Test
         run: npm run test
+        env:
+          # client.ts throws at module-load time if DATABASE_URL is unset.
+          # The test suite only exercises pure functions (getBlockReason) —
+          # no real DB connection is made, so a placeholder URL is sufficient.
+          DATABASE_URL: postgresql://localhost/ci_test
+          NODE_ENV: test


### PR DESCRIPTION
Replaces the existing multi-trigger workflow with a focused pipeline that runs on push to main only: install deps, build, lint, and test.