### PR TITLE
docs: add shared-memory system for session continuity

### DIFF
--- a/project-brain/README.md
+++ b/project-brain/README.md
@@ -1,0 +1,40 @@
+# Project Brain — Shared Memory for Claude Execution
+
+This directory is **working memory for Claude sessions**, not documentation for humans or customers.
+
+## Purpose
+
+Enable execution continuity across Claude sessions. Every session starts faster and makes better decisions because the previous session left structured context behind.
+
+## Session Start Protocol
+
+At the beginning of every session, read these files in order:
+
+1. `current_focus.md` — What to work on right now
+2. `blockers.md` — What is currently blocked and why
+3. `session_handoff.md` — What the last session did and what it recommends next
+4. `task_queue.md` — Prioritized execution queue
+5. `decisions.md` — Stable decisions that should not be re-debated
+6. `openai_advice.md` — Durable reasoning from bridge consultations
+
+Then read the canonical status files:
+- `project_status.json` (source of truth)
+- `project_status.md` (human-readable mirror)
+
+## Session End Protocol
+
+Before ending a session, update:
+
+1. `session_handoff.md` — Summarize what was done, what is next, what to avoid
+2. `current_focus.md` — If the focus changed, update it
+3. `blockers.md` — If blockers were resolved or discovered, update the list
+4. `task_queue.md` — If tasks were completed or priorities shifted, update the queue
+5. `openai_advice.md` — If the bridge was consulted, record durable insights
+
+## Rules
+
+- Only write verified facts. Never invent progress.
+- Keep files concise. This is operational memory, not prose.
+- `project_status.json` remains the canonical source of truth for stage progress and blockers.
+- These files supplement, not replace, the status system.
+- Delete stale content rather than letting it accumulate.

--- a/project-brain/blockers.md
+++ b/project-brain/blockers.md
@@ -1,0 +1,30 @@
+# Blockers
+
+Only real blockers that currently prevent progress. Remove entries when resolved.
+
+## Active Blockers
+
+### 1. n8n credentials not configured
+- **What:** postgres-creds, openai-creds, twilio-creds missing in n8n UI
+- **Owner:** Human
+- **Affects:** Stage 2 (TEST Sandbox Workflow Chain), Stage 3 (Core Messaging & AI Flow)
+- **Required action:** Manual setup in n8n UI with real API keys
+- **Impact:** Cannot run end-to-end SMS test flows. All workflow JSONs are committed but cannot execute.
+
+### 2. Google Calendar OAuth verification
+- **What:** OAuth credentials exist in .env but the end-to-end flow has never been verified
+- **Owner:** Human
+- **Affects:** Stage 4 (Calendar & Booking Reliability)
+- **Required action:** Complete OAuth flow test with existing credentials
+- **Impact:** Calendar sync code is built and tested (24 tests) but unverified against real Google API.
+
+### 3. First pilot tenant
+- **What:** No real auto repair shop onboarded yet
+- **Owner:** Human
+- **Affects:** Stage 7 (First Live Pilot)
+- **Required action:** Working demo + real phone number + willing shop
+- **Impact:** Cannot start Stage 7 until demo is proven.
+
+## Resolved Blockers
+
+_Move resolved blockers here with date and resolution._

--- a/project-brain/current_focus.md
+++ b/project-brain/current_focus.md
@@ -1,0 +1,23 @@
+# Current Focus
+
+## Top Priority
+
+**LT Proteros sandbox SMS test flows** — building and validating TEST workflows for the missed call → SMS → AI → booking pipeline.
+
+## Phase
+
+TEST environment stabilization and SMS flow validation.
+
+## Why This Is the Priority
+
+The core revenue flow (missed call → SMS → AI → booking → calendar) has all API endpoints built and tested (214/214 tests passing), but has never been verified end-to-end with real services. The TEST sandbox workflows are the bridge between unit-tested code and a working demo.
+
+## What "Done" Looks Like
+
+All TEST workflow JSONs committed, importable into n8n, executing successfully in sandbox with test credentials. A missed call can trigger SMS, receive a reply, detect booking intent, create an appointment, and sync to Google Calendar.
+
+## Constraints
+
+- n8n credentials (postgres, openai, twilio) must be manually configured — Human action required
+- Google Calendar OAuth needs end-to-end verification — Human action required
+- Until credentials are provided, Claude can only build/test code that doesn't require live service calls

--- a/project-brain/decisions.md
+++ b/project-brain/decisions.md
@@ -1,5 +1,7 @@
 # Architectural Decisions
 
+> Part of the shared-memory system. These are stable decisions that should not be re-debated each session. See README.md for the full protocol.
+
 ## ADR-001: GitHub as Source of Truth
 
 All n8n workflows are stored in the GitHub repository under `n8n/workflows/`. The n8n UI is not the development environment. Changes are made in code, committed to branches, reviewed via pull requests, and deployed automatically on merge to `main`.

--- a/project-brain/openai_advice.md
+++ b/project-brain/openai_advice.md
@@ -1,0 +1,22 @@
+# OpenAI Bridge Advice Log
+
+Store only durable reasoning outputs from the OpenAI bridge (scripts/ask-openai.ps1) that should inform future sessions.
+
+## Usage Rules
+
+- Only record advice that changes how we build, not ephemeral debugging help
+- Include the question asked and the key insight
+- Delete entries that are no longer relevant
+- Do not store more than 10 entries — prune oldest when full
+- Never include secrets, credentials, or customer data in entries
+
+## Entries
+
+_No bridge consultations recorded yet. Add entries in this format:_
+
+```
+### YYYY-MM-DD — Topic
+**Question:** What was asked
+**Key insight:** The durable takeaway
+**Applied:** How it influenced the implementation (or "not yet applied")
+```

--- a/project-brain/session_handoff.md
+++ b/project-brain/session_handoff.md
@@ -1,0 +1,30 @@
+# Session Handoff
+
+Last updated: 2026-03-14
+
+## What Was Recently Completed
+
+- **Missed call SMS endpoint** — POST /internal/missed-call-sms handles tenant validation, conversation creation, initial outbound SMS via Twilio, message logging. Worker routes missed-call jobs to API. 26 tests, suite 214/214.
+- **WF-002 unified with API** — n8n booking worker now calls POST /internal/booking-intent and POST /internal/appointments instead of inline code. Customer names now flow through to calendar events.
+- **Appointment creation endpoint** — POST /internal/appointments with service layer, tenant validation, conversation-based upsert. 24 tests.
+- **Idempotency guards** — Calendar-event DB dedup + checkout Redis lock. 10 tests.
+- **OpenAI agent-bridge** — Infrastructure for second-opinion reasoning via localhost:3030.
+
+## What Is Next
+
+1. Continue TEST sandbox workflow development (blocked on n8n credentials for live testing)
+2. Any API-side improvements that don't require live services
+3. When credentials are provided: end-to-end demo run with real Twilio numbers
+4. When OAuth is verified: Google Calendar sync end-to-end test
+
+## What to Avoid
+
+- Do not re-debate architecture decisions (see decisions.md) — ADR-001 through ADR-009 are stable
+- Do not attempt live service calls without credentials — they will fail and waste time
+- Do not advance stage percentages without verified evidence
+- Do not refactor working endpoints — the API layer (214 tests) is stable
+- Do not modify production workflows in US_AutoShop/ or LT_Proteros/ without explicit approval
+
+## Context for Next Session
+
+The API layer is feature-complete for the MVP flow. All core endpoints exist with test coverage. The gap is now between "tested in isolation" and "working end-to-end with real services." The primary bottleneck is Human-owned credential setup.

--- a/project-brain/task_queue.md
+++ b/project-brain/task_queue.md
@@ -1,0 +1,35 @@
+# Task Queue
+
+Prioritized execution queue. Work top-down. Update after every session.
+
+## Priority Order
+
+Tasks are ordered by proximity to the core revenue flow:
+missed call → SMS → AI → booking → calendar
+
+## Queue
+
+### Ready (can be done now)
+
+1. **Continue TEST workflow refinement** — Improve workflow JSONs for sandbox testing while waiting for credentials
+2. **API error handling audit** — Verify all /internal/ endpoints surface clear errors for n8n consumption
+3. **Process-sms endpoint hardening** — POST /internal/process-sms is the newest endpoint; verify edge cases
+
+### Blocked (waiting on Human)
+
+4. **End-to-end demo with real Twilio** — Requires n8n credentials (postgres, openai, twilio)
+5. **Google Calendar OAuth e2e verification** — Requires Human to complete OAuth flow
+6. **First pilot tenant onboarding** — Requires working demo + real phone number
+
+### Backlog (lower priority)
+
+7. **Production readiness hardening** — Stage 6 at 32%, but blocked by upstream stages
+8. **Admin dashboard enhancements** — Stage 5 at 65%, functional but not urgent
+
+## Completed Recently
+
+- Missed call SMS endpoint (26 tests)
+- WF-002 API unification
+- Appointment creation endpoint (24 tests)
+- Idempotency guards (10 tests)
+- OpenAI agent-bridge infrastructure


### PR DESCRIPTION
## Summary
- Adds structured working memory files to `project-brain/` for Claude execution continuity across sessions
- New files: README.md (protocol), current_focus.md, blockers.md, session_handoff.md, openai_advice.md, task_queue.md
- Updated existing decisions.md with shared-memory system link
- All content grounded in verified repo facts — no invented business data

## What this enables
Future Claude sessions can read `current_focus.md` + `session_handoff.md` + `blockers.md` to instantly understand what to work on, what was recently done, and what is blocked — without re-reading the full AI_STATUS.md history.

## Test plan
- [x] Docs-only change — no code modified
- [x] All files use only verified facts from project_status.json and AI_STATUS.md
- [x] No stage percentages changed, no project reality altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)