### PR TITLE
fix: add missing columns to tenant_calendar_tokens for OAuth callback

### DIFF
--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -46,7 +46,8 @@ async function upsertCalendarTokens(
   accessToken: string,
   refreshToken: string,
   expiresIn: number,
-  calendarId = "primary"
+  calendarId = "primary",
+  googleEmail?: string
 ): Promise<void> {
   const tokenExpiry = new Date(Date.now() + expiresIn * 1000);
   const encAccess = encryptToken(accessToken);
@@ -54,16 +55,36 @@ async function upsertCalendarTokens(
 
   await query(
     `INSERT INTO tenant_calendar_tokens
-       (tenant_id, access_token, refresh_token, token_expiry, calendar_id, connected_at)
-     VALUES ($1, $2, $3, $4, $5, NOW())
+       (tenant_id, access_token, refresh_token, token_expiry, calendar_id, google_account_email, integration_status, connected_at)
+     VALUES ($1, $2, $3, $4, $5, $6, 'active', NOW())
      ON CONFLICT (tenant_id) DO UPDATE SET
-       access_token   = EXCLUDED.access_token,
-       refresh_token  = EXCLUDED.refresh_token,
-       token_expiry   = EXCLUDED.token_expiry,
-       calendar_id    = EXCLUDED.calendar_id,
-       last_refreshed = NOW()`,
-    [tenantId, encAccess, encRefresh, tokenExpiry.toISOString(), calendarId]
+       access_token         = EXCLUDED.access_token,
+       refresh_token        = EXCLUDED.refresh_token,
+       token_expiry         = EXCLUDED.token_expiry,
+       calendar_id          = EXCLUDED.calendar_id,
+       google_account_email = EXCLUDED.google_account_email,
+       integration_status   = 'active',
+       last_error           = NULL,
+       last_refreshed       = NOW(),
+       updated_at           = NOW()`,
+    [tenantId, encAccess, encRefresh, tokenExpiry.toISOString(), calendarId, googleEmail ?? null]
   );
+}
+
+/**
+ * Fetches the Google account email using the access token.
+ */
+async function fetchGoogleEmail(accessToken: string): Promise<string | undefined> {
+  try {
+    const res = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as { email?: string };
+    return data.email;
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -178,14 +199,18 @@ export async function googleAuthRoute(app: FastifyInstance) {
       return reply.status(502).send({ error: "Incomplete tokens from Google" });
     }
 
+    const googleEmail = await fetchGoogleEmail(tokens.access_token);
+
     await upsertCalendarTokens(
       tenantId,
       tokens.access_token,
       tokens.refresh_token,
-      tokens.expires_in ?? 3600
+      tokens.expires_in ?? 3600,
+      "primary",
+      googleEmail
     );
 
-    request.log.info({ tenantId }, "Google Calendar connected for tenant");
+    request.log.info({ tenantId, googleEmail }, "Google Calendar connected for tenant");
 
     // Redirect back to the app dashboard with a success flag
     return reply.redirect(`${publicOrigin}/app.html?calendar=connected`);

--- a/db/migrations/010_calendar_tokens_extended.sql
+++ b/db/migrations/010_calendar_tokens_extended.sql
@@ -1,0 +1,8 @@
+-- 010: Add extended columns to tenant_calendar_tokens
+-- Required by the OAuth callback to store google account email and integration status
+
+ALTER TABLE tenant_calendar_tokens
+  ADD COLUMN IF NOT EXISTS google_account_email TEXT,
+  ADD COLUMN IF NOT EXISTS integration_status TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS last_error TEXT,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();


### PR DESCRIPTION
## Summary
- Live database was missing `google_account_email`, `integration_status`, `last_error`, and `updated_at` columns on `tenant_calendar_tokens`
- The running API container expected these columns, causing OAuth callback to fail with `column "google_account_email" does not exist`
- Added migration `010_calendar_tokens_extended.sql` and synced `google.ts` source to match the deployed container code

## Test plan
- [x] Columns added to live database via ALTER TABLE
- [x] Schema verified with `\d tenant_calendar_tokens`
- [x] API health check passes (postgres: ok, redis: ok)
- [x] OAuth callback route reachable (returns 302 without code, no DB error)
- [x] 164/164 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)