### PR TITLE
feat: add POST /internal/appointments endpoint

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,40 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: appointment-creation-endpoint — 2026-03-14
+
+**Branch:** ai/appointment-creation-endpoint
+**Status:** COMPLETE — Appointment creation endpoint bridging booking-intent to calendar-event
+
+### What Was Done
+1. Created `POST /internal/appointments` endpoint — accepts booking data, creates/upserts appointment record in DB
+2. Created `apps/api/src/services/appointments.ts` — service layer with tenant validation, conversation-based upsert (ON CONFLICT), proper error handling
+3. Created `apps/api/src/routes/internal/appointments.ts` — Zod-validated route with 201/200/404/500 status codes
+4. Created `apps/api/src/tests/appointments.test.ts` — 24 tests (10 service + 14 route)
+5. Registered route in `apps/api/src/index.ts`
+
+### Why This Matters
+Previously, appointments could only be created via raw SQL in n8n WF-002. This endpoint:
+- Enables n8n WF-002 to call the API instead of inline SQL (proper separation of concerns)
+- Includes tenant validation (WF-002 SQL didn't check tenant exists)
+- Includes `customer_name` in the insert (WF-002 SQL omitted it)
+- Bridges the booking-intent → appointment → calendar-event pipeline in the TypeScript API
+
+### Verification
+- appointments.test.ts: 24/24 pass
+- Full suite: 11 files, 188/188 pass, 6.36s, EXIT_CODE=0
+
+### Files Changed
+- `apps/api/src/services/appointments.ts` — new service
+- `apps/api/src/routes/internal/appointments.ts` — new route
+- `apps/api/src/tests/appointments.test.ts` — new test file (24 tests)
+- `apps/api/src/index.ts` — route registration
+- `project-brain/project_status.json` — Stage 3 progress 48→50%
+- `project-brain/project_status.md` — mirrored
+- `AI_STATUS.md` — this entry
+
+---
+
 ## TASK: idempotency-guards — 2026-03-14
 
 **Branch:** ai/idempotency-guards

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import { tenantDashboardRoute } from "./routes/tenant/dashboard";
 import { calendarTokensRoute } from "./routes/internal/calendar-tokens";
 import { bookingIntentRoute } from "./routes/internal/booking-intent";
 import { calendarEventRoute } from "./routes/internal/calendar-event";
+import { appointmentsRoute } from "./routes/internal/appointments";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { startSmsInboundWorker } from "./workers/sms-inbound.worker";
@@ -75,6 +76,7 @@ async function bootstrap() {
   await app.register(calendarTokensRoute, { prefix: "/internal" });
   await app.register(bookingIntentRoute, { prefix: "/internal" });
   await app.register(calendarEventRoute, { prefix: "/internal" });
+  await app.register(appointmentsRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });

--- a/apps/api/src/routes/internal/appointments.ts
+++ b/apps/api/src/routes/internal/appointments.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createAppointment } from "../../services/appointments";
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid(),
+  conversationId: z.string().uuid().nullable().optional(),
+  customerPhone: z.string().min(1),
+  customerName: z.string().nullable().optional(),
+  serviceType: z.string().nullable().optional(),
+  scheduledAt: z.string().min(1),
+  durationMinutes: z.number().int().positive().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+/**
+ * POST /internal/appointments
+ *
+ * Creates (or upserts) an appointment record after booking intent is detected.
+ * When conversationId is provided, enforces one appointment per conversation.
+ *
+ * Called by n8n WF-002 (ai-booking-worker) or directly after booking detection.
+ * Internal only — NOT exposed externally (nginx does not proxy /internal/).
+ */
+export async function appointmentsRoute(app: FastifyInstance) {
+  app.post("/appointments", async (request, reply) => {
+    const parsed = BodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(
+          (i) => `${i.path.join(".")}: ${i.message}`
+        ),
+      });
+    }
+
+    const result = await createAppointment(parsed.data);
+
+    request.log.info(
+      {
+        tenantId: parsed.data.tenantId,
+        conversationId: parsed.data.conversationId,
+        success: result.success,
+        upserted: result.upserted,
+        appointmentId: result.appointment?.id,
+      },
+      result.success
+        ? `Appointment ${result.upserted ? "updated" : "created"}`
+        : `Appointment creation failed: ${result.error}`
+    );
+
+    if (!result.success) {
+      const status = result.error === "Tenant not found" ? 404 : 500;
+      return reply.status(status).send(result);
+    }
+
+    const status = result.upserted ? 200 : 201;
+    return reply.status(status).send(result);
+  });
+}

--- a/apps/api/src/services/appointments.ts
+++ b/apps/api/src/services/appointments.ts
@@ -1,0 +1,188 @@
+/**
+ * Appointment Creation Service
+ *
+ * Creates appointment records in the database after booking intent is detected.
+ * Bridges the gap between booking-intent detection and calendar-event creation.
+ *
+ * Called by: POST /internal/appointments (n8n WF-002 or API-side booking flow)
+ */
+
+import { query } from "../db/client";
+
+export interface CreateAppointmentInput {
+  tenantId: string;
+  conversationId?: string | null;
+  customerPhone: string;
+  customerName?: string | null;
+  serviceType?: string | null;
+  scheduledAt: string; // ISO 8601
+  durationMinutes?: number;
+  notes?: string | null;
+}
+
+export interface AppointmentRecord {
+  id: string;
+  tenantId: string;
+  conversationId: string | null;
+  customerPhone: string;
+  customerName: string | null;
+  serviceType: string | null;
+  scheduledAt: string;
+  durationMinutes: number;
+  notes: string | null;
+  googleEventId: string | null;
+  calendarSynced: boolean;
+  createdAt: string;
+}
+
+export interface CreateAppointmentResult {
+  success: boolean;
+  appointment: AppointmentRecord | null;
+  upserted: boolean;
+  error: string | null;
+}
+
+/**
+ * Creates or upserts an appointment record.
+ *
+ * When a conversationId is provided, uses ON CONFLICT to upsert — ensuring
+ * one appointment per conversation (matches WF-002 semantics).
+ *
+ * Flow:
+ * 1. Validate tenant exists
+ * 2. INSERT appointment (with upsert on conversation_id if provided)
+ * 3. Return created/updated record
+ */
+export async function createAppointment(
+  input: CreateAppointmentInput
+): Promise<CreateAppointmentResult> {
+  // 1. Validate tenant exists
+  try {
+    const tenants = await query<{ id: string }>(
+      `SELECT id FROM tenants WHERE id = $1`,
+      [input.tenantId]
+    );
+    if (tenants.length === 0) {
+      return {
+        success: false,
+        appointment: null,
+        upserted: false,
+        error: "Tenant not found",
+      };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      appointment: null,
+      upserted: false,
+      error: `Tenant lookup failed: ${(err as Error).message}`,
+    };
+  }
+
+  // 2. Insert or upsert appointment
+  const duration = input.durationMinutes ?? 60;
+
+  try {
+    let rows: Array<{
+      id: string;
+      tenant_id: string;
+      conversation_id: string | null;
+      customer_phone: string;
+      customer_name: string | null;
+      service_type: string | null;
+      scheduled_at: string;
+      duration_minutes: number;
+      notes: string | null;
+      google_event_id: string | null;
+      calendar_synced: boolean;
+      created_at: string;
+      xmax: string;
+    }>;
+
+    if (input.conversationId) {
+      // Upsert: one appointment per conversation
+      rows = await query(
+        `INSERT INTO appointments
+           (tenant_id, conversation_id, customer_phone, customer_name,
+            service_type, scheduled_at, duration_minutes, notes)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (conversation_id) DO UPDATE SET
+           customer_phone = EXCLUDED.customer_phone,
+           customer_name = EXCLUDED.customer_name,
+           service_type = EXCLUDED.service_type,
+           scheduled_at = EXCLUDED.scheduled_at,
+           duration_minutes = EXCLUDED.duration_minutes,
+           notes = EXCLUDED.notes
+         RETURNING *, xmax`,
+        [
+          input.tenantId,
+          input.conversationId,
+          input.customerPhone,
+          input.customerName ?? null,
+          input.serviceType ?? null,
+          input.scheduledAt,
+          duration,
+          input.notes ?? null,
+        ]
+      );
+    } else {
+      // No conversation — always insert new
+      rows = await query(
+        `INSERT INTO appointments
+           (tenant_id, customer_phone, customer_name,
+            service_type, scheduled_at, duration_minutes, notes)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING *, 0::text AS xmax`,
+        [
+          input.tenantId,
+          input.customerPhone,
+          input.customerName ?? null,
+          input.serviceType ?? null,
+          input.scheduledAt,
+          duration,
+          input.notes ?? null,
+        ]
+      );
+    }
+
+    if (rows.length === 0) {
+      return {
+        success: false,
+        appointment: null,
+        upserted: false,
+        error: "Insert returned no rows",
+      };
+    }
+
+    const row = rows[0];
+    // xmax > 0 means the row was updated (upsert), not inserted
+    const upserted = row.xmax !== "0";
+
+    return {
+      success: true,
+      appointment: {
+        id: row.id,
+        tenantId: row.tenant_id,
+        conversationId: row.conversation_id,
+        customerPhone: row.customer_phone,
+        customerName: row.customer_name,
+        serviceType: row.service_type,
+        scheduledAt: row.scheduled_at,
+        durationMinutes: row.duration_minutes,
+        notes: row.notes,
+        googleEventId: row.google_event_id,
+        calendarSynced: row.calendar_synced,
+        createdAt: row.created_at,
+      },
+      upserted,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      appointment: null,
+      upserted: false,
+      error: `Appointment creation failed: ${(err as Error).message}`,
+    };
+  }
+}

--- a/apps/api/src/tests/appointments.test.ts
+++ b/apps/api/src/tests/appointments.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+import { appointmentsRoute } from "../routes/internal/appointments";
+import { createAppointment } from "../services/appointments";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const CONVERSATION_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012";
+const PHONE = "+15551234567";
+const APPT_ID = "d4e5f6a7-b8c9-0123-defa-234567890123";
+const NOW_ISO = "2026-03-15T10:00:00.000Z";
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    tenantId: TENANT_ID,
+    conversationId: CONVERSATION_ID,
+    customerPhone: PHONE,
+    customerName: "John Smith",
+    serviceType: "oil change",
+    scheduledAt: "2026-03-16T10:00:00-05:00",
+    durationMinutes: 60,
+    notes: "Customer prefers morning",
+    ...overrides,
+  };
+}
+
+function dbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: APPT_ID,
+    tenant_id: TENANT_ID,
+    conversation_id: CONVERSATION_ID,
+    customer_phone: PHONE,
+    customer_name: "John Smith",
+    service_type: "oil change",
+    scheduled_at: "2026-03-16T15:00:00.000Z",
+    duration_minutes: 60,
+    notes: "Customer prefers morning",
+    google_event_id: null,
+    calendar_synced: false,
+    created_at: NOW_ISO,
+    xmax: "0",
+    ...overrides,
+  };
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(appointmentsRoute, { prefix: "/internal" });
+  return app;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Service unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("createAppointment — service", () => {
+  it("creates appointment successfully", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }]) // tenant lookup
+      .mockResolvedValueOnce([dbRow()]); // insert
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      conversationId: CONVERSATION_ID,
+      customerPhone: PHONE,
+      customerName: "John Smith",
+      serviceType: "oil change",
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.appointment).not.toBeNull();
+    expect(result.appointment!.id).toBe(APPT_ID);
+    expect(result.appointment!.customerName).toBe("John Smith");
+    expect(result.appointment!.serviceType).toBe("oil change");
+    expect(result.upserted).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns upserted=true when conversation already has appointment", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow({ xmax: "12345" })]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      conversationId: CONVERSATION_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.upserted).toBe(true);
+  });
+
+  it("creates appointment without conversationId (no upsert)", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow({ conversation_id: null, xmax: "0" })]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.upserted).toBe(false);
+    // Verify the INSERT query was used (no ON CONFLICT)
+    const insertCall = mocks.query.mock.calls[1];
+    expect(insertCall[0]).not.toContain("ON CONFLICT");
+  });
+
+  it("returns error when tenant not found", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Tenant not found");
+    expect(result.appointment).toBeNull();
+  });
+
+  it("returns error when tenant lookup fails", async () => {
+    mocks.query.mockRejectedValueOnce(new Error("connection refused"));
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Tenant lookup failed");
+    expect(result.error).toContain("connection refused");
+  });
+
+  it("returns error when insert fails", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockRejectedValueOnce(new Error("unique violation"));
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Appointment creation failed");
+    expect(result.error).toContain("unique violation");
+  });
+
+  it("returns error when insert returns no rows", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Insert returned no rows");
+  });
+
+  it("defaults durationMinutes to 60", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow()]);
+
+    await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    const insertCall = mocks.query.mock.calls[1];
+    // duration_minutes is the 7th param in the upsert-less insert
+    // or param index varies — check that 60 appears in params
+    expect(insertCall[1]).toContain(60);
+  });
+
+  it("passes custom durationMinutes", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow({ duration_minutes: 90 })]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+      durationMinutes: 90,
+    });
+
+    expect(result.success).toBe(true);
+    const insertCall = mocks.query.mock.calls[1];
+    expect(insertCall[1]).toContain(90);
+  });
+
+  it("handles null customerName and serviceType", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([
+        dbRow({ customer_name: null, service_type: null }),
+      ]);
+
+    const result = await createAppointment({
+      tenantId: TENANT_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.appointment!.customerName).toBeNull();
+    expect(result.appointment!.serviceType).toBeNull();
+  });
+
+  it("uses ON CONFLICT query when conversationId provided", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow()]);
+
+    await createAppointment({
+      tenantId: TENANT_ID,
+      conversationId: CONVERSATION_ID,
+      customerPhone: PHONE,
+      scheduledAt: "2026-03-16T10:00:00-05:00",
+    });
+
+    const insertCall = mocks.query.mock.calls[1];
+    expect(insertCall[0]).toContain("ON CONFLICT");
+    expect(insertCall[0]).toContain("conversation_id");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Route integration tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /internal/appointments — route", () => {
+  it("returns 201 on successful creation", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow()]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody(),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.appointment.id).toBe(APPT_ID);
+    expect(body.upserted).toBe(false);
+  });
+
+  it("returns 200 on upsert (existing conversation appointment)", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow({ xmax: "999" })]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.upserted).toBe(true);
+  });
+
+  it("returns 404 when tenant not found", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Tenant not found");
+  });
+
+  it("returns 500 on database error", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody(),
+    });
+
+    expect(res.statusCode).toBe(500);
+    const body = res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("disk full");
+  });
+
+  it("returns 400 on missing tenantId", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: { customerPhone: PHONE, scheduledAt: "2026-03-16T10:00:00-05:00" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe("Validation failed");
+  });
+
+  it("returns 400 on invalid tenantId format", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ tenantId: "not-a-uuid" }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details[0]).toContain("tenantId");
+  });
+
+  it("returns 400 on missing customerPhone", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ customerPhone: undefined }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on missing scheduledAt", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ scheduledAt: undefined }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on empty customerPhone", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ customerPhone: "" }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on invalid conversationId format", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ conversationId: "bad" }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.details[0]).toContain("conversationId");
+  });
+
+  it("returns 400 on negative durationMinutes", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ durationMinutes: -30 }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts null conversationId", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([dbRow({ conversation_id: null, xmax: "0" })]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: validBody({ conversationId: null }),
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("accepts minimal valid payload", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }])
+      .mockResolvedValueOnce([
+        dbRow({
+          conversation_id: null,
+          customer_name: null,
+          service_type: null,
+          notes: null,
+          xmax: "0",
+        }),
+      ]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/appointments",
+      payload: {
+        tenantId: TENANT_ID,
+        customerPhone: PHONE,
+        scheduledAt: "2026-03-16T10:00:00-05:00",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.appointment.customerName).toBeNull();
+  });
+});

--- a/project-brain/project_status.json
+++ b/project-brain/project_status.json
@@ -1,5 +1,5 @@
 {
-  "overall_progress": 46,
+  "overall_progress": 47,
 
   "current_phase": "TEST environment stabilization and SMS flow validation",
 
@@ -25,7 +25,7 @@
       "name": "Core Messaging & AI Flow",
       "weight": 25,
       "status": "in_progress",
-      "progress": 48
+      "progress": 50
     },
     {
       "id": 4,
@@ -66,6 +66,7 @@
       "LT sandbox SMS test flow development"
     ],
     "done": [
+      "Appointment creation endpoint + service (24 tests)",
       "Idempotency guards: calendar-event + checkout (10 tests)",
       "Checkout endpoint test coverage (8 tests)",
       "Conversation health metrics endpoint (14 tests)",
@@ -121,6 +122,11 @@
   ],
 
   "recent_changes": [
+    {
+      "date": "2026-03-14",
+      "change": "Appointment creation endpoint: POST /internal/appointments with service layer, tenant validation, conversation-based upsert, 24 tests. Full suite 188/188.",
+      "branch": "ai/appointment-creation-endpoint"
+    },
     {
       "date": "2026-03-14",
       "change": "Idempotency guards: calendar-event DB-level dedup (prevents duplicate Google Calendar events on retry), checkout Redis lock (prevents duplicate Stripe customers). 10 new tests, full suite 164/164.",

--- a/project-brain/project_status.md
+++ b/project-brain/project_status.md
@@ -7,7 +7,7 @@
 
 ## Project Completion Estimate
 
-**~46%** (weighted)
+**~47%** (weighted)
 
 Calculated from weighted stage progress below. Only objectively verifiable progress counts. Code-complete but unverified stages are capped at 40-50%.
 
@@ -40,12 +40,12 @@ Phase: TEST environment stabilization and SMS flow validation.
 |---|-------|--------|--------|----------|----------|
 | 1 | Foundation & Operating Model | 10% | done | 100% | 10.0% |
 | 2 | TEST Sandbox Workflow Chain | 15% | in_progress | 40% | 6.0% |
-| 3 | Core Messaging & AI Flow | 25% | in_progress | 48% | 12.0% |
+| 3 | Core Messaging & AI Flow | 25% | in_progress | 50% | 12.5% |
 | 4 | Calendar & Booking Reliability | 15% | blocked | 45% | 6.75% |
 | 5 | Admin Visibility & Control | 10% | in_progress | 65% | 6.5% |
 | 6 | Production Readiness | 15% | in_progress | 32% | 4.8% |
 | 7 | First Live Pilot | 10% | not_started | 0% | 0.0% |
-| | **Total** | **100%** | | | **~46%** |
+| | **Total** | **100%** | | | **~47%** |
 
 ## Active Tasks
 
@@ -58,6 +58,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 ## Done (Recent)
 
+- Appointment creation endpoint + service — 24 tests (branch: `ai/appointment-creation-endpoint`)
 - Idempotency guards: calendar-event + checkout — 10 new tests (branch: `ai/idempotency-guards`)
 - Checkout endpoint test coverage — 8 tests (branch: `ai/idempotency-guards`)
 - Conversation health metrics endpoint — 14 tests (branch: `ai/gcal-event-creation`)
@@ -83,6 +84,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 | Date | Change | Branch |
 |------|--------|--------|
+| 2026-03-14 | Appointment creation endpoint: POST /internal/appointments with service layer, tenant validation, conversation-based upsert (24 tests, suite 188/188) | `ai/appointment-creation-endpoint` |
 | 2026-03-14 | Idempotency guards: calendar-event DB dedup + checkout Redis lock (10 new tests, suite 164/164) | `ai/idempotency-guards` |
 | 2026-03-14 | Project Ops v2 polish: stage_id→title mapping, auto-expand current stage subtasks, Admin stage 45→65%, backlog item removed | `ai/project-ops-v2-polish` |
 | 2026-03-14 | Conversation health metrics: GET /internal/admin/metrics/conversation-health (14 tests: completion rate, booking conversion, close reason breakdown, daily volume, filtering) | `ai/gcal-event-creation` |


### PR DESCRIPTION
## Summary
- Adds `POST /internal/appointments` endpoint with service layer, Zod validation, and tenant verification
- Supports conversation-based upsert (one appointment per conversation, matching WF-002 semantics)
- Includes `customer_name` in appointment creation (WF-002 inline SQL omitted this field)
- Bridges the core pipeline gap: booking-intent → **appointment creation** → calendar-event

## Test plan
- [x] 24 new tests (10 service unit + 14 route integration)
- [x] Full suite: 11 files, 188/188 pass, EXIT_CODE=0
- [ ] n8n WF-002 can be updated to call this endpoint instead of inline SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)