### PR TITLE
fix: resolve JWT_SECRET mismatch and store google_account_email in OAuth

### DIFF
--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -46,7 +46,8 @@ async function upsertCalendarTokens(
   accessToken: string,
   refreshToken: string,
   expiresIn: number,
-  calendarId = "primary"
+  calendarId = "primary",
+  googleEmail?: string
 ): Promise<void> {
   const tokenExpiry = new Date(Date.now() + expiresIn * 1000);
   const encAccess = encryptToken(accessToken);
@@ -54,16 +55,36 @@ async function upsertCalendarTokens(
 
   await query(
     `INSERT INTO tenant_calendar_tokens
-       (tenant_id, access_token, refresh_token, token_expiry, calendar_id, connected_at)
-     VALUES ($1, $2, $3, $4, $5, NOW())
+       (tenant_id, access_token, refresh_token, token_expiry, calendar_id, google_account_email, integration_status, connected_at)
+     VALUES ($1, $2, $3, $4, $5, $6, 'active', NOW())
      ON CONFLICT (tenant_id) DO UPDATE SET
-       access_token   = EXCLUDED.access_token,
-       refresh_token  = EXCLUDED.refresh_token,
-       token_expiry   = EXCLUDED.token_expiry,
-       calendar_id    = EXCLUDED.calendar_id,
-       last_refreshed = NOW()`,
-    [tenantId, encAccess, encRefresh, tokenExpiry.toISOString(), calendarId]
+       access_token         = EXCLUDED.access_token,
+       refresh_token        = EXCLUDED.refresh_token,
+       token_expiry         = EXCLUDED.token_expiry,
+       calendar_id          = EXCLUDED.calendar_id,
+       google_account_email = EXCLUDED.google_account_email,
+       integration_status   = 'active',
+       last_error           = NULL,
+       last_refreshed       = NOW(),
+       updated_at           = NOW()`,
+    [tenantId, encAccess, encRefresh, tokenExpiry.toISOString(), calendarId, googleEmail ?? null]
   );
+}
+
+/**
+ * Fetches the Google account email using the access token.
+ */
+async function fetchGoogleEmail(accessToken: string): Promise<string | undefined> {
+  try {
+    const res = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as { email?: string };
+    return data.email;
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -178,14 +199,18 @@ export async function googleAuthRoute(app: FastifyInstance) {
       return reply.status(502).send({ error: "Incomplete tokens from Google" });
     }
 
+    const googleEmail = await fetchGoogleEmail(tokens.access_token);
+
     await upsertCalendarTokens(
       tenantId,
       tokens.access_token,
       tokens.refresh_token,
-      tokens.expires_in ?? 3600
+      tokens.expires_in ?? 3600,
+      "primary",
+      googleEmail
     );
 
-    request.log.info({ tenantId }, "Google Calendar connected for tenant");
+    request.log.info({ tenantId, googleEmail }, "Google Calendar connected for tenant");
 
     // Redirect back to the app dashboard with a success flag
     return reply.redirect(`${publicOrigin}/app.html?calendar=connected`);

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379/0
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis_secret}
       N8N_INTERNAL_URL: http://n8n:5678
-      JWT_SECRET: ${JWT_SECRET:-change_me_jwt_secret}
+      # JWT_SECRET loaded from env_file (../.env) — do NOT override here
     env_file:
       - path: ../.env
         required: false


### PR DESCRIPTION
## Summary
- **JWT_SECRET mismatch fixed**: docker-compose `environment` section was overriding `env_file` with the default `change_me_jwt_secret`. Removed the explicit override so the real secret from `.env` is used.
- **OAuth callback enhanced**: Now fetches Google account email via userinfo endpoint and stores it in `tenant_calendar_tokens.google_account_email`, sets `integration_status = active`, clears `last_error`.
- **Stale tokens cleaned**: Deleted tokens encrypted with the wrong key (undecryptable after fix).
- **Tenant email fixed**: Updated to `mantas.gipiskis@gmail.com`.

## Test plan
- [x] 164/164 unit tests pass
- [x] TypeScript build succeeds
- [x] Docker smoke test passes (API healthy)
- [x] JWT_SECRET in container matches `.env` value
- [x] OAuth URL correctly includes `state=<tenant_id>`
- [ ] Manual: complete Google OAuth consent flow
- [ ] Manual: verify `google_account_email` stored after consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)