### PR TITLE
fix: prefer .env file over stale session env vars for Telegram credentials

### DIFF
--- a/scripts/send-telegram.ps1
+++ b/scripts/send-telegram.ps1
@@ -3,23 +3,39 @@ param(
     [string]$Message
 )
 
-$token = $env:TELEGRAM_BOT_TOKEN
-$chatId = $env:TELEGRAM_CHAT_ID
+$token = $null
+$chatId = $null
 
-# Load from .env if not in environment
-if (-not $token -or -not $chatId) {
-    $envFile = Join-Path $PSScriptRoot "..\.env"
-    if (Test-Path $envFile) {
-        Get-Content $envFile | ForEach-Object {
-            if ($_ -match '^\s*([^#][^=]+?)\s*=\s*(.+?)\s*$') {
-                $key = $matches[1]
-                $val = $matches[2]
-                if ($key -eq 'TELEGRAM_BOT_TOKEN' -and -not $token) { $token = $val }
-                if ($key -eq 'TELEGRAM_CHAT_ID' -and -not $chatId) { $chatId = $val }
-            }
+# Always load from .env file first (prefer file over stale session env vars)
+$envFile = Join-Path $PSScriptRoot "..\.env"
+if (Test-Path $envFile) {
+    Write-Host "[telegram] Loading from: $envFile"
+    Get-Content $envFile | ForEach-Object {
+        if ($_ -match '^\s*([^#][^=]+?)\s*=\s*(.+?)\s*$') {
+            $key = $matches[1].Trim()
+            $val = $matches[2].Trim()
+            # Strip surrounding quotes (single or double)
+            $val = $val -replace '^["'']|["'']$', ''
+            if ($key -eq 'TELEGRAM_BOT_TOKEN') { $token = $val }
+            if ($key -eq 'TELEGRAM_CHAT_ID') { $chatId = $val }
         }
     }
+} else {
+    Write-Host "[telegram] No .env file found at $envFile"
 }
+
+# Fall back to environment variables only if .env didn't provide values
+if (-not $token) { $token = $env:TELEGRAM_BOT_TOKEN }
+if (-not $chatId) { $chatId = $env:TELEGRAM_CHAT_ID }
+
+# Diagnostics (never print full token)
+if ($token) {
+    $maskedToken = $token.Substring(0, [Math]::Min(10, $token.Length)) + "..."
+    Write-Host "[telegram] Token found: $maskedToken"
+} else {
+    Write-Host "[telegram] Token: NOT FOUND"
+}
+Write-Host "[telegram] Chat ID found: $([bool]$chatId)"
 
 if (-not $token -or -not $chatId) {
     Write-Host "[telegram] TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set, skipping notification"


### PR DESCRIPTION
## Summary
- **Root cause**: Session environment had stale/wrong `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` values. The script checked `$env:` first and only fell back to `.env` if empty — so the correct `.env` values were never loaded, causing 401 Unauthorized errors.
- Always load from `.env` file first, fall back to environment variables only if `.env` didn't provide values
- Strip surrounding quotes and trim whitespace from parsed values
- Add safe diagnostics: print env file path, masked token prefix, chat ID presence

## Test plan
- [x] Verified with real `sendMessage` API call through `send-telegram.ps1`
- [x] Verified end-to-end through `notify-task-done.ps1`
- [x] Both calls received successfully on Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)