### PR TITLE
feat: add missed call SMS endpoint and worker routing

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,28 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: missed-call-sms-endpoint — 2026-03-14
+
+**Branch:** ai/missed-call-sms-endpoint
+**Status:** COMPLETE — Missed call → initial SMS flow now implemented end-to-end
+
+### What Was Done
+1. Created `POST /internal/missed-call-sms` endpoint — handles the full missed call flow
+2. Created `apps/api/src/services/missed-call-sms.ts` — service with tenant validation, billing check, conversation creation, Twilio SMS sending, message logging
+3. Updated `apps/api/src/workers/sms-inbound.worker.ts` — routes `missed-call-trigger` jobs to API instead of n8n (no AI needed for initial SMS)
+4. Created 26 tests (unit + integration)
+
+### Why This Matters
+This completes the entry point of the entire core pipeline. Previously, missed calls were enqueued but sent to n8n's SMS inbound webhook with no message body — the AI worker would receive an empty message. Now:
+- Missed call → worker routes to API → tenant validated → conversation created → initial SMS sent → customer can reply → AI conversation begins
+- The initial SMS is a template ("Hi! We noticed you called...") — no AI needed, so it's faster and more reliable
+
+### Verification
+- missed-call-sms.test.ts: 26/26 pass
+- Full suite: 12 files, 214/214 pass, 5.85s, EXIT_CODE=0
+
+---
+
 ## TASK: wf002-use-api-endpoints — 2026-03-14
 
 **Branch:** ai/wf002-use-api-endpoints

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ import { calendarTokensRoute } from "./routes/internal/calendar-tokens";
 import { bookingIntentRoute } from "./routes/internal/booking-intent";
 import { calendarEventRoute } from "./routes/internal/calendar-event";
 import { appointmentsRoute } from "./routes/internal/appointments";
+import { missedCallSmsRoute } from "./routes/internal/missed-call-sms";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { startSmsInboundWorker } from "./workers/sms-inbound.worker";
@@ -77,6 +78,7 @@ async function bootstrap() {
   await app.register(bookingIntentRoute, { prefix: "/internal" });
   await app.register(calendarEventRoute, { prefix: "/internal" });
   await app.register(appointmentsRoute, { prefix: "/internal" });
+  await app.register(missedCallSmsRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });

--- a/apps/api/src/routes/internal/missed-call-sms.ts
+++ b/apps/api/src/routes/internal/missed-call-sms.ts
@@ -1,0 +1,61 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { handleMissedCallSms } from "../../services/missed-call-sms";
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid(),
+  customerPhone: z.string().min(1),
+  ourPhone: z.string().min(1),
+  callSid: z.string().min(1),
+  callStatus: z.string().min(1),
+});
+
+/**
+ * POST /internal/missed-call-sms
+ *
+ * Entry point of the core pipeline: handles a missed call by sending
+ * the initial outbound SMS that starts the AI conversation flow.
+ *
+ * Called by the sms-inbound worker when job.name === "missed-call-trigger".
+ * Internal only — NOT exposed externally.
+ */
+export async function missedCallSmsRoute(app: FastifyInstance) {
+  app.post("/missed-call-sms", async (request, reply) => {
+    const parsed = BodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(
+          (i) => `${i.path.join(".")}: ${i.message}`
+        ),
+      });
+    }
+
+    const result = await handleMissedCallSms(parsed.data);
+
+    request.log.info(
+      {
+        tenantId: parsed.data.tenantId,
+        callSid: parsed.data.callSid,
+        success: result.success,
+        smsSent: result.smsSent,
+        conversationId: result.conversationId,
+      },
+      result.success
+        ? "Missed call SMS sent"
+        : `Missed call SMS failed: ${result.error}`
+    );
+
+    if (!result.success) {
+      const status =
+        result.error === "Tenant not found"
+          ? 404
+          : result.error === "Tenant billing is blocked"
+            ? 402
+            : 500;
+      return reply.status(status).send(result);
+    }
+
+    return reply.status(200).send(result);
+  });
+}

--- a/apps/api/src/services/missed-call-sms.ts
+++ b/apps/api/src/services/missed-call-sms.ts
@@ -1,0 +1,243 @@
+/**
+ * Missed Call SMS Service
+ *
+ * Handles the entry point of the core pipeline:
+ *   missed call → initial outbound SMS → customer can reply → AI conversation begins
+ *
+ * When a call goes unanswered, this service:
+ * 1. Validates the tenant and checks billing status
+ * 2. Gets or creates a conversation for the customer
+ * 3. Logs a synthetic "missed call" inbound event
+ * 4. Sends the initial outbound SMS via Twilio
+ * 5. Logs the outbound message
+ *
+ * Called by: the sms-inbound worker for "missed-call-trigger" jobs
+ */
+
+import { query } from "../db/client";
+
+export interface MissedCallInput {
+  tenantId: string;
+  customerPhone: string;
+  ourPhone: string;
+  callSid: string;
+  callStatus: string;
+}
+
+export interface MissedCallResult {
+  success: boolean;
+  conversationId: string | null;
+  smsSent: boolean;
+  twilioSid: string | null;
+  error: string | null;
+}
+
+/**
+ * Builds the initial SMS text for a missed call.
+ * Uses the shop name if available for a personal touch.
+ */
+export function buildMissedCallSms(shopName: string | null): string {
+  const name = shopName || "our shop";
+  return (
+    `Hi! We noticed you just called ${name} but we couldn't pick up. ` +
+    `How can we help you today? Reply here and we'll get you taken care of.`
+  );
+}
+
+/**
+ * Sends an SMS via Twilio REST API.
+ * Returns the Twilio message SID on success, or null on failure.
+ */
+export async function sendTwilioSms(
+  to: string,
+  body: string,
+  fetchFn: typeof fetch = fetch
+): Promise<{ sid: string | null; error: string | null }> {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+
+  if (!accountSid || !authToken || !messagingServiceSid) {
+    return { sid: null, error: "Twilio credentials not configured" };
+  }
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
+  const auth = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+
+  try {
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: `MessagingServiceSid=${encodeURIComponent(messagingServiceSid)}&To=${encodeURIComponent(to)}&Body=${encodeURIComponent(body)}`,
+    });
+
+    const data = (await res.json()) as {
+      sid?: string;
+      code?: number;
+      message?: string;
+    };
+
+    if (!res.ok || !data.sid) {
+      return {
+        sid: null,
+        error: `Twilio API error ${res.status}: ${data.message || "unknown"}`,
+      };
+    }
+
+    return { sid: data.sid, error: null };
+  } catch (err) {
+    return {
+      sid: null,
+      error: `Twilio request failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+/**
+ * Handles the full missed-call SMS flow.
+ *
+ * This is the entry point of the entire AutoShop AI pipeline.
+ * After this runs, the customer has received an SMS and can reply
+ * to start an AI conversation that leads to booking.
+ */
+export async function handleMissedCallSms(
+  input: MissedCallInput,
+  fetchFn: typeof fetch = fetch
+): Promise<MissedCallResult> {
+  // 1. Validate tenant and get shop info
+  let shopName: string | null = null;
+  let billingStatus: string = "unknown";
+  try {
+    const rows = await query<{
+      id: string;
+      shop_name: string | null;
+      billing_status: string;
+    }>(
+      `SELECT id, shop_name, billing_status FROM tenants WHERE id = $1`,
+      [input.tenantId]
+    );
+
+    if (rows.length === 0) {
+      return {
+        success: false,
+        conversationId: null,
+        smsSent: false,
+        twilioSid: null,
+        error: "Tenant not found",
+      };
+    }
+
+    shopName = rows[0].shop_name;
+    billingStatus = rows[0].billing_status;
+  } catch (err) {
+    return {
+      success: false,
+      conversationId: null,
+      smsSent: false,
+      twilioSid: null,
+      error: `Tenant lookup failed: ${(err as Error).message}`,
+    };
+  }
+
+  // 2. Check billing — don't send SMS if tenant is blocked
+  if (billingStatus === "blocked") {
+    return {
+      success: false,
+      conversationId: null,
+      smsSent: false,
+      twilioSid: null,
+      error: "Tenant billing is blocked",
+    };
+  }
+
+  // 3. Get or create conversation
+  let conversationId: string | null = null;
+  let isNew = false;
+  try {
+    const rows = await query<{ conversation_id: string | null; is_new: boolean }>(
+      `SELECT * FROM get_or_create_conversation($1, $2)`,
+      [input.tenantId, input.customerPhone]
+    );
+
+    if (rows.length === 0 || !rows[0].conversation_id) {
+      return {
+        success: false,
+        conversationId: null,
+        smsSent: false,
+        twilioSid: null,
+        error: "Conversation creation blocked (cooldown active)",
+      };
+    }
+
+    conversationId = rows[0].conversation_id;
+    isNew = rows[0].is_new;
+  } catch (err) {
+    return {
+      success: false,
+      conversationId: null,
+      smsSent: false,
+      twilioSid: null,
+      error: `Conversation creation failed: ${(err as Error).message}`,
+    };
+  }
+
+  // 4. Log the missed call as a synthetic inbound message
+  try {
+    await query(
+      `INSERT INTO messages (tenant_id, conversation_id, direction, body)
+       VALUES ($1, $2, 'inbound', $3)`,
+      [
+        input.tenantId,
+        conversationId,
+        `[Missed call: ${input.callStatus}] from ${input.customerPhone}`,
+      ]
+    );
+  } catch {
+    // Non-fatal — continue with SMS even if logging fails
+  }
+
+  // 5. Send the initial outbound SMS
+  const smsBody = buildMissedCallSms(shopName);
+  const twilioResult = await sendTwilioSms(
+    input.customerPhone,
+    smsBody,
+    fetchFn
+  );
+
+  // 6. Log the outbound message
+  try {
+    await query(
+      `INSERT INTO messages (tenant_id, conversation_id, direction, body)
+       VALUES ($1, $2, 'outbound', $3)`,
+      [input.tenantId, conversationId, smsBody]
+    );
+    // Touch conversation to update last_message_at
+    await query(
+      `SELECT touch_conversation($1, $2)`,
+      [conversationId, input.tenantId]
+    );
+  } catch {
+    // Non-fatal — SMS was sent even if logging fails
+  }
+
+  if (!twilioResult.sid) {
+    return {
+      success: false,
+      conversationId,
+      smsSent: false,
+      twilioSid: null,
+      error: twilioResult.error,
+    };
+  }
+
+  return {
+    success: true,
+    conversationId,
+    smsSent: true,
+    twilioSid: twilioResult.sid,
+    error: null,
+  };
+}

--- a/apps/api/src/tests/missed-call-sms.test.ts
+++ b/apps/api/src/tests/missed-call-sms.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+import { missedCallSmsRoute } from "../routes/internal/missed-call-sms";
+import {
+  handleMissedCallSms,
+  buildMissedCallSms,
+  sendTwilioSms,
+} from "../services/missed-call-sms";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const PHONE = "+15551234567";
+const OUR_PHONE = "+15559876543";
+const CALL_SID = "CA1234567890abcdef";
+const CONVERSATION_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012";
+const TWILIO_SID = "SM1234567890abcdef";
+
+function validInput(overrides: Record<string, unknown> = {}) {
+  return {
+    tenantId: TENANT_ID,
+    customerPhone: PHONE,
+    ourPhone: OUR_PHONE,
+    callSid: CALL_SID,
+    callStatus: "no-answer",
+    ...overrides,
+  };
+}
+
+function mockFetchSuccess(): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ sid: TWILIO_SID }),
+  }) as unknown as typeof fetch;
+}
+
+function mockFetchFailure(status = 400, message = "Bad Request"): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message }),
+  }) as unknown as typeof fetch;
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(missedCallSmsRoute, { prefix: "/internal" });
+  return app;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Set Twilio env vars for tests
+  process.env.TWILIO_ACCOUNT_SID = "AC_test_sid";
+  process.env.TWILIO_AUTH_TOKEN = "test_auth_token";
+  process.env.TWILIO_MESSAGING_SERVICE_SID = "MG_test_sid";
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildMissedCallSms — unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("buildMissedCallSms", () => {
+  it("includes shop name when provided", () => {
+    const sms = buildMissedCallSms("Joe's Auto Repair");
+    expect(sms).toContain("Joe's Auto Repair");
+    expect(sms).toContain("How can we help");
+  });
+
+  it("uses fallback when shop name is null", () => {
+    const sms = buildMissedCallSms(null);
+    expect(sms).toContain("our shop");
+    expect(sms).toContain("How can we help");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// sendTwilioSms — unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("sendTwilioSms", () => {
+  it("returns SID on success", async () => {
+    const result = await sendTwilioSms(PHONE, "Test message", mockFetchSuccess());
+    expect(result.sid).toBe(TWILIO_SID);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns error on Twilio API failure", async () => {
+    const result = await sendTwilioSms(
+      PHONE,
+      "Test message",
+      mockFetchFailure(400, "Invalid phone")
+    );
+    expect(result.sid).toBeNull();
+    expect(result.error).toContain("Twilio API error 400");
+  });
+
+  it("returns error when fetch throws", async () => {
+    const failFetch = vi.fn().mockRejectedValue(
+      new Error("network timeout")
+    ) as unknown as typeof fetch;
+    const result = await sendTwilioSms(PHONE, "Test message", failFetch);
+    expect(result.sid).toBeNull();
+    expect(result.error).toContain("network timeout");
+  });
+
+  it("returns error when Twilio credentials missing", async () => {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    const result = await sendTwilioSms(PHONE, "Test message", mockFetchSuccess());
+    expect(result.sid).toBeNull();
+    expect(result.error).toContain("credentials not configured");
+  });
+
+  it("sends correct request to Twilio API", async () => {
+    const fakeFetch = mockFetchSuccess();
+    await sendTwilioSms(PHONE, "Hello world", fakeFetch);
+
+    expect(fakeFetch).toHaveBeenCalledOnce();
+    const [url, opts] = (fakeFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("api.twilio.com");
+    expect(url).toContain("AC_test_sid");
+    expect(opts.method).toBe("POST");
+    expect(opts.body).toContain(encodeURIComponent(PHONE));
+    expect(opts.body).toContain(encodeURIComponent("Hello world"));
+    expect(opts.body).toContain("MG_test_sid");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// handleMissedCallSms — service tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("handleMissedCallSms", () => {
+  it("completes full flow successfully", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([]) // log inbound
+      .mockResolvedValueOnce([]) // log outbound
+      .mockResolvedValueOnce([]); // touch conversation
+
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+
+    expect(result.success).toBe(true);
+    expect(result.conversationId).toBe(CONVERSATION_ID);
+    expect(result.smsSent).toBe(true);
+    expect(result.twilioSid).toBe(TWILIO_SID);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns error when tenant not found", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Tenant not found");
+  });
+
+  it("returns error when tenant billing is blocked", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "blocked" },
+    ]);
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Tenant billing is blocked");
+  });
+
+  it("returns error when conversation blocked by cooldown", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([{ conversation_id: null, is_new: false }]);
+
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cooldown");
+  });
+
+  it("returns error when Twilio SMS fails", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([]) // log inbound
+      .mockResolvedValueOnce([]) // log outbound
+      .mockResolvedValueOnce([]); // touch
+
+    const result = await handleMissedCallSms(
+      validInput(),
+      mockFetchFailure(400, "Invalid phone number")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.conversationId).toBe(CONVERSATION_ID);
+    expect(result.smsSent).toBe(false);
+    expect(result.error).toContain("Twilio API error");
+  });
+
+  it("handles tenant lookup failure", async () => {
+    mocks.query.mockRejectedValueOnce(new Error("connection refused"));
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Tenant lookup failed");
+  });
+
+  it("handles conversation creation failure", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "active" },
+      ])
+      .mockRejectedValueOnce(new Error("DB error"));
+
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Conversation creation failed");
+  });
+
+  it("continues even if inbound message logging fails", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockRejectedValueOnce(new Error("log fail")) // inbound log fails
+      .mockResolvedValueOnce([]) // outbound log
+      .mockResolvedValueOnce([]); // touch
+
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(true);
+    expect(result.smsSent).toBe(true);
+  });
+
+  it("includes shop name in SMS text", async () => {
+    const fakeFetch = mockFetchSuccess();
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Joe's Auto Repair", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    await handleMissedCallSms(validInput(), fakeFetch);
+
+    // The SMS body should contain the shop name
+    const [, opts] = (fakeFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = opts.body as string;
+    expect(body).toContain(encodeURIComponent("Joe's Auto Repair"));
+  });
+
+  it("allows trial billing status", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Test Shop", billing_status: "trial" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(true);
+  });
+
+  it("logs missed call info in inbound message", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Test Shop", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    await handleMissedCallSms(validInput(), mockFetchSuccess());
+
+    // Third query is the inbound message log
+    const inboundCall = mocks.query.mock.calls[2];
+    expect(inboundCall[1][2]).toContain("Missed call");
+    expect(inboundCall[1][2]).toContain("no-answer");
+    expect(inboundCall[1][2]).toContain(PHONE);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Route integration tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /internal/missed-call-sms — route", () => {
+  it("returns 200 on success", async () => {
+    mocks.query
+      .mockResolvedValueOnce([
+        { id: TENANT_ID, shop_name: "Test Shop", billing_status: "active" },
+      ])
+      .mockResolvedValueOnce([
+        { conversation_id: CONVERSATION_ID, is_new: true },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    // Mock global fetch for Twilio
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sid: TWILIO_SID }),
+    }) as unknown as typeof fetch;
+
+    try {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: "POST",
+        url: "/internal/missed-call-sms",
+        payload: validInput(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.success).toBe(true);
+      expect(body.smsSent).toBe(true);
+      expect(body.conversationId).toBe(CONVERSATION_ID);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns 404 when tenant not found", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 402 when tenant billing is blocked", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Test Shop", billing_status: "blocked" },
+    ]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput(),
+    });
+
+    expect(res.statusCode).toBe(402);
+  });
+
+  it("returns 400 on missing tenantId", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: {
+        customerPhone: PHONE,
+        ourPhone: OUR_PHONE,
+        callSid: CALL_SID,
+        callStatus: "no-answer",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("Validation failed");
+  });
+
+  it("returns 400 on invalid tenantId", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput({ tenantId: "not-uuid" }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on missing customerPhone", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput({ customerPhone: undefined }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on missing callSid", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput({ callSid: undefined }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 on empty callStatus", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/missed-call-sms",
+      payload: validInput({ callStatus: "" }),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/api/src/workers/sms-inbound.worker.ts
+++ b/apps/api/src/workers/sms-inbound.worker.ts
@@ -2,31 +2,41 @@ import { Worker, Job } from "bullmq";
 import { bullmqConnection as connection } from "../queues/redis";
 
 const N8N_INTERNAL_URL = process.env.N8N_INTERNAL_URL ?? "http://n8n:5678";
+const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? "http://localhost:3000";
 const N8N_SMS_WEBHOOK = `${N8N_INTERNAL_URL}/webhook/sms-inbound`;
-console.info(`[sms-worker] posting to ${N8N_SMS_WEBHOOK}`);
+const MISSED_CALL_ENDPOINT = `${API_INTERNAL_URL}/internal/missed-call-sms`;
+console.info(`[sms-worker] SMS replies → ${N8N_SMS_WEBHOOK}`);
+console.info(`[sms-worker] Missed calls → ${MISSED_CALL_ENDPOINT}`);
 
 /**
- * BullMQ worker: consumes jobs from "sms-inbound" queue and forwards
- * each job's payload to the n8n WF-001 webhook trigger.
+ * BullMQ worker: consumes jobs from "sms-inbound" queue and routes them:
  *
- * Both job types land here:
- *   - "process-sms"         (inbound SMS from Twilio)
- *   - "missed-call-trigger" (missed call → initiate outbound SMS flow)
+ *   - "process-sms"         → n8n WF-001 (AI conversation flow)
+ *   - "missed-call-trigger" → API /internal/missed-call-sms (initial outbound SMS)
+ *
+ * Missed calls are handled by the API directly because:
+ * 1. No AI needed for the first message (it's a template)
+ * 2. The API has Twilio credentials and DB access
+ * 3. Faster response (no n8n round-trip)
  */
 export function startSmsInboundWorker(): Worker {
   const worker = new Worker(
     "sms-inbound",
     async (job: Job) => {
-      const res = await fetch(N8N_SMS_WEBHOOK, {
+      const isMissedCall = job.name === "missed-call-trigger";
+      const targetUrl = isMissedCall ? MISSED_CALL_ENDPOINT : N8N_SMS_WEBHOOK;
+
+      const res = await fetch(targetUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(job.data),
-        signal: AbortSignal.timeout(30_000), // n8n must accept within 30s
+        signal: AbortSignal.timeout(30_000),
       });
 
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        throw new Error(`n8n webhook returned ${res.status}: ${body}`);
+        const target = isMissedCall ? "API missed-call-sms" : "n8n webhook";
+        throw new Error(`${target} returned ${res.status}: ${body}`);
       }
     },
     {
@@ -36,7 +46,10 @@ export function startSmsInboundWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    console.info(`[sms-worker] job ${job.id} (${job.name}) delivered to n8n`);
+    const target = job.name === "missed-call-trigger" ? "API" : "n8n";
+    console.info(
+      `[sms-worker] job ${job.id} (${job.name}) delivered to ${target}`
+    );
   });
 
   worker.on("failed", (job, err) => {

--- a/project-brain/project_status.json
+++ b/project-brain/project_status.json
@@ -1,5 +1,5 @@
 {
-  "overall_progress": 47,
+  "overall_progress": 48,
 
   "current_phase": "TEST environment stabilization and SMS flow validation",
 
@@ -66,6 +66,7 @@
       "LT sandbox SMS test flow development"
     ],
     "done": [
+      "Missed call SMS endpoint + worker routing (26 tests)",
       "WF-002 unified with API endpoints (booking-intent + appointments)",
       "Appointment creation endpoint + service (24 tests)",
       "Idempotency guards: calendar-event + checkout (10 tests)",
@@ -123,6 +124,11 @@
   ],
 
   "recent_changes": [
+    {
+      "date": "2026-03-14",
+      "change": "Missed call SMS endpoint: POST /internal/missed-call-sms handles full missed call flow (tenant validation, conversation creation, initial outbound SMS via Twilio, message logging). Worker routes missed-call jobs to API instead of n8n. 26 tests, full suite 214/214.",
+      "branch": "ai/missed-call-sms-endpoint"
+    },
     {
       "date": "2026-03-14",
       "change": "WF-002 unified with API: inline booking detection replaced with POST /internal/booking-intent (44-pattern service), raw SQL appointment insert replaced with POST /internal/appointments (adds customer_name, tenant validation). Eliminates code duplication between n8n and TypeScript.",

--- a/project-brain/project_status.md
+++ b/project-brain/project_status.md
@@ -7,7 +7,7 @@
 
 ## Project Completion Estimate
 
-**~47%** (weighted)
+**~48%** (weighted)
 
 Calculated from weighted stage progress below. Only objectively verifiable progress counts. Code-complete but unverified stages are capped at 40-50%.
 
@@ -45,7 +45,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 | 5 | Admin Visibility & Control | 10% | in_progress | 65% | 6.5% |
 | 6 | Production Readiness | 15% | in_progress | 32% | 4.8% |
 | 7 | First Live Pilot | 10% | not_started | 0% | 0.0% |
-| | **Total** | **100%** | | | **~47%** |
+| | **Total** | **100%** | | | **~48%** |
 
 ## Active Tasks
 
@@ -58,6 +58,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 ## Done (Recent)
 
+- Missed call SMS endpoint + worker routing — 26 tests (branch: `ai/missed-call-sms-endpoint`)
 - WF-002 unified with API endpoints (booking-intent + appointments) (branch: `ai/wf002-use-api-endpoints`)
 - Appointment creation endpoint + service — 24 tests (branch: `ai/appointment-creation-endpoint`)
 - Idempotency guards: calendar-event + checkout — 10 new tests (branch: `ai/idempotency-guards`)
@@ -85,6 +86,7 @@ Phase: TEST environment stabilization and SMS flow validation.
 
 | Date | Change | Branch |
 |------|--------|--------|
+| 2026-03-14 | Missed call SMS: POST /internal/missed-call-sms (tenant validation, conversation creation, initial outbound SMS via Twilio, message logging). Worker routes missed-call jobs to API. 26 tests, suite 214/214 | `ai/missed-call-sms-endpoint` |
 | 2026-03-14 | WF-002 unified with API: inline booking detection → POST /internal/booking-intent, raw SQL appointment insert → POST /internal/appointments (adds customer_name, tenant validation, eliminates code duplication) | `ai/wf002-use-api-endpoints` |
 | 2026-03-14 | Appointment creation endpoint: POST /internal/appointments with service layer, tenant validation, conversation-based upsert (24 tests, suite 188/188) | `ai/appointment-creation-endpoint` |
 | 2026-03-14 | Idempotency guards: calendar-event DB dedup + checkout Redis lock (10 new tests, suite 164/164) | `ai/idempotency-guards` |


### PR DESCRIPTION
## Summary
- New `POST /internal/missed-call-sms` endpoint handles the full missed-call → initial SMS flow
- Service validates tenant, checks billing, creates conversation, sends SMS via Twilio, logs messages
- Worker now routes `missed-call-trigger` jobs to API (no AI needed for template SMS) while SMS replies go to n8n
- Completes the entry point of the core pipeline: missed call → SMS → customer replies → AI conversation → booking

## Test plan
- [x] 26 new tests (unit + integration: SMS text, Twilio send, full flow, billing block, cooldown, error paths, validation)
- [x] Full suite: 12 files, 214/214 pass, EXIT_CODE=0
- [ ] Live Twilio test (requires production credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)