### PR TITLE
AI: add verifiable work audit trail

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -16,3 +16,7 @@ bash scripts/ai-verify.sh
 5. Always produce the smallest safe patch
 6. Do not refactor unrelated areas
 7. Do not rewrite architecture unless explicitly required
+8. After each completed task, Claude must update AI_STATUS.md
+9. After each completed task, Claude must move the task in AI_TASKS.md from OPEN to DONE
+10. Commit messages for AI work should start with:
+    AI:

--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -1,0 +1,32 @@
+# AI Work Status
+
+## Last completed task
+- Task: Finalize Claude automation system and fix Docker compose path
+- Branch: ai/final-automation-system
+- Commit: 4105a71
+- Verification: passed
+- Checks passed:
+  - CI / api-check
+  - Docker Smoke Test / docker-test
+- Files changed:
+  - .github/workflows/ci.yml
+  - .github/workflows/docker-check.yml
+  - scripts/ai-verify.sh
+  - scripts/ai-task.sh
+  - AI_TASKS.md
+  - AI_RULES.md
+  - CLAUDE.md
+  - infra/docker-compose.yml
+  - apps/api/package-lock.json
+  - .gitignore
+- Date: 2026-03-06
+
+## Rules
+After every completed AI task, Claude must update this file with:
+- task name
+- branch
+- commit hash
+- verification result
+- checks passed
+- files changed
+- date

--- a/AI_TASKS.md
+++ b/AI_TASKS.md
@@ -8,10 +8,16 @@ Workflow:
 3. Run verification
 4. Commit
 5. Mark task DONE
-6. Move to next task
+6. Update AI_STATUS.md
+7. Move to next task
+
+## DONE
+- Fix CI reliability and workflow stability
+- Add Docker smoke verification and fix compose path
+- Add autonomous AI workflow files
+- Fix CI lint step when ESLint config is missing
 
 ## OPEN
-- Fix CI reliability and workflow stability
 - Add Stripe checkout endpoint for subscription creation
 - Add Twilio inbound webhook test coverage
 - Add Google Calendar booking confirmation logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,28 @@ After every completed task Claude MUST:
    - What passed/failed
 2. Suggest the next highest-value task for the repository.
 
+## AI Audit Trail
+
+Claude must leave a repository-visible audit trail after every completed task.
+
+Required updates after each completed task:
+1. Update AI_STATUS.md with:
+   - task name
+   - branch
+   - commit hash
+   - verification result
+   - checks passed
+   - files changed
+   - date
+
+2. Update AI_TASKS.md:
+   - move completed task from OPEN to DONE
+
+3. Use commit messages starting with:
+   AI:
+
+Do not rewrite unrelated sections.
+
 Claude should always prefer:
 - small patches
 - minimal changes

--- a/scripts/ai-task.sh
+++ b/scripts/ai-task.sh
@@ -7,8 +7,14 @@ if [ ! -f AI_TASKS.md ]; then
   exit 1
 fi
 
-echo "Next tasks:"
-grep -n "OPEN\|DONE\|-" AI_TASKS.md || true
+echo ""
+echo "=== DONE tasks ==="
+awk '/^## DONE/{found=1; next} /^## /{found=0} found && /^-/{print}' AI_TASKS.md
+
+echo ""
+echo "=== OPEN tasks ==="
+awk '/^## OPEN/{found=1; next} /^## /{found=0} found && /^-/{print}' AI_TASKS.md
 
 echo ""
 echo "Select the first OPEN task and implement it."
+echo "After completion, remember to update AI_STATUS.md."


### PR DESCRIPTION
## Summary
- Creates `AI_STATUS.md` with machine-readable audit record of last completed AI task
- Restructures `AI_TASKS.md` with explicit DONE/OPEN sections and step to update AI_STATUS.md
- Adds rules 8–10 to `AI_RULES.md` (update status file, move tasks, use `AI:` commit prefix)
- Appends `## AI Audit Trail` section to `CLAUDE.md`
- Improves `scripts/ai-task.sh` to print DONE/OPEN task lists and reminder

## Test plan
- [ ] `AI_STATUS.md` exists in repo root with correct structure
- [ ] `AI_TASKS.md` has DONE and OPEN sections
- [ ] `AI_RULES.md` contains rules 8, 9, 10
- [ ] `CLAUDE.md` contains `## AI Audit Trail` section
- [ ] `scripts/ai-task.sh` prints DONE/OPEN tasks and reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)