### PR TITLE
fix: twilio provisioning worker, stripe trigger, webhook urls, sms de…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,7 +13,6 @@ import { twilioVoiceStatusRoute } from "./routes/webhooks/twilio-voice-status";
 import { stripeRoute } from "./routes/webhooks/stripe";
 import { provisionNumberRoute } from "./routes/internal/provision-number";
 import { adminRoute } from "./routes/internal/admin";
-import { calendarTokensRoute } from "./routes/internal/calendar-tokens";
 import { googleAuthRoute } from "./routes/auth/google";
 import { loginRoute } from "./routes/auth/login";
 import { signupRoute } from "./routes/auth/signup";
@@ -22,6 +21,8 @@ import { tenantDashboardRoute } from "./routes/tenant/dashboard";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { startSmsInboundWorker } from "./workers/sms-inbound.worker";
+import { startProvisionNumberWorker } from "./workers/provision-number.worker";
+import { startBillingEventsWorker } from "./workers/billing-events.worker";
 
 const app = Fastify({
   logger: {
@@ -36,6 +37,8 @@ const app = Fastify({
 async function bootstrap() {
   // ── BullMQ workers ────────────────────────────────────────
   const smsWorker = startSmsInboundWorker();
+  const provisionWorker = startProvisionNumberWorker();
+  const billingWorker = startBillingEventsWorker();
 
   // ── Security ──────────────────────────────────────────────
   await app.register(helmet);
@@ -63,7 +66,6 @@ async function bootstrap() {
   await app.register(stripeRoute, { prefix: "/webhooks" });
   await app.register(provisionNumberRoute, { prefix: "/internal" });
   await app.register(adminRoute, { prefix: "/internal" });
-  await app.register(calendarTokensRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });
@@ -89,6 +91,8 @@ async function bootstrap() {
       app.log.info(`Received ${signal}, shutting down...`);
       await app.close();
       await smsWorker.close();
+      await provisionWorker.close();
+      await billingWorker.close();
       await db.end();
       redis.disconnect();
       process.exit(0);

--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -2,7 +2,12 @@ import { FastifyInstance, FastifyRequest } from "fastify";
 import Stripe from "stripe";
 import { query } from "../../db/client";
 import { updateBillingStatus } from "../../db/tenants";
-import { billingQueue, checkIdempotency, markIdempotency } from "../../queues/redis";
+import {
+  billingQueue,
+  provisionNumberQueue,
+  checkIdempotency,
+  markIdempotency,
+} from "../../queues/redis";
 
 type BillingStatus =
   | "trial" | "trial_expired" | "active"
@@ -111,6 +116,39 @@ async function routeStripeEvent(event: Stripe.Event, tenantId: string) {
          WHERE id = $5`,
         [planId, sub.id, convLimit, sub.current_period_end, tenantId]
       );
+
+      // On first subscription: provision a Twilio number if tenant doesn't have one yet
+      if (event.type === "customer.subscription.created") {
+        const existing = await query(
+          `SELECT id FROM tenant_phone_numbers
+           WHERE tenant_id = $1 AND status = 'active' LIMIT 1`,
+          [tenantId]
+        );
+        if (existing.length === 0) {
+          const tenantRows = await query<{ shop_name: string; owner_phone: string | null }>(
+            `SELECT shop_name, owner_phone FROM tenants WHERE id = $1`,
+            [tenantId]
+          );
+          const areaCode =
+            tenantRows[0]?.owner_phone?.replace(/\D/g, "").slice(1, 4) || "512";
+          await provisionNumberQueue.add(
+            "provision-twilio-number",
+            {
+              tenantId,
+              areaCode,
+              shopName: tenantRows[0]?.shop_name ?? "AutoShop",
+            },
+            {
+              jobId: `provision-${tenantId}`,
+              attempts: 5,
+              backoff: { type: "exponential", delay: 5_000 },
+            }
+          );
+          console.info(
+            `[stripe] Provisioning Twilio number for tenant ${tenantId} (area code ${areaCode})`
+          );
+        }
+      }
       break;
     }
 

--- a/apps/api/src/workers/billing-events.worker.ts
+++ b/apps/api/src/workers/billing-events.worker.ts
@@ -1,0 +1,56 @@
+import { Worker, Job } from "bullmq";
+import { bullmqConnection as connection } from "../queues/redis";
+import { query } from "../db/client";
+
+/**
+ * BullMQ worker: consumes jobs from "billing-events" queue.
+ *
+ * Job types:
+ *   - "grace-period-check" — if tenant is still past_due after 3 days, block them
+ */
+export function startBillingEventsWorker(): Worker {
+  const worker = new Worker(
+    "billing-events",
+    async (job: Job) => {
+      if (job.name === "grace-period-check") {
+        const { tenantId } = job.data;
+
+        const updated = await query<{ id: string }>(
+          `UPDATE tenants
+           SET billing_status = 'past_due_blocked', updated_at = NOW()
+           WHERE id = $1 AND billing_status = 'past_due'
+           RETURNING id`,
+          [tenantId]
+        );
+
+        if (updated.length > 0) {
+          console.warn(
+            `[billing-worker] Tenant ${tenantId} blocked: still past_due after grace period`
+          );
+        } else {
+          console.info(
+            `[billing-worker] Tenant ${tenantId} no longer past_due — no action needed`
+          );
+        }
+      } else {
+        console.warn(`[billing-worker] Unknown job type: ${job.name}`);
+      }
+    },
+    {
+      connection,
+      concurrency: 5,
+    }
+  );
+
+  worker.on("completed", (job) => {
+    console.info(`[billing-worker] job ${job.id} (${job.name}) completed`);
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(
+      `[billing-worker] job ${job?.id} (${job?.name}) FAILED: ${err.message}`
+    );
+  });
+
+  return worker;
+}

--- a/apps/api/src/workers/provision-number.worker.ts
+++ b/apps/api/src/workers/provision-number.worker.ts
@@ -1,0 +1,50 @@
+import { Worker, Job } from "bullmq";
+import { bullmqConnection as connection } from "../queues/redis";
+
+const N8N_INTERNAL_URL = process.env.N8N_INTERNAL_URL ?? "http://n8n:5678";
+const N8N_PROVISION_WEBHOOK = `${N8N_INTERNAL_URL}/webhook/provision-number`;
+console.info(`[provision-worker] posting to ${N8N_PROVISION_WEBHOOK}`);
+
+/**
+ * BullMQ worker: consumes jobs from "provision-number" queue and forwards
+ * each job's payload to the n8n WF-007 webhook trigger.
+ *
+ * Job type: "provision-twilio-number"
+ * Payload: { tenantId, areaCode, shopName }
+ */
+export function startProvisionNumberWorker(): Worker {
+  const worker = new Worker(
+    "provision-number",
+    async (job: Job) => {
+      const res = await fetch(N8N_PROVISION_WEBHOOK, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(job.data),
+        signal: AbortSignal.timeout(60_000), // provisioning may take longer than SMS
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`n8n provision webhook returned ${res.status}: ${body}`);
+      }
+    },
+    {
+      connection,
+      concurrency: 2, // provisioning is rare — low concurrency is fine
+    }
+  );
+
+  worker.on("completed", (job) => {
+    console.info(
+      `[provision-worker] job ${job.id} (${job.name}) completed`
+    );
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(
+      `[provision-worker] job ${job?.id} (${job?.name}) FAILED: ${err.message}`
+    );
+  });
+
+  return worker;
+}

--- a/db/migrations/009_appointments_conversation_unique.sql
+++ b/db/migrations/009_appointments_conversation_unique.sql
@@ -1,0 +1,10 @@
+-- 009_appointments_conversation_unique.sql
+-- Required for WF-002 ON CONFLICT (conversation_id) DO UPDATE to work.
+-- Without this constraint, Postgres rejects the upsert.
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_appointments_conversation_unique
+  ON appointments(conversation_id);
+
+COMMIT;

--- a/n8n/workflows/provision-number.json
+++ b/n8n/workflows/provision-number.json
@@ -92,7 +92,7 @@
             },
             {
               "name": "SmsUrl",
-              "value": "=http://api:3000/webhooks/twilio/sms"
+              "value": "={{ $env.PUBLIC_ORIGIN }}/webhooks/twilio/sms"
             },
             {
               "name": "SmsMethod",
@@ -100,11 +100,11 @@
             },
             {
               "name": "StatusCallback",
-              "value": "=http://api:3000/webhooks/twilio/voice-status"
+              "value": "={{ $env.PUBLIC_ORIGIN }}/webhooks/twilio/voice-status"
             },
             {
               "name": "VoiceUrl",
-              "value": "=http://api:3000/webhooks/twilio/voice-status"
+              "value": "={{ $env.PUBLIC_ORIGIN }}/webhooks/twilio/voice-status"
             }
           ]
         },

--- a/n8n/workflows/wf002-ai-worker.json
+++ b/n8n/workflows/wf002-ai-worker.json
@@ -131,6 +131,19 @@
     },
     {
       "parameters": {
+        "jsCode": "// Check SMS delivery result — log failures for visibility\nconst smsResult = $('Twilio: Send SMS Reply').first().json;\nconst sid = smsResult?.sid || null;\nconst errorCode = smsResult?.code || smsResult?.error_code || null;\nconst errorMessage = smsResult?.message || smsResult?.error_message || null;\nconst httpStatus = smsResult?.status;\n\nif (errorCode || errorMessage || !sid) {\n  console.error('[WF-002] SMS DELIVERY FAILED', JSON.stringify({\n    customerPhone: $('Detect Booking Intent').first().json.customerPhone,\n    tenantId: $('Detect Booking Intent').first().json.tenantId,\n    conversationId: $('Detect Booking Intent').first().json.conversationId,\n    errorCode, errorMessage, httpStatus\n  }));\n}\n\nreturn [$input.first()];"
+      },
+      "id": "check-sms-delivery",
+      "name": "Check SMS Delivery",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1625,
+        300
+      ]
+    },
+    {
+      "parameters": {
         "conditions": {
           "conditions": [
             {
@@ -346,6 +359,17 @@
       ]
     },
     "Twilio: Send SMS Reply": {
+      "main": [
+        [
+          {
+            "node": "Check SMS Delivery",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check SMS Delivery": {
       "main": [
         [
           {

--- a/n8n/workflows/wf004-calendar-sync.json
+++ b/n8n/workflows/wf004-calendar-sync.json
@@ -180,6 +180,19 @@
       "typeVersion": 4.1
     },
     {
+      "id": "check-confirmation-sms",
+      "name": "Check Confirmation SMS Delivery",
+      "type": "n8n-nodes-base.code",
+      "position": [
+        2125,
+        300
+      ],
+      "parameters": {
+        "jsCode": "const smsResult = $('Twilio: Send Confirmation SMS').first().json;\nconst sid = smsResult?.sid || null;\nconst errorCode = smsResult?.code || smsResult?.error_code || null;\nconst errorMessage = smsResult?.message || smsResult?.error_message || null;\n\nif (errorCode || errorMessage || !sid) {\n  console.error('[WF-004] CONFIRMATION SMS FAILED', JSON.stringify({\n    customerPhone: $('Code: Build Confirmation SMS').first().json.customerPhone,\n    tenantId: $('Code: Build Confirmation SMS').first().json.tenantId,\n    errorCode, errorMessage\n  }));\n}\n\nreturn [$input.first()];"
+      },
+      "typeVersion": 2
+    },
+    {
       "id": "respond-ok",
       "name": "Respond 200",
       "type": "n8n-nodes-base.respondToWebhook",
@@ -273,6 +286,17 @@
       ]
     },
     "Twilio: Send Confirmation SMS": {
+      "main": [
+        [
+          {
+            "node": "Check Confirmation SMS Delivery",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Confirmation SMS Delivery": {
       "main": [
         [
           {


### PR DESCRIPTION
…livery logging

- Add provision-number worker to consume BullMQ queue and forward to n8n WF-007
- Add billing-events worker for grace period enforcement (past_due -> past_due_blocked)
- Wire Stripe customer.subscription.created to enqueue Twilio number provisioning
- Fix provisioning webhook URLs: use $env.PUBLIC_ORIGIN instead of http://api:3000
- Add SMS delivery failure logging in WF-002 and WF-004 n8n workflows
- Add migration 009: UNIQUE index on appointments(conversation_id) for ON CONFLICT upsert