### PR TITLE
fix: WF-007 $json.body wrapping and responseMode for webhook v1.1

### DIFF
--- a/n8n/workflows/provision-number.json
+++ b/n8n/workflows/provision-number.json
@@ -4,7 +4,7 @@
     {
       "parameters": {
         "path": "provision-number",
-        "responseMode": "responseNode",
+        "responseMode": "lastNode",
         "options": {}
       },
       "id": "webhook-trigger",
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validate input\nconst data = $json;\nif (!data.tenantId || !data.areaCode) {\n  throw new Error('Missing tenantId or areaCode');\n}\n\n// Texas area codes fallback list\nconst TX_AREA_CODES = ['512', '737', '210', '214', '972', '469', '817', '682', '281', '832', '713', '346', '361', '915', '806', '903', '936', '956'];\n\nconst primaryAreaCode = data.areaCode;\nconst fallbacks = TX_AREA_CODES.filter(c => c !== primaryAreaCode).slice(0, 3);\n\nreturn [{\n  json: {\n    tenantId: data.tenantId,\n    areaCode: primaryAreaCode,\n    fallbackAreaCodes: fallbacks,\n    shopName: data.shopName || 'AutoShop',\n    attempt: 0,\n  }\n}];"
+        "jsCode": "// Validate input — webhook v1.1 wraps POST body under $json.body\nconst data = $json.body || $json;\nif (!data.tenantId || !data.areaCode) {\n  throw new Error('Missing tenantId or areaCode');\n}\n\n// Texas area codes fallback list\nconst TX_AREA_CODES = ['512', '737', '210', '214', '972', '469', '817', '682', '281', '832', '713', '346', '361', '915', '806', '903', '936', '956'];\n\nconst primaryAreaCode = data.areaCode;\nconst fallbacks = TX_AREA_CODES.filter(c => c !== primaryAreaCode).slice(0, 3);\n\nreturn [{\n  json: {\n    tenantId: data.tenantId,\n    areaCode: primaryAreaCode,\n    fallbackAreaCodes: fallbacks,\n    shopName: data.shopName || 'AutoShop',\n    attempt: 0,\n  }\n}];"
       },
       "id": "validate-input",
       "name": "Validate + Prepare",


### PR DESCRIPTION
- Validate+Prepare now reads $json.body (webhook typeVersion 1.1 wraps POST payload under .body). Previously always threw "Missing tenantId".
- Changed responseMode from "responseNode" to "lastNode" so the provision worker receives a timely HTTP response instead of timing out and retrying (which could purchase duplicate Twilio numbers).