### PR TITLE
fix: validate tenant exists in OAuth flow before token storage

### DIFF
--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -93,6 +93,16 @@ export async function googleAuthRoute(app: FastifyInstance) {
 
     const { tenantId } = request.user as { tenantId: string };
 
+    // Verify tenant exists before generating OAuth URL
+    const [tenant] = await query<{ id: string }>(
+      `SELECT id FROM tenants WHERE id = $1`,
+      [tenantId]
+    );
+    if (!tenant) {
+      request.log.error({ tenantId }, "OAuth URL requested for non-existent tenant");
+      return reply.status(400).send({ error: "Tenant not found — cannot initiate OAuth" });
+    }
+
     const params = new URLSearchParams({
       client_id: clientId,
       redirect_uri: redirectUri,
@@ -126,6 +136,16 @@ export async function googleAuthRoute(app: FastifyInstance) {
 
     if (!clientId || !clientSecret || !redirectUri) {
       return reply.status(503).send({ error: "Google OAuth not configured" });
+    }
+
+    // Verify tenant exists before exchanging tokens (prevents FK violation)
+    const [tenant] = await query<{ id: string }>(
+      `SELECT id FROM tenants WHERE id = $1`,
+      [tenantId]
+    );
+    if (!tenant) {
+      request.log.error({ tenantId }, "OAuth callback for non-existent tenant");
+      return reply.status(400).send({ error: "Invalid tenant in OAuth state" });
     }
 
     // Exchange authorization code for tokens


### PR DESCRIPTION
## Summary
- Adds tenant existence check in `GET /auth/google/url` — rejects OAuth initiation if JWT contains a non-existent tenant_id
- Adds tenant existence check in `GET /auth/google/callback` — returns 400 instead of crashing with FK constraint violation when state contains invalid tenant_id
- Root cause: OAuth was initiated with `00000000-0000-0000-0000-000000000000` which doesn't exist in the tenants table

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 164 tests pass (10 test files)
- [x] Verified callback rejects zero UUID with `{"error":"Invalid tenant in OAuth state"}`
- [x] Verified callback accepts real tenant `3c222f93-...` (proceeds to token exchange)
- [x] API container rebuilt and health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)