### PR TITLE
docs: add agent-bridge README and CLAUDE.md usage section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,16 @@ All notification scripts use `scripts/send-telegram.ps1` with `TELEGRAM_BOT_TOKE
 
 ---
 
+## Agent Bridge (OpenAI Reasoning Proxy)
+
+When deeper reasoning or a second opinion is needed during a task, call:
+
+    powershell -ExecutionPolicy Bypass -File scripts/ask-openai.ps1 -Prompt "<question>"
+
+This sends the prompt to the agent bridge (`tools/agent-bridge/`) which proxies it to OpenAI and returns the answer. Requires `BRIDGE_TOKEN` in the environment and the bridge running on `localhost:3030`. Use the returned answer as advisory reasoning — do not treat it as authoritative.
+
+---
+
 ## Work Cycle
 
 At session start:

--- a/tools/agent-bridge/README.md
+++ b/tools/agent-bridge/README.md
@@ -1,0 +1,57 @@
+# Agent Bridge
+
+Express server that proxies reasoning requests to OpenAI, authenticated with a shared token.
+
+## Setup
+
+```bash
+cd tools/agent-bridge
+npm install
+```
+
+## Required Environment Variables
+
+Create a `.env` file in `tools/agent-bridge/` (see `.env.example`):
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | Your OpenAI API key |
+| `BRIDGE_TOKEN` | Shared secret for `x-bridge-token` auth header |
+| `BRIDGE_PORT` | Port to listen on (default: `3030`) |
+
+## Start the Bridge
+
+```bash
+cd tools/agent-bridge
+npm start
+```
+
+Expected output:
+
+```
+Agent bridge running on port 3030
+```
+
+## Test Health
+
+```bash
+curl http://localhost:3030/health
+```
+
+Expected response:
+
+```json
+{"ok":true,"service":"agent-bridge"}
+```
+
+## Example: Ask OpenAI
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/ask-openai.ps1 -Prompt "Explain this Fastify webhook bug"
+```
+
+Or with bash:
+
+```bash
+BRIDGE_TOKEN=your_secret ./scripts/ask-openai.sh "Explain this Fastify webhook bug"
+```


### PR DESCRIPTION
## Summary
- Adds `tools/agent-bridge/README.md` with setup steps, env vars, start/health/example instructions
- Adds "Agent Bridge" section to `CLAUDE.md` explaining when to use `scripts/ask-openai.ps1`
- No product logic changed

## Files Changed
- `CLAUDE.md` — new section between "Merge Flow" and "Work Cycle"
- `tools/agent-bridge/README.md` — new file

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify README.md covers setup, env vars, start, health check, and example call

🤖 Generated with [Claude Code](https://claude.com/claude-code)