### PR TITLE
feat: unify WF-002 with API endpoints for booking and appointments

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,37 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: wf002-use-api-endpoints — 2026-03-14
+
+**Branch:** ai/wf002-use-api-endpoints
+**Status:** COMPLETE — n8n WF-002 now calls TypeScript API endpoints instead of inline code
+
+### What Was Done
+1. Replaced inline booking detection Code node (10 keyword patterns) with HTTP call to `POST http://api:3000/internal/booking-intent` (44 patterns, confidence levels, customer name extraction, natural language date parsing)
+2. Replaced direct Postgres INSERT node with HTTP call to `POST http://api:3000/internal/appointments` (adds tenant validation, customer_name persistence, proper error handling)
+3. Updated "Call WF-004: Calendar Sync" to pass `customerName` from API response (was previously always NULL)
+4. Preserved all downstream node references by keeping "Detect Booking Intent" as the merge node name
+
+### Why This Matters
+- **Eliminates code duplication**: Booking detection logic now lives in one place (TypeScript service with 44 tests), not two (TypeScript + n8n inline)
+- **customer_name now persisted**: The API endpoint includes customer_name in the INSERT; the old n8n SQL omitted it
+- **Calendar events get customer names**: WF-004 now receives customerName, so Google Calendar events show "oil change — John Smith — +15551234567" instead of just phone number
+- **Tenant validation**: API validates tenant exists before creating appointment; old SQL did not
+
+### Verification
+- Workflow JSON is valid and structurally correct
+- All downstream `$('Detect Booking Intent')` references preserved (merge node retains the name)
+- API endpoints verified: booking-intent (44 tests), appointments (24 tests), full suite 188/188
+- Cannot live-test without n8n credentials (existing blocker)
+
+### Files Changed
+- `n8n/workflows/US_AutoShop/ai-booking-worker.json` — workflow rewrite
+- `project-brain/project_status.json` — task added to done
+- `project-brain/project_status.md` — mirrored
+- `AI_STATUS.md` — this entry
+
+---
+
 ## TASK: appointment-creation-endpoint — 2026-03-14
 
 **Branch:** ai/appointment-creation-endpoint

--- a/n8n/workflows/US_AutoShop/ai-booking-worker.json
+++ b/n8n/workflows/US_AutoShop/ai-booking-worker.json
@@ -65,14 +65,56 @@
     },
     {
       "parameters": {
-        "jsCode": "// Detect booking intent from AI response\nconst aiResponse = $('OpenAI: Chat Completion').first().json.choices?.[0]?.message?.content || '';\nconst lowerResponse = aiResponse.toLowerCase();\nconst bookingKeywords = [\n  'appointment is confirmed',\n  'is confirmed',\n  'appointment confirmed',\n  'booked for',\n  'scheduled for',\n  'see you on',\n  'appointment set',\n  'confirmed for',\n  'confirmed, john',\n  'confirmed,',\n];\nconst isBooked = bookingKeywords.some(k => lowerResponse.includes(k));\nconst closeKeywords = ['stop','cancel','nevermind','never mind','no thanks','not interested'];\nconst rawMessage = $('Build OpenAI Messages').first().json.rawMessage || '';\nconst userWantsClose = closeKeywords.some(k => rawMessage.toLowerCase().includes(k));\n// Extract ISO 8601 date from user message; fallback to +24h\nconst isoDateMatch = rawMessage.match(/\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}/i);\nconst scheduledAt = isoDateMatch ? isoDateMatch[0] : new Date(Date.now() + 86400000).toISOString();\nconst scheduledAtExtracted = !!isoDateMatch;\n// Extract service type from user message\nconst serviceKeywords = ['oil change','tire rotation','brake','inspection','tune up','alignment','transmission'];\nconst serviceType = serviceKeywords.find(k => rawMessage.toLowerCase().includes(k)) || 'general service';\nreturn [{ json: {\n  tenantId: $('Build OpenAI Messages').first().json.tenantId,\n  conversationId: $('Build OpenAI Messages').first().json.conversationId,\n  customerPhone: $('Build OpenAI Messages').first().json.customerPhone,\n  ourPhone: $('Build OpenAI Messages').first().json.ourPhone,\n  aiResponse, isBooked, userWantsClose, scheduledAt, scheduledAtExtracted, serviceType,\n  tokensUsed: $('OpenAI: Chat Completion').first().json.usage?.total_tokens ?? 0\n} }];"
+        "jsCode": "// Extract AI response and context for the booking intent API call\nconst aiResponse = $('OpenAI: Chat Completion').first().json.choices?.[0]?.message?.content || '';\nconst context = $('Build OpenAI Messages').first().json;\nreturn [{ json: {\n  aiResponse,\n  customerMessage: context.rawMessage || '',\n  tenantId: context.tenantId,\n  conversationId: context.conversationId,\n  customerPhone: context.customerPhone,\n  ourPhone: context.ourPhone,\n  tokensUsed: $('OpenAI: Chat Completion').first().json.usage?.total_tokens ?? 0\n} }];"
+      },
+      "id": "extract-ai-response",
+      "name": "Extract AI Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        950,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://api:3000/internal/booking-intent",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ aiResponse: $json.aiResponse, customerMessage: $json.customerMessage }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "api-booking-intent",
+      "name": "API: Booking Intent",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [
+        1150,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Merge booking intent API result with conversation context.\n// Output shape matches the old inline detection so downstream nodes work unchanged.\nconst api = $('API: Booking Intent').first().json;\nconst context = $('Extract AI Response').first().json;\nreturn [{ json: {\n  tenantId: context.tenantId,\n  conversationId: context.conversationId,\n  customerPhone: context.customerPhone,\n  ourPhone: context.ourPhone,\n  aiResponse: context.aiResponse,\n  isBooked: api.isBooked,\n  confidence: api.confidence || 'none',\n  userWantsClose: api.userWantsClose,\n  scheduledAt: api.scheduledAt,\n  scheduledAtExtracted: api.scheduledAtExtracted,\n  serviceType: api.serviceType,\n  customerName: api.customerName || null,\n  matchedPatterns: api.matchedPatterns || [],\n  tokensUsed: context.tokensUsed\n} }];"
       },
       "id": "detect-booking-intent",
       "name": "Detect Booking Intent",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1000,
+        1350,
         300
       ]
     },
@@ -87,7 +129,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.3,
       "position": [
-        1250,
+        1550,
         300
       ],
       "credentials": {
@@ -124,7 +166,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
       "position": [
-        1500,
+        1800,
         300
       ],
       "onError": "continueRegularOutput"
@@ -138,7 +180,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1625,
+        1925,
         300
       ]
     },
@@ -162,30 +204,38 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        1750,
+        2100,
         300
       ]
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "SET LOCAL app.current_tenant_id = '{{ $('Detect Booking Intent').first().json.tenantId }}';\nINSERT INTO appointments (tenant_id, conversation_id, customer_phone, service_type, scheduled_at)\nVALUES (\n  '{{ $('Detect Booking Intent').first().json.tenantId }}'::uuid,\n  '{{ $('Detect Booking Intent').first().json.conversationId }}'::uuid,\n  '{{ $('Detect Booking Intent').first().json.customerPhone }}',\n  '{{ $('Detect Booking Intent').first().json.serviceType }}',\n  '{{ $('Detect Booking Intent').first().json.scheduledAt }}'::timestamptz\n)\nON CONFLICT (conversation_id) DO UPDATE\n  SET service_type = EXCLUDED.service_type,\n      scheduled_at = EXCLUDED.scheduled_at\nRETURNING id, tenant_id, conversation_id, customer_phone, service_type, scheduled_at;",
-        "options": {}
-      },
-      "id": "db-save-appointment",
-      "name": "DB: Save Appointment",
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.3,
-      "position": [
-        2000,
-        200
-      ],
-      "credentials": {
-        "postgres": {
-          "id": "postgres-creds",
-          "name": "AutoShop Postgres"
+        "method": "POST",
+        "url": "http://api:3000/internal/appointments",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ tenantId: $('Detect Booking Intent').first().json.tenantId, conversationId: $('Detect Booking Intent').first().json.conversationId, customerPhone: $('Detect Booking Intent').first().json.customerPhone, customerName: $('Detect Booking Intent').first().json.customerName, serviceType: $('Detect Booking Intent').first().json.serviceType, scheduledAt: $('Detect Booking Intent').first().json.scheduledAt }) }}",
+        "options": {
+          "timeout": 10000
         }
-      }
+      },
+      "id": "api-create-appointment",
+      "name": "API: Create Appointment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [
+        2350,
+        200
+      ]
     },
     {
       "parameters": {
@@ -193,7 +243,7 @@
         "url": "http://n8n:5678/webhook/calendar-sync",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ appointmentId: $json.id, tenantId: $json.tenant_id, conversationId: $json.conversation_id, customerPhone: $json.customer_phone, serviceType: $json.service_type, scheduledAt: $json.scheduled_at }) }}",
+        "jsonBody": "={{ JSON.stringify({ appointmentId: $json.appointment.id, tenantId: $json.appointment.tenantId, conversationId: $json.appointment.conversationId, customerPhone: $json.appointment.customerPhone, customerName: $json.appointment.customerName, serviceType: $json.appointment.serviceType, scheduledAt: $json.appointment.scheduledAt }) }}",
         "options": {
           "timeout": 30000
         }
@@ -203,7 +253,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
       "position": [
-        2250,
+        2600,
         200
       ]
     },
@@ -238,7 +288,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
       "position": [
-        2500,
+        2850,
         200
       ]
     },
@@ -262,7 +312,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        2000,
+        2350,
         400
       ]
     },
@@ -297,7 +347,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.1,
       "position": [
-        2250,
+        2600,
         400
       ]
     }
@@ -326,6 +376,28 @@
       ]
     },
     "OpenAI: Chat Completion": {
+      "main": [
+        [
+          {
+            "node": "Extract AI Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract AI Response": {
+      "main": [
+        [
+          {
+            "node": "API: Booking Intent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API: Booking Intent": {
       "main": [
         [
           {
@@ -384,7 +456,7 @@
       "main": [
         [
           {
-            "node": "DB: Save Appointment",
+            "node": "API: Create Appointment",
             "type": "main",
             "index": 0
           }
@@ -398,7 +470,7 @@
         ]
       ]
     },
-    "DB: Save Appointment": {
+    "API: Create Appointment": {
       "main": [
         [
           {

--- a/project-brain/project_status.json
+++ b/project-brain/project_status.json
@@ -66,6 +66,7 @@
       "LT sandbox SMS test flow development"
     ],
     "done": [
+      "WF-002 unified with API endpoints (booking-intent + appointments)",
       "Appointment creation endpoint + service (24 tests)",
       "Idempotency guards: calendar-event + checkout (10 tests)",
       "Checkout endpoint test coverage (8 tests)",
@@ -122,6 +123,11 @@
   ],
 
   "recent_changes": [
+    {
+      "date": "2026-03-14",
+      "change": "WF-002 unified with API: inline booking detection replaced with POST /internal/booking-intent (44-pattern service), raw SQL appointment insert replaced with POST /internal/appointments (adds customer_name, tenant validation). Eliminates code duplication between n8n and TypeScript.",
+      "branch": "ai/wf002-use-api-endpoints"
+    },
     {
       "date": "2026-03-14",
       "change": "Appointment creation endpoint: POST /internal/appointments with service layer, tenant validation, conversation-based upsert, 24 tests. Full suite 188/188.",

--- a/project-brain/project_status.md
+++ b/project-brain/project_status.md
@@ -58,6 +58,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 ## Done (Recent)
 
+- WF-002 unified with API endpoints (booking-intent + appointments) (branch: `ai/wf002-use-api-endpoints`)
 - Appointment creation endpoint + service — 24 tests (branch: `ai/appointment-creation-endpoint`)
 - Idempotency guards: calendar-event + checkout — 10 new tests (branch: `ai/idempotency-guards`)
 - Checkout endpoint test coverage — 8 tests (branch: `ai/idempotency-guards`)
@@ -84,6 +85,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 | Date | Change | Branch |
 |------|--------|--------|
+| 2026-03-14 | WF-002 unified with API: inline booking detection → POST /internal/booking-intent, raw SQL appointment insert → POST /internal/appointments (adds customer_name, tenant validation, eliminates code duplication) | `ai/wf002-use-api-endpoints` |
 | 2026-03-14 | Appointment creation endpoint: POST /internal/appointments with service layer, tenant validation, conversation-based upsert (24 tests, suite 188/188) | `ai/appointment-creation-endpoint` |
 | 2026-03-14 | Idempotency guards: calendar-event DB dedup + checkout Redis lock (10 new tests, suite 164/164) | `ai/idempotency-guards` |
 | 2026-03-14 | Project Ops v2 polish: stage_id→title mapping, auto-expand current stage subtasks, Admin stage 45→65%, backlog item removed | `ai/project-ops-v2-polish` |


### PR DESCRIPTION
## Summary
- Replaces inline booking detection in n8n WF-002 (10 keyword patterns) with HTTP call to `POST /internal/booking-intent` (44 patterns, confidence levels, customer name extraction, natural language date parsing)
- Replaces direct Postgres INSERT for appointments with HTTP call to `POST /internal/appointments` (adds tenant validation, `customer_name` persistence)
- Calendar sync now receives `customerName` — Google Calendar events show customer name alongside phone number

## Why
WF-002 had duplicated, weaker versions of logic that already existed as tested TypeScript services. This unification eliminates code duplication and ensures the production workflow uses the same validated logic as the test suite (44 + 24 = 68 tests).

## Test plan
- [x] Full API test suite: 11 files, 188/188 pass, EXIT_CODE=0
- [x] Workflow JSON validated (parseable, structurally correct)
- [x] All downstream `$('Detect Booking Intent')` references preserved (merge node retains name)
- [ ] Live n8n test (blocked by n8n credentials — existing human-owned blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)