### PR TITLE
feat: auto-sync to latest main before each ca session

### DIFF
--- a/scripts/run-ca-with-notify.ps1
+++ b/scripts/run-ca-with-notify.ps1
@@ -5,6 +5,11 @@
 $RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 Set-Location $RepoRoot
 
+# Sync to latest main before starting
+git fetch origin
+git checkout main
+git reset --hard origin/main
+
 # Run Claude — pass through any extra arguments
 claude --dangerously-skip-permissions @args
 $exitCode = $LASTEXITCODE


### PR DESCRIPTION
## Summary
- Adds `git fetch origin`, `git checkout main`, and `git reset --hard origin/main` to the `ca` launcher script
- Ensures every Claude session starts from a clean, fully synced main branch

## Test plan
- [ ] Run `ca` and verify it fetches, checks out main, resets, then launches Claude
- [ ] Confirm Telegram notification still fires on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)