### PR TITLE
feat: API-native SMS conversation flow (process-sms endpoint)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,6 +25,7 @@ import { bookingIntentRoute } from "./routes/internal/booking-intent";
 import { calendarEventRoute } from "./routes/internal/calendar-event";
 import { appointmentsRoute } from "./routes/internal/appointments";
 import { missedCallSmsRoute } from "./routes/internal/missed-call-sms";
+import { processSmsRoute } from "./routes/internal/process-sms";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { startSmsInboundWorker } from "./workers/sms-inbound.worker";
@@ -79,6 +80,7 @@ async function bootstrap() {
   await app.register(calendarEventRoute, { prefix: "/internal" });
   await app.register(appointmentsRoute, { prefix: "/internal" });
   await app.register(missedCallSmsRoute, { prefix: "/internal" });
+  await app.register(processSmsRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });

--- a/apps/api/src/routes/internal/process-sms.ts
+++ b/apps/api/src/routes/internal/process-sms.ts
@@ -1,0 +1,59 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { processSms } from "../../services/process-sms";
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid(),
+  customerPhone: z.string().min(1),
+  ourPhone: z.string().min(1),
+  body: z.string().min(1),
+  messageSid: z.string().min(1),
+  atSoftLimit: z.boolean().default(false),
+});
+
+/**
+ * POST /internal/process-sms
+ *
+ * Full AI conversation processing for inbound SMS replies.
+ * Replaces n8n WF-001 + WF-002 with an API-native flow:
+ *   inbound SMS → conversation → AI response → booking detection
+ *   → appointment creation → calendar sync → SMS reply
+ *
+ * Called by: sms-inbound worker for "process-sms" jobs.
+ * Internal only — NOT exposed externally.
+ */
+export async function processSmsRoute(app: FastifyInstance) {
+  app.post("/process-sms", async (request, reply) => {
+    const parsed = BodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(
+          (i) => `${i.path.join(".")}: ${i.message}`
+        ),
+      });
+    }
+
+    const result = await processSms(parsed.data);
+
+    request.log.info(
+      {
+        tenantId: parsed.data.tenantId,
+        conversationId: result.conversationId,
+        success: result.success,
+        smsSent: result.smsSent,
+        isBooked: result.isBooked,
+        calendarSynced: result.calendarSynced,
+      },
+      result.success
+        ? "SMS processed"
+        : `SMS processing failed: ${result.error}`
+    );
+
+    if (!result.success) {
+      return reply.status(500).send(result);
+    }
+
+    return reply.status(200).send(result);
+  });
+}

--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -1,0 +1,335 @@
+/**
+ * SMS Conversation Processing Service
+ *
+ * Handles the full AI conversation loop when a customer replies to an SMS:
+ *   inbound SMS → get/create conversation → fetch history → OpenAI → booking detection
+ *   → log messages → send reply → create appointment + calendar event if booked
+ *
+ * This replaces the n8n WF-001 + WF-002 dependency with a single API-native flow,
+ * removing the requirement for n8n credentials to be configured.
+ *
+ * Called by: POST /internal/process-sms (sms-inbound worker)
+ */
+
+import { query } from "../db/client";
+import { detectBookingIntent } from "./booking-intent";
+import { createAppointment } from "./appointments";
+import { createCalendarEvent } from "./google-calendar";
+import { sendTwilioSms } from "./missed-call-sms";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ProcessSmsInput {
+  tenantId: string;
+  customerPhone: string;
+  ourPhone: string;
+  body: string;
+  messageSid: string;
+  atSoftLimit: boolean;
+}
+
+export interface ProcessSmsResult {
+  success: boolean;
+  conversationId: string | null;
+  aiResponse: string | null;
+  smsSent: boolean;
+  isBooked: boolean;
+  appointmentId: string | null;
+  calendarSynced: boolean;
+  conversationClosed: boolean;
+  error: string | null;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_MODEL = "gpt-4o-mini";
+const OPENAI_MAX_TOKENS = 800;
+const OPENAI_TEMPERATURE = 0.3;
+const HISTORY_LIMIT = 8;
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are an auto shop scheduling assistant. Help customers book appointments for vehicle maintenance and repair. " +
+  "Be friendly, professional, and concise. Keep responses under 160 characters when possible (SMS length). " +
+  "When a customer confirms a time and service, clearly confirm the appointment details.";
+
+const SOFT_LIMIT_RESPONSE =
+  "We've reached our monthly messaging limit. " +
+  "Please call us directly to schedule your appointment. Thank you!";
+
+// ── Core processing function ─────────────────────────────────────────────────
+
+export async function processSms(
+  input: ProcessSmsInput,
+  fetchFn: typeof fetch = fetch
+): Promise<ProcessSmsResult> {
+  const result: ProcessSmsResult = {
+    success: false,
+    conversationId: null,
+    aiResponse: null,
+    smsSent: false,
+    isBooked: false,
+    appointmentId: null,
+    calendarSynced: false,
+    conversationClosed: false,
+    error: null,
+  };
+
+  // ── 1. Get or create conversation ────────────────────────────────────────
+  try {
+    const rows = await query<{ conversation_id: string | null; is_new: boolean }>(
+      `SELECT * FROM get_or_create_conversation($1, $2)`,
+      [input.tenantId, input.customerPhone]
+    );
+
+    if (rows.length === 0 || !rows[0].conversation_id) {
+      result.error = "Conversation creation blocked (cooldown active)";
+      return result;
+    }
+
+    result.conversationId = rows[0].conversation_id;
+  } catch (err) {
+    result.error = `Conversation creation failed: ${(err as Error).message}`;
+    return result;
+  }
+
+  // ── 2. Log inbound message ───────────────────────────────────────────────
+  try {
+    await query(
+      `INSERT INTO messages (tenant_id, conversation_id, direction, body, twilio_sid)
+       VALUES ($1, $2, 'inbound', $3, $4)`,
+      [input.tenantId, result.conversationId, input.body, input.messageSid]
+    );
+  } catch {
+    // Non-fatal: continue even if logging fails (twilio_sid unique constraint = already logged)
+  }
+
+  // Touch conversation to update last_message_at + turn_count
+  try {
+    await query(`SELECT touch_conversation($1, $2)`, [
+      result.conversationId,
+      input.tenantId,
+    ]);
+  } catch {
+    // Non-fatal
+  }
+
+  // ── 3. Soft limit check ──────────────────────────────────────────────────
+  if (input.atSoftLimit) {
+    result.aiResponse = SOFT_LIMIT_RESPONSE;
+    const smsResult = await sendTwilioSms(
+      input.customerPhone,
+      SOFT_LIMIT_RESPONSE,
+      fetchFn
+    );
+    result.smsSent = !!smsResult.sid;
+
+    // Log outbound
+    try {
+      await query(
+        `INSERT INTO messages (tenant_id, conversation_id, direction, body)
+         VALUES ($1, $2, 'outbound', $3)`,
+        [input.tenantId, result.conversationId, SOFT_LIMIT_RESPONSE]
+      );
+    } catch {
+      // Non-fatal
+    }
+
+    result.success = true;
+    return result;
+  }
+
+  // ── 4. Fetch system prompt ───────────────────────────────────────────────
+  let systemPrompt = DEFAULT_SYSTEM_PROMPT;
+  try {
+    const rows = await query<{ prompt_text: string }>(
+      `SELECT prompt_text FROM system_prompts
+       WHERE tenant_id = $1 AND is_active = TRUE
+       ORDER BY version DESC LIMIT 1`,
+      [input.tenantId]
+    );
+    if (rows.length > 0) {
+      systemPrompt = rows[0].prompt_text;
+    }
+  } catch {
+    // Use default prompt if lookup fails
+  }
+
+  // ── 5. Fetch conversation history ────────────────────────────────────────
+  let history: Array<{ role: string; content: string }> = [];
+  try {
+    const rows = await query<{ direction: string; body: string }>(
+      `SELECT direction, body FROM messages
+       WHERE conversation_id = $1 AND tenant_id = $2
+       ORDER BY sent_at DESC LIMIT $3`,
+      [result.conversationId, input.tenantId, HISTORY_LIMIT]
+    );
+
+    // Reverse so oldest first, map to OpenAI format
+    history = rows
+      .reverse()
+      .filter((r) => r.body && r.body.trim())
+      .map((r) => ({
+        role: r.direction === "inbound" ? "user" : "assistant",
+        content: r.body,
+      }));
+  } catch {
+    // Continue with no history — AI will still respond
+  }
+
+  // ── 6. Call OpenAI ───────────────────────────────────────────────────────
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    result.error = "OPENAI_API_KEY not configured";
+    return result;
+  }
+
+  const messages = [
+    { role: "system", content: systemPrompt },
+    ...history,
+    { role: "user", content: input.body },
+  ];
+
+  let aiResponse: string;
+  let tokensUsed: number | null = null;
+
+  try {
+    const res = await fetchFn(OPENAI_API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${openaiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages,
+        max_tokens: OPENAI_MAX_TOKENS,
+        temperature: OPENAI_TEMPERATURE,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      result.error = `OpenAI API error ${res.status}: ${body}`;
+      return result;
+    }
+
+    const data = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>;
+      usage?: { total_tokens: number };
+    };
+
+    aiResponse = data.choices?.[0]?.message?.content ?? "";
+    tokensUsed = data.usage?.total_tokens ?? null;
+
+    if (!aiResponse) {
+      result.error = "OpenAI returned empty response";
+      return result;
+    }
+  } catch (err) {
+    result.error = `OpenAI request failed: ${(err as Error).message}`;
+    return result;
+  }
+
+  result.aiResponse = aiResponse;
+
+  // ── 7. Detect booking intent ─────────────────────────────────────────────
+  const intent = detectBookingIntent(aiResponse, input.body);
+
+  // ── 8. Log outbound AI message ───────────────────────────────────────────
+  try {
+    await query(
+      `INSERT INTO messages (tenant_id, conversation_id, direction, body, tokens_used, model_version)
+       VALUES ($1, $2, 'outbound', $3, $4, $5)`,
+      [input.tenantId, result.conversationId, aiResponse, tokensUsed, OPENAI_MODEL]
+    );
+  } catch {
+    // Non-fatal
+  }
+
+  // ── 9. Send SMS reply ────────────────────────────────────────────────────
+  const smsResult = await sendTwilioSms(input.customerPhone, aiResponse, fetchFn);
+  result.smsSent = !!smsResult.sid;
+
+  if (!smsResult.sid) {
+    // AI response was generated but SMS delivery failed
+    result.error = `SMS send failed: ${smsResult.error}`;
+    // Don't return — still process booking intent
+  }
+
+  // Touch conversation again after outbound
+  try {
+    await query(`SELECT touch_conversation($1, $2)`, [
+      result.conversationId,
+      input.tenantId,
+    ]);
+  } catch {
+    // Non-fatal
+  }
+
+  // ── 10. Handle booking ───────────────────────────────────────────────────
+  if (intent.isBooked) {
+    result.isBooked = true;
+
+    // Create appointment
+    const apptResult = await createAppointment({
+      tenantId: input.tenantId,
+      conversationId: result.conversationId,
+      customerPhone: input.customerPhone,
+      customerName: intent.customerName,
+      serviceType: intent.serviceType,
+      scheduledAt: intent.scheduledAt,
+    });
+
+    if (apptResult.success && apptResult.appointment) {
+      result.appointmentId = apptResult.appointment.id;
+
+      // Create calendar event
+      const calResult = await createCalendarEvent(
+        {
+          tenantId: input.tenantId,
+          appointmentId: apptResult.appointment.id,
+          customerPhone: input.customerPhone,
+          customerName: intent.customerName,
+          serviceType: intent.serviceType,
+          scheduledAt: intent.scheduledAt,
+        },
+        fetchFn
+      );
+
+      result.calendarSynced = calResult.calendarSynced;
+    }
+
+    // Close conversation as booked
+    try {
+      await query(`SELECT close_conversation($1, $2, $3, $4)`, [
+        result.conversationId,
+        input.tenantId,
+        "booked",
+        "booking_completed",
+      ]);
+      result.conversationClosed = true;
+    } catch {
+      // Non-fatal: appointment was created even if close fails
+    }
+  }
+
+  // ── 11. Handle user close request ────────────────────────────────────────
+  if (!intent.isBooked && intent.userWantsClose) {
+    try {
+      await query(`SELECT close_conversation($1, $2, $3, $4)`, [
+        result.conversationId,
+        input.tenantId,
+        "closed",
+        "user_closed",
+      ]);
+      result.conversationClosed = true;
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  result.success = true;
+  return result;
+}

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -1,0 +1,627 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+// Mock google calendar token decryption
+vi.mock("../routes/auth/google", () => ({
+  decryptToken: vi.fn((t: string) => t),
+}));
+
+import { processSms, ProcessSmsInput } from "../services/process-sms";
+import { processSmsRoute } from "../routes/internal/process-sms";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const PHONE = "+15551234567";
+const OUR_PHONE = "+15559876543";
+const CONVERSATION_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012";
+const APPOINTMENT_ID = "d4e5f6a7-b8c9-0123-def4-567890123456";
+const MESSAGE_SID = "SM1234567890abcdef";
+const TWILIO_SID = "SM0987654321fedcba";
+
+function validInput(overrides: Partial<ProcessSmsInput> = {}): ProcessSmsInput {
+  return {
+    tenantId: TENANT_ID,
+    customerPhone: PHONE,
+    ourPhone: OUR_PHONE,
+    body: "I need an oil change",
+    messageSid: MESSAGE_SID,
+    atSoftLimit: false,
+    ...overrides,
+  };
+}
+
+// Mock fetch that handles both OpenAI and Twilio calls
+function mockFetchAll(options: {
+  aiResponse?: string;
+  aiError?: boolean;
+  twilioOk?: boolean;
+  googleOk?: boolean;
+} = {}): typeof fetch {
+  const aiResponse = options.aiResponse ?? "Sure! When would you like to come in for an oil change?";
+  const twilioOk = options.twilioOk ?? true;
+
+  return vi.fn().mockImplementation(async (url: string) => {
+    // OpenAI
+    if (typeof url === "string" && url.includes("openai.com")) {
+      if (options.aiError) {
+        return { ok: false, status: 500, text: () => Promise.resolve("Internal error") };
+      }
+      return {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: aiResponse } }],
+            usage: { total_tokens: 150 },
+          }),
+      };
+    }
+
+    // Twilio
+    if (typeof url === "string" && url.includes("twilio.com")) {
+      if (!twilioOk) {
+        return {
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ message: "Invalid phone" }),
+        };
+      }
+      return {
+        ok: true,
+        json: () => Promise.resolve({ sid: TWILIO_SID }),
+      };
+    }
+
+    // Google Calendar
+    if (typeof url === "string" && url.includes("googleapis.com")) {
+      if (options.googleOk === false) {
+        return { ok: false, status: 401, text: () => Promise.resolve("Unauthorized") };
+      }
+      return {
+        ok: true,
+        json: () => Promise.resolve({ id: "gcal_event_123" }),
+      };
+    }
+
+    return { ok: true, json: () => Promise.resolve({}) };
+  }) as unknown as typeof fetch;
+}
+
+// Standard DB mock setup for successful flow
+function setupDbMocks(options: {
+  conversationBlocked?: boolean;
+  hasSystemPrompt?: boolean;
+  hasHistory?: boolean;
+  hasCalendarTokens?: boolean;
+} = {}) {
+  mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    // get_or_create_conversation
+    if (sql.includes("get_or_create_conversation")) {
+      if (options.conversationBlocked) return [];
+      return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+    }
+
+    // Insert message (inbound or outbound)
+    if (sql.includes("INSERT INTO messages")) {
+      return [{ id: "msg-123" }];
+    }
+
+    // touch_conversation
+    if (sql.includes("touch_conversation")) {
+      return [];
+    }
+
+    // system_prompts
+    if (sql.includes("system_prompts")) {
+      if (options.hasSystemPrompt) {
+        return [{ prompt_text: "You are Joe's Auto Repair assistant." }];
+      }
+      return [];
+    }
+
+    // Fetch message history
+    if (sql.includes("SELECT direction, body FROM messages")) {
+      if (options.hasHistory) {
+        return [
+          { direction: "outbound", body: "Hi! How can we help?" },
+          { direction: "inbound", body: "I need an oil change" },
+        ];
+      }
+      return [];
+    }
+
+    // Tenant lookup (for appointments)
+    if (sql.includes("SELECT id FROM tenants")) {
+      return [{ id: TENANT_ID }];
+    }
+
+    // Appointment insert
+    if (sql.includes("INSERT INTO appointments")) {
+      return [{
+        id: APPOINTMENT_ID,
+        tenant_id: TENANT_ID,
+        conversation_id: CONVERSATION_ID,
+        customer_phone: PHONE,
+        customer_name: null,
+        service_type: "oil change",
+        scheduled_at: new Date().toISOString(),
+        duration_minutes: 60,
+        notes: null,
+        google_event_id: null,
+        calendar_synced: false,
+        created_at: new Date().toISOString(),
+        xmax: "0",
+      }];
+    }
+
+    // Calendar token lookup (idempotency check)
+    if (sql.includes("SELECT google_event_id FROM appointments")) {
+      return [];
+    }
+
+    // Calendar tokens
+    if (sql.includes("SELECT access_token, calendar_id")) {
+      if (options.hasCalendarTokens) {
+        return [{ access_token: "test_access_token", calendar_id: "primary" }];
+      }
+      return [];
+    }
+
+    // Update appointment with google_event_id
+    if (sql.includes("UPDATE appointments")) {
+      return [];
+    }
+
+    // close_conversation
+    if (sql.includes("close_conversation")) {
+      return [{ close_conversation: true }];
+    }
+
+    return [];
+  });
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(processSmsRoute, { prefix: "/internal" });
+  return app;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.TWILIO_ACCOUNT_SID = "AC_test_sid";
+  process.env.TWILIO_AUTH_TOKEN = "test_auth_token";
+  process.env.TWILIO_MESSAGING_SERVICE_SID = "MG_test_sid";
+  process.env.OPENAI_API_KEY = "sk-test-key";
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// processSms — service unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("processSms — happy path", () => {
+  it("processes inbound SMS and returns AI response", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(true);
+    expect(result.conversationId).toBe(CONVERSATION_ID);
+    expect(result.aiResponse).toContain("oil change");
+    expect(result.smsSent).toBe(true);
+    expect(result.isBooked).toBe(false);
+  });
+
+  it("uses tenant system prompt when available", async () => {
+    setupDbMocks({ hasSystemPrompt: true });
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput(), fetchMock);
+
+    // Verify OpenAI was called with the right messages
+    const openaiCall = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("openai.com")
+    );
+    expect(openaiCall).toBeDefined();
+    const body = JSON.parse((openaiCall![1] as { body: string }).body);
+    expect(body.messages[0].content).toBe("You are Joe's Auto Repair assistant.");
+  });
+
+  it("includes conversation history in OpenAI request", async () => {
+    setupDbMocks({ hasHistory: true });
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput(), fetchMock);
+
+    const openaiCall = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("openai.com")
+    );
+    const body = JSON.parse((openaiCall![1] as { body: string }).body);
+    // system + 2 history + 1 new message = 4
+    expect(body.messages.length).toBe(4);
+    // History reversed from DESC: [outbound, inbound] → [inbound, outbound]
+    expect(body.messages[1].role).toBe("user");
+    expect(body.messages[2].role).toBe("assistant");
+  });
+});
+
+describe("processSms — booking flow", () => {
+  it("creates appointment when AI confirms booking", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Monday at 2 PM for an oil change!",
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(true);
+    expect(result.isBooked).toBe(true);
+    expect(result.appointmentId).toBe(APPOINTMENT_ID);
+    expect(result.conversationClosed).toBe(true);
+  });
+
+  it("syncs to Google Calendar when tokens available", async () => {
+    setupDbMocks({ hasCalendarTokens: true });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Tuesday at 10 AM.",
+      googleOk: true,
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.isBooked).toBe(true);
+    expect(result.calendarSynced).toBe(true);
+  });
+
+  it("creates appointment even when calendar sync fails", async () => {
+    setupDbMocks({ hasCalendarTokens: true });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Wednesday at 3 PM.",
+      googleOk: false,
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.isBooked).toBe(true);
+    expect(result.appointmentId).toBe(APPOINTMENT_ID);
+    expect(result.calendarSynced).toBe(false);
+  });
+
+  it("skips calendar when no tokens for tenant", async () => {
+    setupDbMocks({ hasCalendarTokens: false });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Booking confirmed for Thursday at 9 AM.",
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.isBooked).toBe(true);
+    expect(result.calendarSynced).toBe(false);
+  });
+});
+
+describe("processSms — conversation close", () => {
+  it("closes conversation when user sends stop", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({
+      aiResponse: "No problem! Have a great day.",
+    });
+
+    const result = await processSms(
+      validInput({ body: "stop" }),
+      fetchMock
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.conversationClosed).toBe(true);
+    expect(result.isBooked).toBe(false);
+  });
+
+  it("closes conversation on cancel", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({
+      aiResponse: "Understood, no worries!",
+    });
+
+    const result = await processSms(
+      validInput({ body: "cancel" }),
+      fetchMock
+    );
+
+    expect(result.conversationClosed).toBe(true);
+  });
+});
+
+describe("processSms — soft limit", () => {
+  it("sends soft limit response instead of AI", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(
+      validInput({ atSoftLimit: true }),
+      fetchMock
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.aiResponse).toContain("monthly messaging limit");
+    // Should NOT call OpenAI
+    const openaiCall = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("openai.com")
+    );
+    expect(openaiCall).toBeUndefined();
+  });
+});
+
+describe("processSms — error handling", () => {
+  it("returns error when conversation creation is blocked", async () => {
+    setupDbMocks({ conversationBlocked: true });
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cooldown");
+  });
+
+  it("returns error when conversation creation throws", async () => {
+    mocks.query.mockRejectedValueOnce(new Error("DB connection lost"));
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Conversation creation failed");
+  });
+
+  it("returns error when OPENAI_API_KEY not set", async () => {
+    delete process.env.OPENAI_API_KEY;
+    setupDbMocks();
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("OPENAI_API_KEY");
+  });
+
+  it("returns error when OpenAI API fails", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({ aiError: true });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("OpenAI API error");
+  });
+
+  it("returns error when OpenAI returns empty response", async () => {
+    setupDbMocks();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("openai.com")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ choices: [{ message: { content: "" } }] }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({ sid: TWILIO_SID }) };
+    }) as unknown as typeof fetch;
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("empty response");
+  });
+
+  it("returns error when OpenAI request times out", async () => {
+    setupDbMocks();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("openai.com")) {
+        throw new Error("The operation was aborted due to timeout");
+      }
+      return { ok: true, json: () => Promise.resolve({ sid: TWILIO_SID }) };
+    }) as unknown as typeof fetch;
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("timeout");
+  });
+
+  it("succeeds with SMS error when Twilio send fails", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({ twilioOk: false });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    // success is true because AI processing worked, but smsSent is false
+    expect(result.success).toBe(true);
+    expect(result.smsSent).toBe(false);
+    expect(result.error).toContain("SMS send failed");
+    expect(result.aiResponse).toBeTruthy();
+  });
+
+  it("continues with empty history when history query fails", async () => {
+    let callCount = 0;
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("get_or_create_conversation")) {
+        return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+      }
+      if (sql.includes("SELECT direction, body FROM messages")) {
+        throw new Error("DB timeout");
+      }
+      if (sql.includes("system_prompts")) {
+        return [];
+      }
+      return [];
+    });
+    const fetchMock = mockFetchAll();
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(true);
+    expect(result.aiResponse).toBeTruthy();
+  });
+});
+
+describe("processSms — message logging", () => {
+  it("logs inbound message with twilio_sid", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput(), fetchMock);
+
+    const insertCalls = mocks.query.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO messages") && (call[0] as string).includes("inbound")
+    );
+    expect(insertCalls.length).toBeGreaterThanOrEqual(1);
+    // Check twilio_sid was passed
+    expect(insertCalls[0][1]).toContain(MESSAGE_SID);
+  });
+
+  it("logs outbound AI message with token count and model", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput(), fetchMock);
+
+    const insertCalls = mocks.query.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO messages") && (call[0] as string).includes("tokens_used")
+    );
+    expect(insertCalls.length).toBeGreaterThanOrEqual(1);
+    // Check tokens_used and model_version were passed
+    expect(insertCalls[0][1]).toContain(150); // total_tokens from mock
+    expect(insertCalls[0][1]).toContain("gpt-4o-mini");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POST /internal/process-sms — route tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /internal/process-sms — route", () => {
+  it("returns 200 on successful processing", async () => {
+    setupDbMocks();
+    const app = await buildApp();
+
+    // Need to mock fetch globally for route test since we can't inject it
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetchAll();
+
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/internal/process-sms",
+        payload: {
+          tenantId: TENANT_ID,
+          customerPhone: PHONE,
+          ourPhone: OUR_PHONE,
+          body: "I need an oil change",
+          messageSid: MESSAGE_SID,
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.success).toBe(true);
+      expect(body.conversationId).toBe(CONVERSATION_ID);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns 400 on missing required fields", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/process-sms",
+      payload: { tenantId: "not-a-uuid" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("Validation failed");
+  });
+
+  it("returns 400 on empty body", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/process-sms",
+      payload: {
+        tenantId: TENANT_ID,
+        customerPhone: PHONE,
+        ourPhone: OUR_PHONE,
+        body: "",
+        messageSid: MESSAGE_SID,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 500 when processing fails", async () => {
+    setupDbMocks({ conversationBlocked: true });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/process-sms",
+      payload: {
+        tenantId: TENANT_ID,
+        customerPhone: PHONE,
+        ourPhone: OUR_PHONE,
+        body: "hello",
+        messageSid: MESSAGE_SID,
+      },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toContain("cooldown");
+  });
+
+  it("defaults atSoftLimit to false", async () => {
+    setupDbMocks();
+    const app = await buildApp();
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetchAll();
+
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/internal/process-sms",
+        payload: {
+          tenantId: TENANT_ID,
+          customerPhone: PHONE,
+          ourPhone: OUR_PHONE,
+          body: "hello",
+          messageSid: MESSAGE_SID,
+          // atSoftLimit not provided — should default to false
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      // Should have AI response, not soft limit response
+      expect(res.json().aiResponse).not.toContain("monthly messaging limit");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/workers/sms-inbound.worker.ts
+++ b/apps/api/src/workers/sms-inbound.worker.ts
@@ -1,41 +1,39 @@
 import { Worker, Job } from "bullmq";
 import { bullmqConnection as connection } from "../queues/redis";
 
-const N8N_INTERNAL_URL = process.env.N8N_INTERNAL_URL ?? "http://n8n:5678";
 const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? "http://localhost:3000";
-const N8N_SMS_WEBHOOK = `${N8N_INTERNAL_URL}/webhook/sms-inbound`;
 const MISSED_CALL_ENDPOINT = `${API_INTERNAL_URL}/internal/missed-call-sms`;
-console.info(`[sms-worker] SMS replies → ${N8N_SMS_WEBHOOK}`);
+const PROCESS_SMS_ENDPOINT = `${API_INTERNAL_URL}/internal/process-sms`;
+console.info(`[sms-worker] SMS replies → ${PROCESS_SMS_ENDPOINT}`);
 console.info(`[sms-worker] Missed calls → ${MISSED_CALL_ENDPOINT}`);
 
 /**
  * BullMQ worker: consumes jobs from "sms-inbound" queue and routes them:
  *
- *   - "process-sms"         → n8n WF-001 (AI conversation flow)
+ *   - "process-sms"         → API /internal/process-sms (AI conversation flow)
  *   - "missed-call-trigger" → API /internal/missed-call-sms (initial outbound SMS)
  *
- * Missed calls are handled by the API directly because:
- * 1. No AI needed for the first message (it's a template)
- * 2. The API has Twilio credentials and DB access
- * 3. Faster response (no n8n round-trip)
+ * Both job types are now handled by the API directly (no n8n dependency):
+ * 1. process-sms: full AI conversation loop (OpenAI → booking detection → appointment → calendar)
+ * 2. missed-call-trigger: template SMS + conversation creation
  */
 export function startSmsInboundWorker(): Worker {
   const worker = new Worker(
     "sms-inbound",
     async (job: Job) => {
       const isMissedCall = job.name === "missed-call-trigger";
-      const targetUrl = isMissedCall ? MISSED_CALL_ENDPOINT : N8N_SMS_WEBHOOK;
+      const targetUrl = isMissedCall ? MISSED_CALL_ENDPOINT : PROCESS_SMS_ENDPOINT;
 
       const res = await fetch(targetUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(job.data),
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(60_000), // 60s for AI processing
       });
 
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        const target = isMissedCall ? "API missed-call-sms" : "n8n webhook";
+        const target = isMissedCall ? "API missed-call-sms" : "API process-sms";
         throw new Error(`${target} returned ${res.status}: ${body}`);
       }
     },
@@ -46,9 +44,8 @@ export function startSmsInboundWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    const target = job.name === "missed-call-trigger" ? "API" : "n8n";
     console.info(
-      `[sms-worker] job ${job.id} (${job.name}) delivered to ${target}`
+      `[sms-worker] job ${job.id} (${job.name}) delivered to API`
     );
   });
 


### PR DESCRIPTION
## Summary
- Adds `POST /internal/process-sms` endpoint that handles the full AI conversation loop natively in the API
- Replaces n8n WF-001/WF-002 dependency: inbound SMS → conversation → OpenAI → booking detection → appointment → calendar sync → SMS reply
- Updates sms-inbound worker to route process-sms jobs to API instead of n8n (removes n8n credential blocker)
- 25 new tests covering happy path, booking flow, soft limits, error handling, and message logging

## What this unblocks
The core conversation flow (missed call → SMS → AI → booking → calendar) no longer requires n8n credentials to be configured. The entire pipeline now runs through the API.

## Test plan
- [x] 25 new tests for process-sms service and route
- [x] Full suite: 239/239 passed (13 test files)
- [ ] Live validation with real Twilio + OpenAI credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)