### PR TITLE
fix: remove cleanUrls from vercel.json — .html links 404 in production

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "outputDirectory": "apps/web",
   "trailingSlash": false,
-  "cleanUrls": true,
   "rewrites": [
     { "source": "/health", "destination": "https://autoshop-api-7ek9.onrender.com/health" },
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },


### PR DESCRIPTION
cleanUrls: true makes Vercel return 404 for all .html URLs instead of serving the file. Every internal link in the codebase uses .html extensions (login.html, signup.html, app.html, etc). The config was inconsistent with the code, breaking all page navigation in production.

Verified:
- /signup returns 200 (clean URL works with cleanUrls: true)
- /signup.html returns 404 (root cause confirmed live)
- /login.html returns 404 (same issue)
- All apps/web/*.html files referenced internally with .html extension

Fix: remove cleanUrls: true so Vercel serves .html files at their natural paths, consistent with how all internal links are written.