### PR TITLE
fix: resolve JWT_SECRET mismatch and add email scope to OAuth

### DIFF
--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -6,7 +6,7 @@ import { requireAuth } from "../../middleware/require-auth";
 
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
-const SCOPES = "https://www.googleapis.com/auth/calendar";
+const SCOPES = "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/userinfo.email";
 
 // ── Token encryption (AES-256-GCM) ───────────────────────────────────────────
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       REDIS_URL: redis://:${REDIS_PASSWORD:-redis_secret}@redis:6379/0
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis_secret}
       N8N_INTERNAL_URL: http://n8n:5678
-      JWT_SECRET: ${JWT_SECRET:-change_me_jwt_secret}
+      # JWT_SECRET provided by env_file (../.env)
     env_file:
       - path: ../.env
         required: false


### PR DESCRIPTION
## Summary
- Removed explicit `JWT_SECRET` from docker-compose `environment` section — it was overriding the real secret from `.env` with a default fallback, causing AES-GCM token decryption failures
- Added `userinfo.email` scope to Google OAuth so `google_account_email` gets populated on future authorizations
- Fixed `PUBLIC_ORIGIN` and `CORS_ORIGINS` in `.env` to point to port 3000 (actual API) instead of 8090 (unrelated Wondershare process)

## Verification
- API container now uses correct JWT_SECRET from `.env`
- Calendar event creation succeeds (event ID: `2lhokr2qe1snd6ovi3ufd93amc`)
- Test appointment synced to Google Calendar for tenant `7f4f1224`
- `app.html` returns HTTP 200 on port 3000
- All 164 tests pass (10 test files)

## Test plan
- [ ] Verify `docker compose up -d api` picks up JWT_SECRET from `.env`
- [ ] Verify calendar event creation via `/internal/calendar-event`
- [ ] Re-authorize Google OAuth to verify email scope populates `google_account_email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)