### PR TITLE
chore: track notification scripts and sandbox test workflows

### DIFF
--- a/n8n/workflows/TEST/wf001-lt-sandbox-missed-call.json
+++ b/n8n/workflows/TEST/wf001-lt-sandbox-missed-call.json
@@ -1,0 +1,359 @@
+{
+  "id": "LT-SANDBOX-WF001-missed-call",
+  "name": "LT_PROTEROS_SANDBOX: WF001 Missed Call Event",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-sandbox-missed-call",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "sb-mc-webhook",
+      "name": "Webhook: Zadarma Call Event",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "lt-sandbox-missed-call"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse Zadarma PBX call event\n// Zadarma sends: caller_id, called_did, call_start, duration, disposition, pbx_call_id\nconst body = $input.first().json.body || $input.first().json;\nconst callerPhone = (body.caller_id || body.caller_phone || body.from || body.caller_number || body.number || '').replace(/[^+\\d]/g, '');\nconst calledDid = body.called_did || body.called_number || body.to || '+37045512300';\nconst duration = parseInt(body.duration || body.seconds || '0', 10);\nconst disposition = (body.disposition || body.status || body.result || '').toLowerCase();\nconst callId = body.pbx_call_id || body.call_id || body.call_id_with_rec || $execution.id;\nconst callStart = body.call_start || body.timestamp || body.callstart || new Date().toISOString();\nconst eventType = (body.event || body.type || '').toUpperCase();\n\n// Skip NOTIFY_START events - only process end/unknown events\nif (eventType === 'NOTIFY_START' || eventType === 'NOTIFY_OUT_START') {\n  return [{ json: { isMissed: false, phoneValid: false, callerPhone, calledDid, duration, disposition, callId, callStart, eventType, reason: 'call_start_event_ignored', raw: body } }];\n}\n\n// Missed call = duration < 10 seconds OR disposition contains 'no-answer'/'missed'/'busy'\nconst isMissed = duration < 10 || ['no-answer', 'missed', 'busy', 'noanswer', 'cancel'].includes(disposition);\n\n// Validate Lithuanian phone\nconst phoneValid = /^\\+370\\d{7,8}$/.test(callerPhone);\n\nreturn [{\n  json: {\n    isMissed,\n    phoneValid,\n    callerPhone,\n    calledDid,\n    duration,\n    disposition,\n    callId,\n    callStart,\n    eventType,\n    raw: body\n  }\n}];"
+      },
+      "id": "sb-mc-parse",
+      "name": "Parse Zadarma Call Event",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-missed",
+              "leftValue": "={{ $json.isMissed }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            },
+            {
+              "id": "cond-phone-valid",
+              "leftValue": "={{ $json.phoneValid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-mc-if-missed",
+      "name": "Is Missed Call (<10s) + Valid Phone?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Dedup: skip if same caller within 30 minutes\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.recentCalls) staticData.recentCalls = {};\n\nconst phone = $input.first().json.callerPhone;\nconst now = Date.now();\n\n// Purge entries older than 30 min\nfor (const key of Object.keys(staticData.recentCalls)) {\n  if (now - staticData.recentCalls[key] > 30 * 60 * 1000) {\n    delete staticData.recentCalls[key];\n  }\n}\n\nif (staticData.recentCalls[phone]) {\n  return [{ json: { duplicate: true, callerPhone: phone, reason: 'Already processed within 30min' } }];\n}\n\nstaticData.recentCalls[phone] = now;\nreturn [{ json: { duplicate: false, ...$input.first().json } }];"
+      },
+      "id": "sb-mc-dedup",
+      "name": "Deduplicate (30min)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 250]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-not-dup",
+              "leftValue": "={{ $json.duplicate }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-mc-if-new",
+      "name": "Is New?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1250, 250]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/lt-sandbox-send-sms",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ to: $json.callerPhone, message: 'Matome kad skambinote Proteros Servisui.\\nJei norite registracijos parašykite:\\nDATA LAIKAS AUTO PROBLEMA', callId: $json.callId, source: 'missed_call' }) }}",
+        "options": {}
+      },
+      "id": "sb-mc-trigger-sms",
+      "name": "Trigger WF002: Send SMS",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1500, 200],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Calls_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $('Parse Zadarma Call Event').item.json.callStart }}",
+            "phone": "={{ $('Parse Zadarma Call Event').item.json.callerPhone }}",
+            "duration": "={{ $('Parse Zadarma Call Event').item.json.duration }}",
+            "event": "=missed_call_sms_triggered"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "duration", "displayName": "duration", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "event", "displayName": "event", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-mc-log",
+      "name": "Log: Calls_Log (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1750, 200],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"ok\", \"action\": \"sms_triggered\", \"callerPhone\": $('Parse Zadarma Call Event').item.json.callerPhone, \"callId\": $('Parse Zadarma Call Event').item.json.callId } }}",
+        "options": {}
+      },
+      "id": "sb-mc-respond-ok",
+      "name": "Respond: OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [2000, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"skipped\", \"reason\": \"not_missed_or_invalid_phone\" } }}",
+        "options": {}
+      },
+      "id": "sb-mc-respond-skip",
+      "name": "Respond: Skipped",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 500]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"skipped\", \"reason\": \"duplicate_within_30min\" } }}",
+        "options": {}
+      },
+      "id": "sb-mc-respond-dup",
+      "name": "Respond: Duplicate",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1500, 400]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Errors",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "workflow": "=WF001_LT_MISSED_CALL_EVENT",
+            "error": "={{ $json.reason || 'skipped: not missed or invalid phone' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "workflow", "displayName": "workflow", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "error", "displayName": "error", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-mc-log-error",
+      "name": "Log: Error (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [750, 500],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook: Zadarma Call Event": {
+      "main": [
+        [
+          {
+            "node": "Parse Zadarma Call Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Zadarma Call Event": {
+      "main": [
+        [
+          {
+            "node": "Is Missed Call (<10s) + Valid Phone?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Missed Call (<10s) + Valid Phone?": {
+      "main": [
+        [
+          {
+            "node": "Deduplicate (30min)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log: Error (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Error (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: Skipped",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Deduplicate (30min)": {
+      "main": [
+        [
+          {
+            "node": "Is New?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is New?": {
+      "main": [
+        [
+          {
+            "node": "Trigger WF002: Send SMS",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond: Duplicate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Trigger WF002: Send SMS": {
+      "main": [
+        [
+          {
+            "node": "Log: Calls_Log (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Calls_Log (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_SANDBOX" },
+    { "name": "missed-call" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf002-lt-sandbox-send-sms.json
+++ b/n8n/workflows/TEST/wf002-lt-sandbox-send-sms.json
@@ -1,0 +1,332 @@
+{
+  "id": "LT-SANDBOX-WF002-send-sms",
+  "name": "LT_PROTEROS_SANDBOX: WF002 Send SMS",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-sandbox-send-sms",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "sb-sms-webhook",
+      "name": "Webhook: Send SMS Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "lt-sandbox-send-sms"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || $input.first().json;\nconst to = (body.to || '').replace(/[^+\\d]/g, '');\nconst message = body.message || '';\nconst source = body.source || 'manual';\nconst callId = body.callId || '';\n\nif (!to || !message) {\n  return [{ json: { valid: false, reason: 'Missing to or message' } }];\n}\n\nif (!/^\\+370\\d{7,8}$/.test(to)) {\n  return [{ json: { valid: false, reason: 'Invalid LT phone: ' + to } }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    to,\n    message,\n    from: '+37045512300',\n    source,\n    callId,\n    timestamp: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "sb-sms-validate",
+      "name": "Validate SMS Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-sms-if-valid",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build Zadarma SMS API request\n// Zadarma SMS API: POST https://api.zadarma.com/v1/sms/send/\n// Auth: HMAC-SHA1 signature\nconst crypto = require('crypto');\n\nconst apiKey = $env.ZADARMA_API_KEY;\nconst apiSecret = $env.ZADARMA_API_SECRET;\n\nif (!apiKey || !apiSecret) {\n  throw new Error('ZADARMA_API_KEY and ZADARMA_API_SECRET env vars must be set in n8n');\n}\n\nconst to = $input.first().json.to;\nconst message = $input.first().json.message;\nconst from = $input.first().json.from;\n\n// Zadarma API params (sorted alphabetically for signature)\nconst params = {\n  caller_id: from,\n  message: message,\n  number: to\n};\n\n// Build query string sorted by key\nconst sortedKeys = Object.keys(params).sort();\nconst queryParts = sortedKeys.map(k => k + '=' + encodeURIComponent(params[k]));\nconst queryString = queryParts.join('&');\n\n// Zadarma signature: base64(hmac-sha1(apiSecret, apiPath + queryString + md5(queryString)))\nconst apiPath = '/v1/sms/send/';\nconst md5Hash = crypto.createHash('md5').update(queryString).digest('hex');\nconst signData = apiPath + queryString + md5Hash;\nconst signature = crypto.createHmac('sha1', apiSecret).update(signData).digest('base64');\nconst authHeader = apiKey + ':' + signature;\n\nreturn [{\n  json: {\n    url: 'https://api.zadarma.com/v1/sms/send/',\n    authHeader,\n    params,\n    to,\n    message,\n    from,\n    source: $input.first().json.source,\n    callId: $input.first().json.callId,\n    timestamp: $input.first().json.timestamp\n  }\n}];"
+      },
+      "id": "sb-sms-build-zadarma",
+      "name": "Build Zadarma SMS Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 250]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.zadarma.com/v1/sms/send/",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "={{ $json.authHeader }}" }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "number", "value": "={{ $json.params.number }}" },
+            { "name": "message", "value": "={{ $json.params.message }}" },
+            { "name": "caller_id", "value": "={{ $json.params.caller_id }}" }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "sb-sms-send",
+      "name": "Zadarma: Send SMS",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1250, 250],
+      "continueOnFail": true,
+      "notes": "Sends SMS via Zadarma API. continueOnFail=true to log errors."
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\nconst prevData = $('Build Zadarma SMS Request').first().json;\nconst success = response.status === 'success' || response.result === 'success';\n\nreturn [{\n  json: {\n    success,\n    to: prevData.to,\n    message: prevData.message,\n    from: prevData.from,\n    source: prevData.source,\n    callId: prevData.callId,\n    timestamp: prevData.timestamp,\n    apiResponse: response\n  }\n}];"
+      },
+      "id": "sb-sms-check-result",
+      "name": "Check SMS Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 250]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "SMS_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.timestamp }}",
+            "phone": "={{ $json.to }}",
+            "direction": "=outbound",
+            "message": "={{ $json.message }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "direction", "displayName": "direction", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "message", "displayName": "message", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-sms-log",
+      "name": "Log: SMS_Log (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1750, 250],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": $json.success ? 'sent' : 'failed', \"to\": $json.to, \"source\": $json.source } }}",
+        "options": {}
+      },
+      "id": "sb-sms-respond-ok",
+      "name": "Respond: SMS Result",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [2000, 250]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Errors",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "workflow": "=WF002_LT_SEND_SMS",
+            "error": "={{ $json.reason || 'invalid SMS request' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "workflow", "displayName": "workflow", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "error", "displayName": "error", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-sms-log-error",
+      "name": "Log: Error (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [750, 500],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"error\", \"reason\": $json.reason || 'invalid request' } }}",
+        "options": {}
+      },
+      "id": "sb-sms-respond-error",
+      "name": "Respond: Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 500]
+    }
+  ],
+  "connections": {
+    "Webhook: Send SMS Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate SMS Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate SMS Request": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Build Zadarma SMS Request",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log: Error (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Error (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Zadarma SMS Request": {
+      "main": [
+        [
+          {
+            "node": "Zadarma: Send SMS",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zadarma: Send SMS": {
+      "main": [
+        [
+          {
+            "node": "Check SMS Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check SMS Result": {
+      "main": [
+        [
+          {
+            "node": "Log: SMS_Log (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: SMS_Log (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: SMS Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_SANDBOX" },
+    { "name": "sms" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf003-lt-sandbox-sms-ai-agent.json
+++ b/n8n/workflows/TEST/wf003-lt-sandbox-sms-ai-agent.json
@@ -1,0 +1,396 @@
+{
+  "id": "LT-SANDBOX-WF003-sms-ai-agent",
+  "name": "LT_PROTEROS_SANDBOX: WF003 SMS AI Agent",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-sandbox-sms-inbound",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "sb-ai-webhook",
+      "name": "Webhook: Inbound SMS",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 400],
+      "webhookId": "lt-sandbox-sms-inbound"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse Zadarma inbound SMS or manual test payload\nconst body = $input.first().json.body || $input.first().json;\nconst from = (body.caller_id || body.from || body.sender || body.caller_number || body.number || '').replace(/[^+\\d]/g, '');\nconst message = (body.message || body.text || body.content || body.sms_text || body.sms_body || '').trim();\nconst messageId = body.message_id || body.sms_id || body.id || $execution.id;\n\nif (!from || !message) {\n  return [{ json: { valid: false, reason: 'Missing from or message' } }];\n}\n\nif (!/^\\+370\\d{7,8}$/.test(from)) {\n  return [{ json: { valid: false, reason: 'Invalid LT phone: ' + from } }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    customerPhone: from,\n    messageBody: message,\n    messageId,\n    receivedAt: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "sb-ai-validate",
+      "name": "Validate Inbound SMS",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-ai-if-valid",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Load/init conversation from static data\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.conversations) staticData.conversations = {};\n\nconst phone = $input.first().json.customerPhone;\nconst now = new Date().toISOString();\n\nif (!staticData.conversations[phone]) {\n  staticData.conversations[phone] = {\n    messages: [],\n    startedAt: now,\n    bookingStatus: 'none'\n  };\n}\n\nconst conv = staticData.conversations[phone];\nconv.messages.push({\n  role: 'customer',\n  content: $input.first().json.messageBody,\n  timestamp: now\n});\n\n// Keep last 20\nif (conv.messages.length > 20) {\n  conv.messages = conv.messages.slice(-20);\n}\n\nreturn [{\n  json: {\n    customerPhone: phone,\n    messageBody: $input.first().json.messageBody,\n    messageId: $input.first().json.messageId,\n    conversationHistory: conv.messages,\n    bookingStatus: conv.bookingStatus,\n    isNewConversation: conv.messages.length === 1\n  }\n}];"
+      },
+      "id": "sb-ai-load-conv",
+      "name": "Load Conversation",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 350]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Normalize text: try quick booking intent extraction\n// Pattern: DATA LAIKAS AUTO PROBLEMA\nconst msg = $input.first().json.messageBody;\nconst phone = $input.first().json.customerPhone;\n\n// Try to extract structured booking from single message\n// Examples: \"2026-03-15 10:00 BMW 320d stabdžiai\" or \"kovo 15 10val audi a4 alyvos keitimas\"\nconst normalized = msg\n  .replace(/\\s+/g, ' ')\n  .trim();\n\nreturn [{\n  json: {\n    ...$input.first().json,\n    normalizedMessage: normalized\n  }\n}];"
+      },
+      "id": "sb-ai-normalize",
+      "name": "Normalize Text",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1250, 350]
+    },
+    {
+      "parameters": {
+        "url": "https://api.openai.com/v1/chat/completions",
+        "method": "POST",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bearer {{ $env.OPENAI_API_KEY }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"temperature\": 0.7,\n  \"max_tokens\": 500,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu esi Proteros Servisas automatinis SMS asistentas. Servisas yra Panevėžyje, Lietuva.\\n\\nTelefono numeris: +37045512300\\n\\nTavo tikslas:\\n1. Suprasti kliento žinutę\\n2. Nustatyti ar klientas nori registracijos\\n3. Surinkti:\\n   - Pageidaujama data\\n   - Pageidaujamas laikas\\n   - Automobilis (markė/modelis)\\n   - Problema / paslauga\\n4. Patvirtinti registraciją\\n\\nAtsakyk TIK lietuviškai. Būk trumpas ir draugiškas.\\nKlausk tik vieno dalyko vienu metu.\\n\\nDarbo laikas: I-V 08:00-17:00, VI 09:00-14:00\\nAdresas: Proteros Servisas, Panevėžys\\n\\nŠiandienos data: {{ new Date().toISOString().split('T')[0] }}\\n\\nKai turi visą informaciją, atsakyk JSON formatu:\\n{\\\"booking_ready\\\": true, \\\"preferred_date\\\": \\\"YYYY-MM-DD\\\", \\\"preferred_time\\\": \\\"HH:MM\\\", \\\"car_info\\\": \\\"...\\\", \\\"problem\\\": \\\"...\\\", \\\"client_name\\\": \\\"...\\\"}\\n\\nJei registracija dar nebaigta, tiesiog rašyk žinutę klientui.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Kliento telefonas: {{ $json.customerPhone }}\\n\\nPokalbio istorija:\\n{{ $json.conversationHistory.map(m => m.role + ': ' + m.content).join('\\\\n') }}\\n\\nPaskutinė žinutė: {{ $json.normalizedMessage }}\"\n    }\n  ]\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "sb-ai-openai",
+      "name": "OpenAI: Chat Completion",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1500, 350],
+      "notes": "Uses OPENAI_API_KEY env var. gpt-4o-mini for Lithuanian SMS."
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse AI response, detect booking intent\nconst aiRaw = $input.first().json;\nlet aiText = '';\nif (aiRaw.choices && aiRaw.choices[0]) {\n  aiText = aiRaw.choices[0].message?.content || '';\n} else {\n  aiText = JSON.stringify(aiRaw);\n}\naiText = aiText.trim();\n\nlet bookingReady = false;\nlet bookingData = null;\n\ntry {\n  const jsonMatch = aiText.match(/\\{[\\s\\S]*\"booking_ready\"\\s*:\\s*true[\\s\\S]*\\}/);\n  if (jsonMatch) {\n    bookingData = JSON.parse(jsonMatch[0]);\n    bookingReady = true;\n  }\n} catch (e) { /* not JSON, conversation reply */ }\n\n// Extract fields if booking ready\nconst extracted = bookingData ? {\n  date: bookingData.preferred_date || '',\n  time: bookingData.preferred_time || '',\n  carInfo: bookingData.car_info || '',\n  problem: bookingData.problem || bookingData.service_type || '',\n  clientName: bookingData.client_name || ''\n} : null;\n\nconst convData = $('Load Conversation').first().json;\n\n// Save AI reply to conversation\nconst staticData = $getWorkflowStaticData('global');\nif (staticData.conversations && staticData.conversations[convData.customerPhone]) {\n  staticData.conversations[convData.customerPhone].messages.push({\n    role: 'assistant',\n    content: bookingReady ? 'Registracija patvirtinta!' : aiText,\n    timestamp: new Date().toISOString()\n  });\n  if (bookingReady) {\n    staticData.conversations[convData.customerPhone].bookingStatus = 'booked';\n  }\n}\n\nreturn [{\n  json: {\n    bookingReady,\n    replyText: bookingReady ? null : aiText,\n    bookingData,\n    extracted,\n    customerPhone: convData.customerPhone,\n    messageId: convData.messageId\n  }\n}];"
+      },
+      "id": "sb-ai-parse",
+      "name": "Parse AI Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1750, 350]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-booking",
+              "leftValue": "={{ $json.bookingReady }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-ai-if-booking",
+      "name": "Booking Intent Detected?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2000, 350]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/lt-sandbox-booking",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ customerPhone: $json.customerPhone, bookingData: $json.bookingData, extracted: $json.extracted, messageId: $json.messageId }) }}",
+        "options": {}
+      },
+      "id": "sb-ai-trigger-booking",
+      "name": "Trigger WF004: Create Booking",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [2250, 200],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/lt-sandbox-send-sms",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ to: $json.customerPhone, message: $json.replyText, source: 'ai_reply' }) }}",
+        "options": {}
+      },
+      "id": "sb-ai-send-reply",
+      "name": "Send AI Reply via WF002",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [2250, 500],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "SMS_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "phone": "={{ $('Parse AI Response').item.json.customerPhone }}",
+            "direction": "=inbound",
+            "message": "={{ $('Load Conversation').item.json.messageBody }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "direction", "displayName": "direction", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "message", "displayName": "message", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-ai-log-sms",
+      "name": "Log: SMS_Log (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [2500, 350],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"ok\", \"bookingReady\": $('Parse AI Response').item.json.bookingReady, \"customerPhone\": $('Parse AI Response').item.json.customerPhone } }}",
+        "options": {}
+      },
+      "id": "sb-ai-respond-ok",
+      "name": "Respond: OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [2750, 350]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"error\", \"reason\": $json.reason || 'invalid SMS' } }}",
+        "options": {}
+      },
+      "id": "sb-ai-respond-invalid",
+      "name": "Respond: Invalid",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 600]
+    }
+  ],
+  "connections": {
+    "Webhook: Inbound SMS": {
+      "main": [
+        [
+          {
+            "node": "Validate Inbound SMS",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Inbound SMS": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Load Conversation",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond: Invalid",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Load Conversation": {
+      "main": [
+        [
+          {
+            "node": "Normalize Text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Text": {
+      "main": [
+        [
+          {
+            "node": "OpenAI: Chat Completion",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI: Chat Completion": {
+      "main": [
+        [
+          {
+            "node": "Parse AI Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse AI Response": {
+      "main": [
+        [
+          {
+            "node": "Booking Intent Detected?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Booking Intent Detected?": {
+      "main": [
+        [
+          {
+            "node": "Trigger WF004: Create Booking",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send AI Reply via WF002",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Trigger WF004: Create Booking": {
+      "main": [
+        [
+          {
+            "node": "Log: SMS_Log (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send AI Reply via WF002": {
+      "main": [
+        [
+          {
+            "node": "Log: SMS_Log (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: SMS_Log (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_SANDBOX" },
+    { "name": "sms-ai" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf004-lt-sandbox-booking.json
+++ b/n8n/workflows/TEST/wf004-lt-sandbox-booking.json
@@ -1,0 +1,332 @@
+{
+  "id": "LT-SANDBOX-WF004-booking",
+  "name": "LT_PROTEROS_SANDBOX: WF004 Booking",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-sandbox-booking",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "sb-bk-webhook",
+      "name": "Webhook: Booking Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "lt-sandbox-booking"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate booking request\nconst body = $input.first().json.body || $input.first().json;\nconst phone = (body.customerPhone || '').replace(/[^+\\d]/g, '');\nconst booking = body.bookingData || body.extracted || body;\nconst extracted = body.extracted || {};\n\nconst date = extracted.date || booking.preferred_date || '';\nconst time = extracted.time || booking.preferred_time || '09:00';\nconst problem = extracted.problem || booking.problem || booking.service_type || 'Nenurodyta';\nconst carInfo = extracted.carInfo || booking.car_info || '';\nconst clientName = extracted.clientName || booking.client_name || 'Nežinomas';\n\nif (!phone) {\n  return [{ json: { valid: false, reason: 'Missing customer phone' } }];\n}\n\nif (!date) {\n  return [{ json: { valid: false, reason: 'Missing preferred date' } }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    customerPhone: phone,\n    preferredDate: date,\n    preferredTime: time,\n    problem,\n    carInfo,\n    clientName,\n    messageId: body.messageId || ''\n  }\n}];"
+      },
+      "id": "sb-bk-validate",
+      "name": "Validate Booking Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-bk-if-valid",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build Google Calendar event\nconst data = $input.first().json;\nconst startISO = `${data.preferredDate}T${data.preferredTime}:00+02:00`;\n\n// End = start + 1 hour\nconst [h, m] = data.preferredTime.split(':').map(Number);\nconst endH = h + 1;\nconst endISO = `${data.preferredDate}T${String(endH).padStart(2, '0')}:${String(m).padStart(2, '0')}:00+02:00`;\n\nreturn [{\n  json: {\n    summary: 'Autoservisas rezervacija',\n    description: `Klientas: ${data.clientName}\\nTelefonas: ${data.customerPhone}\\nAutomobilis: ${data.carInfo}\\nProblema: ${data.problem}\\n\\nSukurta automatiškai per SMS AI agent (LT Sandbox).`,\n    startDateTime: startISO,\n    endDateTime: endISO,\n    customerPhone: data.customerPhone,\n    clientName: data.clientName,\n    problem: data.problem,\n    carInfo: data.carInfo,\n    preferredDate: data.preferredDate,\n    preferredTime: data.preferredTime\n  }\n}];"
+      },
+      "id": "sb-bk-build-event",
+      "name": "Build Calendar Event",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 250]
+    },
+    {
+      "parameters": {
+        "calendar": {
+          "__rl": true,
+          "value": "PROTEROS_TEST_CALENDAR_ID",
+          "mode": "id"
+        },
+        "start": "={{ $json.startDateTime }}",
+        "end": "={{ $json.endDateTime }}",
+        "additionalFields": {
+          "summary": "={{ $json.summary }}",
+          "description": "={{ $json.description }}"
+        }
+      },
+      "id": "sb-bk-create-event",
+      "name": "Create Google Calendar Event",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 1.3,
+      "position": [1250, 250],
+      "retryOnFail": true,
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "GOOGLE_CALENDAR_CREDENTIAL_ID",
+          "name": "Google Calendar account"
+        }
+      },
+      "notes": "Calendar: Proteros Test Calendar. Replace PROTEROS_TEST_CALENDAR_ID and credential ID."
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Bookings",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "phone": "={{ $('Build Calendar Event').item.json.customerPhone }}",
+            "problem": "={{ $('Build Calendar Event').item.json.problem }}",
+            "date": "={{ $('Build Calendar Event').item.json.preferredDate + ' ' + $('Build Calendar Event').item.json.preferredTime }}",
+            "status": "=confirmed"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "problem", "displayName": "problem", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "date", "displayName": "date", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "status", "displayName": "status", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-bk-log-booking",
+      "name": "Log: Bookings (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1500, 250],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/lt-sandbox-send-sms",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ to: $('Build Calendar Event').item.json.customerPhone, message: 'Jūsų registracija patvirtinta!\\nData: ' + $('Build Calendar Event').item.json.preferredDate + '\\nLaikas: ' + $('Build Calendar Event').item.json.preferredTime + '\\nProteros Servisas, Panevėžys\\nIki pasimatymo!', source: 'booking_confirmation' }) }}",
+        "options": {}
+      },
+      "id": "sb-bk-send-confirm",
+      "name": "Send Confirmation SMS via WF002",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1750, 250],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"ok\", \"action\": \"booking_created\", \"customerPhone\": $('Build Calendar Event').item.json.customerPhone, \"calendarEventId\": $('Create Google Calendar Event').item.json.id || '' } }}",
+        "options": {}
+      },
+      "id": "sb-bk-respond-ok",
+      "name": "Respond: Booking Created",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [2000, 250]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Errors",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "workflow": "=WF004_LT_BOOKING",
+            "error": "={{ $json.reason || 'invalid booking data' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "workflow", "displayName": "workflow", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "error", "displayName": "error", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-bk-log-error",
+      "name": "Log: Error (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [750, 500],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"error\", \"reason\": $json.reason || 'invalid booking' } }}",
+        "options": {}
+      },
+      "id": "sb-bk-respond-error",
+      "name": "Respond: Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 500]
+    }
+  ],
+  "connections": {
+    "Webhook: Booking Request": {
+      "main": [
+        [
+          {
+            "node": "Validate Booking Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Booking Data": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Build Calendar Event",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log: Error (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Error (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Calendar Event": {
+      "main": [
+        [
+          {
+            "node": "Create Google Calendar Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Google Calendar Event": {
+      "main": [
+        [
+          {
+            "node": "Log: Bookings (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Bookings (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Send Confirmation SMS via WF002",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Confirmation SMS via WF002": {
+      "main": [
+        [
+          {
+            "node": "Respond: Booking Created",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_SANDBOX" },
+    { "name": "booking" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf005-lt-sandbox-log-sheets.json
+++ b/n8n/workflows/TEST/wf005-lt-sandbox-log-sheets.json
@@ -1,0 +1,540 @@
+{
+  "id": "LT-SANDBOX-WF005-log-sheets",
+  "name": "LT_PROTEROS_SANDBOX: WF005 Log to Google Sheets",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-sandbox-log",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "sb-log-webhook",
+      "name": "Webhook: Log Event",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "lt-sandbox-log"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Generic logging endpoint for all sandbox workflows\n// Accepts: { sheet: 'Calls_Log'|'SMS_Log'|'Bookings'|'Errors'|'KPI', data: {...} }\nconst body = $input.first().json.body || $input.first().json;\nconst sheet = body.sheet || 'Errors';\nconst data = body.data || {};\n\nconst validSheets = ['Calls_Log', 'SMS_Log', 'Bookings', 'Errors', 'KPI'];\nif (!validSheets.includes(sheet)) {\n  return [{ json: { valid: false, reason: 'Invalid sheet: ' + sheet, validSheets } }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    sheet,\n    data,\n    timestamp: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "sb-log-validate",
+      "name": "Validate Log Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "sb-log-if-valid",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.sheet }}",
+                    "rightValue": "Calls_Log",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "Calls_Log"
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.sheet }}",
+                    "rightValue": "SMS_Log",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "SMS_Log"
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.sheet }}",
+                    "rightValue": "Bookings",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "Bookings"
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.sheet }}",
+                    "rightValue": "Errors",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "Errors"
+            },
+            {
+              "conditions": {
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.sheet }}",
+                    "rightValue": "KPI",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ]
+              },
+              "renameOutput": true,
+              "outputKey": "KPI"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-switch",
+      "name": "Route to Sheet",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1000, 300]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Calls_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.data.time || $json.timestamp }}",
+            "phone": "={{ $json.data.phone || '' }}",
+            "duration": "={{ $json.data.duration || '' }}",
+            "event": "={{ $json.data.event || '' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "duration", "displayName": "duration", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "event", "displayName": "event", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-calls",
+      "name": "Append: Calls_Log",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1300, 50],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "SMS_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.data.time || $json.timestamp }}",
+            "phone": "={{ $json.data.phone || '' }}",
+            "direction": "={{ $json.data.direction || '' }}",
+            "message": "={{ $json.data.message || '' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "direction", "displayName": "direction", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "message", "displayName": "message", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-sms",
+      "name": "Append: SMS_Log",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1300, 175],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Bookings",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.data.time || $json.timestamp }}",
+            "phone": "={{ $json.data.phone || '' }}",
+            "problem": "={{ $json.data.problem || '' }}",
+            "date": "={{ $json.data.date || '' }}",
+            "status": "={{ $json.data.status || '' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "problem", "displayName": "problem", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "date", "displayName": "date", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "status", "displayName": "status", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-bookings",
+      "name": "Append: Bookings",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1300, 300],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Errors",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.data.time || $json.timestamp }}",
+            "workflow": "={{ $json.data.workflow || '' }}",
+            "error": "={{ $json.data.error || '' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "workflow", "displayName": "workflow", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "error", "displayName": "error", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-errors",
+      "name": "Append: Errors",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1300, 425],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "KPI",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "today_calls": "={{ $json.data.today_calls || '' }}",
+            "today_sms": "={{ $json.data.today_sms || '' }}",
+            "booking_requests": "={{ $json.data.booking_requests || '' }}",
+            "confirmed_bookings": "={{ $json.data.confirmed_bookings || '' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "today_calls", "displayName": "today_calls", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "today_sms", "displayName": "today_sms", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "booking_requests", "displayName": "booking_requests", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "confirmed_bookings", "displayName": "confirmed_bookings", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "sb-log-kpi",
+      "name": "Append: KPI",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1300, 550],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"ok\", \"sheet\": $('Validate Log Request').item.json.sheet, \"logged\": true } }}",
+        "options": {}
+      },
+      "id": "sb-log-respond-ok",
+      "name": "Respond: Logged",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1600, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"error\", \"reason\": $json.reason || 'invalid log request' } }}",
+        "options": {}
+      },
+      "id": "sb-log-respond-error",
+      "name": "Respond: Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 500]
+    }
+  ],
+  "connections": {
+    "Webhook: Log Event": {
+      "main": [
+        [
+          {
+            "node": "Validate Log Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Log Request": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Route to Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond: Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route to Sheet": {
+      "main": [
+        [
+          {
+            "node": "Append: Calls_Log",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Append: SMS_Log",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Append: Bookings",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Append: Errors",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Append: KPI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append: Calls_Log": {
+      "main": [
+        [
+          {
+            "node": "Respond: Logged",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append: SMS_Log": {
+      "main": [
+        [
+          {
+            "node": "Respond: Logged",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append: Bookings": {
+      "main": [
+        [
+          {
+            "node": "Respond: Logged",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append: Errors": {
+      "main": [
+        [
+          {
+            "node": "Respond: Logged",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append: KPI": {
+      "main": [
+        [
+          {
+            "node": "Respond: Logged",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_SANDBOX" },
+    { "name": "logging" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf006-test-telia-missed-call-sms.json
+++ b/n8n/workflows/TEST/wf006-test-telia-missed-call-sms.json
@@ -1,0 +1,333 @@
+{
+  "id": "TEST-TELIA-MISSED-CALL-SMS",
+  "name": "TEST_TELIA_MISSED_CALL_SMS",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "telia-missed-call",
+        "responseMode": "lastNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "telia-mc-webhook",
+      "name": "Webhook: Telia Missed Call",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "telia-missed-call"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate incoming Telia missed-call payload\nconst body = $input.first().json.body || $input.first().json;\nconst event = (body.event || '').toLowerCase();\nconst callerPhone = (body.caller_phone || '').replace(/[^+\\d]/g, '');\nconst targetPhone = (body.target_phone || '').replace(/[^+\\d]/g, '');\nconst timestamp = body.timestamp || new Date().toISOString();\nconst source = body.source || 'unknown';\n\nconst errors = [];\nif (event !== 'missed_call') errors.push('event must be missed_call, got: ' + event);\nif (!callerPhone) errors.push('caller_phone is required');\nif (callerPhone && !/^\\+370\\d{7,8}$/.test(callerPhone)) errors.push('caller_phone must match +370 format, got: ' + callerPhone);\n\nif (errors.length > 0) {\n  return [{ json: { valid: false, errors, raw: body } }];\n}\n\nreturn [{ json: { valid: true, errors: [], raw: body } }];"
+      },
+      "id": "telia-mc-validate",
+      "name": "Validate Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "telia-mc-if-valid",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Normalize fields from validated payload\nconst body = $input.first().json.raw;\nconst callerPhone = (body.caller_phone || '').replace(/[^+\\d]/g, '');\nconst targetPhone = (body.target_phone || '').replace(/[^+\\d]/g, '');\nconst timestamp = body.timestamp || new Date().toISOString();\nconst eventSource = body.source || 'unknown';\n\nreturn [{\n  json: {\n    callerPhone,\n    timestamp,\n    targetPhone,\n    eventSource\n  }\n}];"
+      },
+      "id": "telia-mc-normalize",
+      "name": "Normalize Fields",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1000, 250]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Calls_Log",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ $json.timestamp }}",
+            "phone": "={{ $json.callerPhone }}",
+            "event": "=telia_missed_call",
+            "source": "={{ $json.eventSource }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "phone", "displayName": "phone", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "event", "displayName": "event", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "source", "displayName": "source", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "telia-mc-log-sheets",
+      "name": "Log: Calls_Log (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [1250, 250],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build Zadarma SMS API request with HMAC-SHA1 signature\nconst crypto = require('crypto');\n\nconst apiKey = $env.ZADARMA_API_KEY;\nconst apiSecret = $env.ZADARMA_API_SECRET;\n\nif (!apiKey || !apiSecret) {\n  throw new Error('ZADARMA_API_KEY and ZADARMA_API_SECRET env vars must be set in n8n');\n}\n\nconst to = $input.first().json.callerPhone;\nconst message = 'Matome kad skambinote Proteros Servisui. Jei norite registracijos parašykite: data laikas automobilis problema.';\n\n// Zadarma API params (sorted alphabetically for signature)\nconst params = {\n  caller_id: $input.first().json.targetPhone || '+37045512300',\n  message: message,\n  number: to\n};\n\n// Build query string sorted by key\nconst sortedKeys = Object.keys(params).sort();\nconst queryParts = sortedKeys.map(k => k + '=' + encodeURIComponent(params[k]));\nconst queryString = queryParts.join('&');\n\n// Zadarma signature: base64(hmac-sha1(apiSecret, apiPath + queryString + md5(queryString)))\nconst apiPath = '/v1/sms/send/';\nconst md5Hash = crypto.createHash('md5').update(queryString).digest('hex');\nconst signData = apiPath + queryString + md5Hash;\nconst signature = crypto.createHmac('sha1', apiSecret).update(signData).digest('base64');\nconst authHeader = apiKey + ':' + signature;\n\nreturn [{\n  json: {\n    url: 'https://api.zadarma.com/v1/sms/send/',\n    authHeader,\n    params,\n    to,\n    message,\n    callerPhone: $input.first().json.callerPhone,\n    targetPhone: $input.first().json.targetPhone,\n    timestamp: $input.first().json.timestamp,\n    eventSource: $input.first().json.eventSource\n  }\n}];"
+      },
+      "id": "telia-mc-build-sms",
+      "name": "Build Zadarma SMS Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 250]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.zadarma.com/v1/sms/send/",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "={{ $json.authHeader }}" }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "number", "value": "={{ $json.params.number }}" },
+            { "name": "message", "value": "={{ $json.params.message }}" },
+            { "name": "caller_id", "value": "={{ $json.params.caller_id }}" }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "telia-mc-send-sms",
+      "name": "Zadarma: Send SMS",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1750, 250],
+      "continueOnFail": true,
+      "notes": "Sends SMS via Zadarma API. continueOnFail=true to log errors."
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ status: 'ok', sms_sent: true }) }}",
+        "options": {}
+      },
+      "id": "telia-mc-respond-ok",
+      "name": "Respond: OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [2000, 250]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "PROTEROS_LT_TEST_LOG_SHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "Errors",
+          "mode": "name"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "time": "={{ new Date().toISOString() }}",
+            "workflow": "=TEST_TELIA_MISSED_CALL_SMS",
+            "error": "={{ $json.errors ? $json.errors.join('; ') : 'validation_failed' }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            { "id": "time", "displayName": "time", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "workflow", "displayName": "workflow", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true },
+            { "id": "error", "displayName": "error", "required": false, "defaultMatch": false, "display": true, "type": "string", "canBeUsedToMatch": true }
+          ]
+        },
+        "options": {}
+      },
+      "id": "telia-mc-log-error",
+      "name": "Log: Error (Google Sheets)",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [750, 500],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ status: 'error', sms_sent: false, errors: $('Validate Payload').item.json.errors }) }}",
+        "options": {}
+      },
+      "id": "telia-mc-respond-error",
+      "name": "Respond: Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1000, 500]
+    }
+  ],
+  "connections": {
+    "Webhook: Telia Missed Call": {
+      "main": [
+        [
+          {
+            "node": "Validate Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Payload": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Normalize Fields",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log: Error (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Fields": {
+      "main": [
+        [
+          {
+            "node": "Log: Calls_Log (Google Sheets)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Calls_Log (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Build Zadarma SMS Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Zadarma SMS Request": {
+      "main": [
+        [
+          {
+            "node": "Zadarma: Send SMS",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zadarma: Send SMS": {
+      "main": [
+        [
+          {
+            "node": "Respond: OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log: Error (Google Sheets)": {
+      "main": [
+        [
+          {
+            "node": "Respond: Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_PROTEROS_TEST" },
+    { "name": "telia" },
+    { "name": "missed-call" },
+    { "name": "test" }
+  ]
+}

--- a/n8n/workflows/TEST/wf010-project-status-auto-update.json
+++ b/n8n/workflows/TEST/wf010-project-status-auto-update.json
@@ -1,0 +1,378 @@
+{
+  "id": "TEST-PROJECT-STATUS-AUTO-UPDATE",
+  "name": "TEST_PROJECT_STATUS_AUTO_UPDATE",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "project-status-update",
+        "responseMode": "onReceived",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "psa-webhook",
+      "name": "Webhook: GitHub Push",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "project-status-update"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse GitHub push webhook payload\nconst body = $input.first().json.body || $input.first().json;\n\n// Extract commit data\nconst headCommit = body.head_commit || {};\nconst commitMessage = headCommit.message || '';\nconst branch = (body.ref || '').replace('refs/heads/', '');\nconst commits = body.commits || [];\n\n// Collect all changed files across commits\nconst allAdded = [];\nconst allModified = [];\nconst allRemoved = [];\n\nfor (const c of commits) {\n  if (c.added) allAdded.push(...c.added);\n  if (c.modified) allModified.push(...c.modified);\n  if (c.removed) allRemoved.push(...c.removed);\n}\n\nconst changedFiles = [...new Set([...allAdded, ...allModified, ...allRemoved])];\n\n// Check for auto-status loop prevention\nconst isAutoStatus = commitMessage.includes('auto-status:');\n\nreturn [{\n  json: {\n    commitMessage,\n    branch,\n    changedFiles,\n    changedFilesList: changedFiles.join('\\n'),\n    isAutoStatus,\n    pusher: body.pusher ? body.pusher.name : 'unknown',\n    repository: body.repository ? body.repository.full_name : 'unknown',\n    timestamp: headCommit.timestamp || new Date().toISOString()\n  }\n}];"
+      },
+      "id": "psa-parse-commit",
+      "name": "Parse Commit Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-not-auto-status",
+              "leftValue": "={{ $json.isAutoStatus }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equal"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "psa-loop-guard",
+      "name": "Not Auto-Status?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [750, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/{{ $env.GITHUB_OWNER }}/{{ $env.GITHUB_REPO }}/contents/project-brain/project_status.json",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "ref",
+              "value": "={{ $('Parse Commit Data').item.json.branch }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "psa-fetch-json",
+      "name": "Fetch project_status.json",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [1050, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.github.com/repos/{{ $env.GITHUB_OWNER }}/{{ $env.GITHUB_REPO }}/contents/project-brain/project_status.md",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "ref",
+              "value": "={{ $('Parse Commit Data').item.json.branch }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "psa-fetch-md",
+      "name": "Fetch project_status.md",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [1050, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Decode base64 content from GitHub API responses\nconst jsonItem = $('Fetch project_status.json').first().json;\nconst mdItem = $('Fetch project_status.md').first().json;\n\nconst jsonContent = Buffer.from(jsonItem.content, 'base64').toString('utf-8');\nconst mdContent = Buffer.from(mdItem.content, 'base64').toString('utf-8');\n\nconst commitData = $('Parse Commit Data').first().json;\n\nreturn [{\n  json: {\n    currentStatusJson: jsonContent,\n    currentStatusMd: mdContent,\n    jsonSha: jsonItem.sha,\n    mdSha: mdItem.sha,\n    commitMessage: commitData.commitMessage,\n    changedFiles: commitData.changedFilesList,\n    branch: commitData.branch,\n    pusher: commitData.pusher,\n    timestamp: commitData.timestamp\n  }\n}];"
+      },
+      "id": "psa-merge-data",
+      "name": "Merge & Decode",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1350, 300]
+    },
+    {
+      "parameters": {
+        "model": "={{ $env.OPENAI_STATUS_MODEL || 'gpt-4o-mini' }}",
+        "messages": {
+          "values": [
+            {
+              "role": "system",
+              "content": "You are a project status updater for the AutoShop SMS AI project. You analyze git commits and update the project status JSON conservatively.\n\nRules:\n- Never change stage weights\n- Never remove stages\n- Only increase stage progress if the commit clearly indicates real, verified progress\n- Update recent_changes with a dated entry describing what changed\n- Keep progress conservative — when uncertain, do not increase\n- Never exceed 100% on any stage\n- Output ONLY valid JSON — no markdown fences, no commentary\n- Preserve all existing structure and fields\n- Only modify: stage progress percentages (if warranted), recent_changes, and active_tasks if clearly applicable"
+            },
+            {
+              "role": "user",
+              "content": "=Here is the current project_status.json:\n\n{{ $json.currentStatusJson }}\n\n---\n\nA new commit was pushed:\n\nBranch: {{ $json.branch }}\nPusher: {{ $json.pusher }}\nTimestamp: {{ $json.timestamp }}\n\nCommit message:\n{{ $json.commitMessage }}\n\nFiles changed:\n{{ $json.changedFiles }}\n\n---\n\nInstructions:\n\nUpdate the project_status.json conservatively based on this commit.\n\nRules:\n- Never change stage weights\n- Never remove stages\n- Only increase stage progress if the commit indicates real progress\n- Add a dated entry to recent_changes describing what was done\n- Keep progress conservative\n- Never exceed 100%\n\nReturn ONLY the complete updated JSON. No markdown fences. No explanation."
+            }
+          ]
+        },
+        "options": {
+          "temperature": 0.2,
+          "maxTokens": 4000
+        }
+      },
+      "id": "psa-ai-analysis",
+      "name": "AI: Update Status JSON",
+      "type": "@n8n/n8n-nodes-langchain.openAi",
+      "typeVersion": 1,
+      "position": [1650, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse AI output and generate markdown from updated JSON\nconst aiOutput = $('AI: Update Status JSON').first().json;\nconst rawText = aiOutput.text || aiOutput.message || JSON.stringify(aiOutput);\n\n// Clean up potential markdown fences\nlet cleanJson = rawText.trim();\nif (cleanJson.startsWith('```')) {\n  cleanJson = cleanJson.replace(/^```(?:json)?\\n?/, '').replace(/\\n?```$/, '');\n}\n\nlet statusObj;\ntry {\n  statusObj = JSON.parse(cleanJson);\n} catch (e) {\n  throw new Error('AI returned invalid JSON: ' + e.message + '\\n\\nRaw output: ' + rawText.substring(0, 500));\n}\n\nconst updatedJson = JSON.stringify(statusObj, null, 2);\n\n// Generate markdown from the JSON\nconst lines = [];\nlines.push('# Project Status — AutoShop SMS AI');\nlines.push('');\nlines.push(`> Last updated: ${statusObj.last_updated || new Date().toISOString().split('T')[0]}`);\nlines.push(`> Updated by: auto-status workflow`);\nlines.push('');\n\n// Project completion\nif (statusObj.project_completion_estimate) {\n  lines.push(`## Project Completion Estimate: ${statusObj.project_completion_estimate}%`);\n  lines.push('');\n}\n\n// Stage progress table\nif (statusObj.stages) {\n  lines.push('## Stage Progress');\n  lines.push('');\n  lines.push('| Stage | Weight | Progress | Weighted |');\n  lines.push('|-------|--------|----------|----------|');\n  for (const stage of statusObj.stages) {\n    const weighted = ((stage.weight * stage.progress) / 100).toFixed(1);\n    lines.push(`| ${stage.name} | ${stage.weight}% | ${stage.progress}% | ${weighted}% |`);\n  }\n  lines.push('');\n}\n\n// Current focus\nif (statusObj.current_focus) {\n  lines.push('## Current Focus');\n  lines.push('');\n  lines.push(statusObj.current_focus);\n  lines.push('');\n}\n\n// Active tasks\nif (statusObj.active_tasks) {\n  lines.push('## Active Tasks');\n  lines.push('');\n  if (statusObj.active_tasks.in_progress && statusObj.active_tasks.in_progress.length > 0) {\n    lines.push('### In Progress');\n    for (const t of statusObj.active_tasks.in_progress) {\n      lines.push(`- ${t}`);\n    }\n    lines.push('');\n  }\n  if (statusObj.active_tasks.todo && statusObj.active_tasks.todo.length > 0) {\n    lines.push('### Todo');\n    for (const t of statusObj.active_tasks.todo) {\n      lines.push(`- ${t}`);\n    }\n    lines.push('');\n  }\n  if (statusObj.active_tasks.done && statusObj.active_tasks.done.length > 0) {\n    lines.push('### Done');\n    for (const t of statusObj.active_tasks.done) {\n      lines.push(`- ${t}`);\n    }\n    lines.push('');\n  }\n}\n\n// Blocked items\nif (statusObj.blocked_items && statusObj.blocked_items.length > 0) {\n  lines.push('## Blocked Items');\n  lines.push('');\n  for (const b of statusObj.blocked_items) {\n    lines.push(`- **${b.item || b}**: ${b.reason || ''} (owner: ${b.owner || 'unassigned'})`);\n  }\n  lines.push('');\n}\n\n// Recent changes\nif (statusObj.recent_changes && statusObj.recent_changes.length > 0) {\n  lines.push('## Recent Changes');\n  lines.push('');\n  for (const c of statusObj.recent_changes) {\n    if (typeof c === 'string') {\n      lines.push(`- ${c}`);\n    } else {\n      lines.push(`- **${c.date || 'undated'}**: ${c.description || c.change || JSON.stringify(c)}`);\n    }\n  }\n  lines.push('');\n}\n\n// Next owner decision\nif (statusObj.next_owner_decision) {\n  lines.push('## Next Owner Decision');\n  lines.push('');\n  lines.push(statusObj.next_owner_decision);\n  lines.push('');\n}\n\nconst updatedMd = lines.join('\\n');\n\nconst mergeData = $('Merge & Decode').first().json;\n\nreturn [{\n  json: {\n    updatedJson,\n    updatedMd,\n    jsonSha: mergeData.jsonSha,\n    mdSha: mergeData.mdSha,\n    branch: mergeData.branch\n  }\n}];"
+      },
+      "id": "psa-render-md",
+      "name": "Render Markdown",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1950, 300]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=https://api.github.com/repos/{{ $env.GITHUB_OWNER }}/{{ $env.GITHUB_REPO }}/contents/project-brain/project_status.json",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "message",
+              "value": "auto-status: update project status after commit"
+            },
+            {
+              "name": "content",
+              "value": "={{ Buffer.from($json.updatedJson).toString('base64') }}"
+            },
+            {
+              "name": "sha",
+              "value": "={{ $json.jsonSha }}"
+            },
+            {
+              "name": "branch",
+              "value": "={{ $json.branch }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "psa-commit-json",
+      "name": "Commit project_status.json",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [2250, 200]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=https://api.github.com/repos/{{ $env.GITHUB_OWNER }}/{{ $env.GITHUB_REPO }}/contents/project-brain/project_status.md",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "message",
+              "value": "auto-status: update project status markdown"
+            },
+            {
+              "name": "content",
+              "value": "={{ Buffer.from($json.updatedMd).toString('base64') }}"
+            },
+            {
+              "name": "sha",
+              "value": "={{ $json.mdSha }}"
+            },
+            {
+              "name": "branch",
+              "value": "={{ $json.branch }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "psa-commit-md",
+      "name": "Commit project_status.md",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [2250, 400]
+    }
+  ],
+  "connections": {
+    "Webhook: GitHub Push": {
+      "main": [
+        [
+          {
+            "node": "Parse Commit Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Commit Data": {
+      "main": [
+        [
+          {
+            "node": "Not Auto-Status?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Not Auto-Status?": {
+      "main": [
+        [
+          {
+            "node": "Fetch project_status.json",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Fetch project_status.md",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Fetch project_status.json": {
+      "main": [
+        [
+          {
+            "node": "Merge & Decode",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch project_status.md": {
+      "main": [
+        [
+          {
+            "node": "Merge & Decode",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge & Decode": {
+      "main": [
+        [
+          {
+            "node": "AI: Update Status JSON",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "AI: Update Status JSON": {
+      "main": [
+        [
+          {
+            "node": "Render Markdown",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Render Markdown": {
+      "main": [
+        [
+          {
+            "node": "Commit project_status.json",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Commit project_status.md",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "TEST"
+    },
+    {
+      "name": "automation"
+    }
+  ],
+  "meta": {
+    "description": "Receives GitHub push webhooks, analyzes commits with AI, and auto-updates project-brain/project_status.json and project_status.md. Loop-safe via auto-status: prefix detection.",
+    "templateCredsSetupCompleted": false
+  }
+}

--- a/scripts/notify-error.ps1
+++ b/scripts/notify-error.ps1
@@ -1,0 +1,19 @@
+# Call when an error occurs. Pass error description as first argument.
+param(
+    [string]$ErrorMsg = "unknown error"
+)
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Branch = git -C $RepoRoot rev-parse --abbrev-ref HEAD 2>$null
+if (-not $Branch) { $Branch = "unknown" }
+$Time = Get-Date -Format "yyyy-MM-dd HH:mm"
+
+$Message = @"
+❌ Claude error
+
+Error: $ErrorMsg
+Branch: $Branch
+Time: $Time
+"@
+
+& "$RepoRoot\scripts\send-telegram.ps1" -Message $Message

--- a/scripts/notify-error.sh
+++ b/scripts/notify-error.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Call when an error occurs. Pass error description as argument.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+ERROR="${1:-unknown error}"
+bash "$SCRIPT_DIR/notify-telegram.sh" "❌ Error: $ERROR — branch: $BRANCH"

--- a/scripts/notify-session-start.ps1
+++ b/scripts/notify-session-start.ps1
@@ -1,0 +1,14 @@
+# Call at the start of every Claude session
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Branch = git -C $RepoRoot rev-parse --abbrev-ref HEAD 2>$null
+if (-not $Branch) { $Branch = "unknown" }
+$Time = Get-Date -Format "yyyy-MM-dd HH:mm"
+
+$Message = @"
+🚀 Claude session started
+
+Branch: $Branch
+Time: $Time
+"@
+
+& "$RepoRoot\scripts\send-telegram.ps1" -Message $Message

--- a/scripts/notify-session-start.sh
+++ b/scripts/notify-session-start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Call at the start of every Claude session
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+bash "$SCRIPT_DIR/notify-telegram.sh" "🤖 Claude session started — branch: $BRANCH"

--- a/scripts/notify-task-done.sh
+++ b/scripts/notify-task-done.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Call after completing a task. Pass task name as argument.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+TASK="${1:-unnamed task}"
+bash "$SCRIPT_DIR/notify-telegram.sh" "✅ Task complete: $TASK — branch: $BRANCH"

--- a/scripts/notify-telegram.sh
+++ b/scripts/notify-telegram.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Wrapper to send Telegram notifications via send-telegram.ps1
+# Usage: bash scripts/notify-telegram.sh "Your message here"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+[ -z "$SCRIPT_DIR" ] && SCRIPT_DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PS_SCRIPT="$REPO_ROOT/scripts/send-telegram.ps1"
+
+MESSAGE="${1:-No message provided}"
+
+if [ ! -f "$PS_SCRIPT" ]; then
+  echo "[notify] send-telegram.ps1 not found at $PS_SCRIPT — skipping"
+  exit 0
+fi
+
+powershell.exe -ExecutionPolicy Bypass -File "$PS_SCRIPT" -Message "$MESSAGE" 2>/dev/null
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "[notify] Telegram notification failed (exit $EXIT_CODE) — continuing"
+fi
+
+exit 0

--- a/scripts/run-ca-with-notify.ps1
+++ b/scripts/run-ca-with-notify.ps1
@@ -1,0 +1,22 @@
+# Launch Claude with permission bypass and send Telegram notification on exit.
+# Usage: powershell -ExecutionPolicy Bypass -File scripts/run-ca-with-notify.ps1
+# Alias: ca  (set up in your PowerShell profile)
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $RepoRoot
+
+# Run Claude — pass through any extra arguments
+claude --dangerously-skip-permissions @args
+$exitCode = $LASTEXITCODE
+
+# Build notification message
+if ($exitCode -eq 0) {
+    $task = "Claude session finished"
+} else {
+    $task = "Claude session exited with code $exitCode"
+}
+
+# Always notify on exit
+& "$RepoRoot\scripts\notify-task-done.ps1" -Task $task
+
+exit $exitCode


### PR DESCRIPTION
## Summary
- Track 7 notification scripts (bash+ps1 pairs) that support the canonical Claude work cycle defined in CLAUDE.md: session-start, task-done, error, and telegram wrapper
- Track 7 sandbox test workflow definitions (wf001-wf006, wf010) in `n8n/workflows/TEST/`
- `telegram.ps1` (root) excluded locally — personal scratch script superseded by `scripts/send-telegram.ps1`

## Test plan
- [ ] Verify notification scripts execute without errors
- [ ] Verify n8n workflow JSON files are valid and importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)