### PR TITLE
feat: add agent-bridge infrastructure

### DIFF
--- a/scripts/ask-openai.ps1
+++ b/scripts/ask-openai.ps1
@@ -1,0 +1,20 @@
+param(
+    [string]$Prompt
+)
+
+$headers = @{
+  "x-bridge-token" = $env:BRIDGE_TOKEN
+  "Content-Type" = "application/json"
+}
+
+$body = @{
+  prompt = $Prompt
+} | ConvertTo-Json
+
+$res = Invoke-RestMethod `
+  -Uri http://localhost:3030/ask-openai `
+  -Method POST `
+  -Headers $headers `
+  -Body $body
+
+$res.answer

--- a/scripts/ask-openai.sh
+++ b/scripts/ask-openai.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PROMPT="$1"
+
+curl -s http://localhost:3030/ask-openai \
+  -H "x-bridge-token: $BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"prompt\":\"$PROMPT\"}" \
+  | jq -r ".answer"

--- a/tools/agent-bridge/.env.example
+++ b/tools/agent-bridge/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your_openai_key
+BRIDGE_TOKEN=change_this_secret
+BRIDGE_PORT=3030

--- a/tools/agent-bridge/package.json
+++ b/tools/agent-bridge/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-bridge",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2"
+  }
+}

--- a/tools/agent-bridge/server.js
+++ b/tools/agent-bridge/server.js
@@ -1,0 +1,64 @@
+import express from "express"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+const app = express()
+app.use(express.json({ limit: "2mb" }))
+
+const PORT = process.env.BRIDGE_PORT || 3030
+const TOKEN = process.env.BRIDGE_TOKEN
+const OPENAI = process.env.OPENAI_API_KEY
+
+function auth(req, res, next) {
+  if (req.headers["x-bridge-token"] !== TOKEN) {
+    return res.status(401).json({ error: "unauthorized" })
+  }
+  next()
+}
+
+app.get("/health", (_, res) => {
+  res.json({ ok: true, service: "agent-bridge" })
+})
+
+app.post("/ask-openai", auth, async (req, res) => {
+
+  const { prompt } = req.body
+
+  const r = await fetch(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${OPENAI}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: "gpt-5",
+        temperature: 0.2,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a senior engineer assisting another AI agent. Be concise and actionable."
+          },
+          {
+            role: "user",
+            content: prompt
+          }
+        ]
+      })
+    }
+  )
+
+  const data = await r.json()
+
+  res.json({
+    ok: true,
+    answer: data.choices?.[0]?.message?.content || ""
+  })
+})
+
+app.listen(PORT, () => {
+  console.log("Agent bridge running on port", PORT)
+})


### PR DESCRIPTION
## Summary
- Adds `tools/agent-bridge/` — Express server (localhost:3030) that proxies reasoning requests to OpenAI with `x-bridge-token` auth
- Adds `scripts/ask-openai.ps1` and `scripts/ask-openai.sh` — helper scripts for Claude-to-bridge calls
- No existing project logic modified

## Files Created
- `tools/agent-bridge/package.json`
- `tools/agent-bridge/server.js`
- `tools/agent-bridge/.env.example`
- `scripts/ask-openai.ps1`
- `scripts/ask-openai.sh`

## Test plan
- [ ] `cd tools/agent-bridge && npm install && npm start` → "Agent bridge running on port 3030"
- [ ] `curl http://localhost:3030/health` → `{"ok":true,"service":"agent-bridge"}`
- [ ] Verify auth rejection without token: `curl -X POST http://localhost:3030/ask-openai` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)