### PR TITLE
docs: add OpenAI bridge usage rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,33 @@ powershell -ExecutionPolicy Bypass -File scripts/notify-task-done.ps1 "<task>"
 
 ---
 
+## OpenAI Bridge (Second Opinion)
+
+Claude may call the agent-bridge for a second opinion during implementation.
+
+```
+powershell -ExecutionPolicy Bypass -File scripts/ask-openai.ps1 -Prompt "<question>"
+```
+
+Requires `BRIDGE_TOKEN` in the environment. The bridge runs on `localhost:3030`.
+
+**When to use:**
+
+1. **Bug analysis** — root cause is unclear after reading code and logs
+2. **Architecture tradeoffs** — weighing two viable approaches with non-obvious consequences
+3. **Prompt generation** — drafting or refining LLM prompts for the SMS AI conversation flow
+4. **Blocked reasoning** — stuck for >5 minutes with no clear next step
+
+**Rules:**
+
+- Do not use for tasks Claude can resolve directly (lookups, simple fixes, test failures with clear output)
+- Do not use more than 3 times per task
+- Never send secrets, credentials, or customer data in the prompt
+- Treat the response as advisory — Claude owns the final decision and must verify independently
+- Log that the bridge was consulted in the commit message if it influenced the approach
+
+---
+
 ## Output Format
 
 Return:


### PR DESCRIPTION
## Summary
- Adds an **OpenAI Bridge (Second Opinion)** section to CLAUDE.md
- Defines 4 use cases: bug analysis, architecture tradeoffs, prompt generation, blocked reasoning
- Includes guardrails to prevent overuse (max 3/task, no secrets, advisory-only, log in commits)

## Files changed
- `CLAUDE.md` — 27 lines added between Work Cycle and Output Format sections

## Test plan
- [ ] Read CLAUDE.md and verify the new section is well-placed and concise
- [ ] Confirm no existing sections were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)