### PR TITLE
AI: fix billing buttons reading JWT from wrong localStorage key

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -1603,14 +1603,14 @@ function renderBillingPage() {
 // BILLING ACTIONS
 // ════════════════════════════════════════════
 async function startCheckout(plan) {
-  var session = JSON.parse(localStorage.getItem('autoshop_session') || '{}');
-  if (!session.token) { showToast('Session expired — please log in again.'); return; }
+  var token = localStorage.getItem('autoshop_jwt');
+  if (!token) { showToast('Session expired — please log in again.'); return; }
 
   showToast('Redirecting to Stripe checkout...');
   try {
     var res = await fetch('/billing/checkout', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + session.token },
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
       body: JSON.stringify({
         plan: plan,
         successUrl: window.location.origin + '/app.html?billing=success',
@@ -1628,13 +1628,13 @@ async function startCheckout(plan) {
 }
 
 async function openBillingPortal() {
-  var session = JSON.parse(localStorage.getItem('autoshop_session') || '{}');
-  if (!session.token) { showToast('Session expired — please log in again.'); return; }
+  var token = localStorage.getItem('autoshop_jwt');
+  if (!token) { showToast('Session expired — please log in again.'); return; }
 
   showToast('Opening billing portal...');
   try {
     var res = await fetch('/billing/portal', {
-      headers: { 'Authorization': 'Bearer ' + session.token }
+      headers: { 'Authorization': 'Bearer ' + token }
     });
     if (res.status === 401) { showToast('Session expired — please log in again.'); return; }
     var data = await res.json();


### PR DESCRIPTION
startCheckout() and openBillingPortal() were reading session.token from autoshop_session, but login.html stores the JWT in a separate autoshop_jwt key. The autoshop_session object only contains { email, tenantId, shopName, loginAt } — no token field.

Changed both functions to read localStorage.getItem('autoshop_jwt') which matches how login.html stores the token and how loadDashboardData() already reads it.