### PR TITLE
docs: cleanup shared-memory focus to pipeline level

### DIFF
--- a/project-brain/README.md
+++ b/project-brain/README.md
@@ -2,6 +2,8 @@
 
 This directory is **working memory for Claude sessions**, not documentation for humans or customers.
 
+`project-brain/` is the canonical shared-memory directory for this repository. All session-persistent context, status tracking, and architectural decisions live here.
+
 ## Purpose
 
 Enable execution continuity across Claude sessions. Every session starts faster and makes better decisions because the previous session left structured context behind.

--- a/project-brain/current_focus.md
+++ b/project-brain/current_focus.md
@@ -2,19 +2,19 @@
 
 ## Top Priority
 
-**LT Proteros sandbox SMS test flows** — building and validating TEST workflows for the missed call → SMS → AI → booking pipeline.
+**Verify the core missed call → SMS → AI → booking → calendar pipeline end-to-end.** All API endpoints are built and unit-tested (214/214 passing). The gap is between isolated tests and a working demo with real services.
 
 ## Phase
 
-TEST environment stabilization and SMS flow validation.
+End-to-end pipeline verification. TEST sandbox workflows are the current mechanism, but any path that proves the pipeline works is valid.
 
 ## Why This Is the Priority
 
-The core revenue flow (missed call → SMS → AI → booking → calendar) has all API endpoints built and tested (214/214 tests passing), but has never been verified end-to-end with real services. The TEST sandbox workflows are the bridge between unit-tested code and a working demo.
+This is the entire revenue flow. Nothing else matters until a missed call can trigger an SMS, the customer can reply, AI detects booking intent, an appointment is created, and it syncs to Google Calendar. Every other feature (billing, admin, dashboards) depends on this working.
 
 ## What "Done" Looks Like
 
-All TEST workflow JSONs committed, importable into n8n, executing successfully in sandbox with test credentials. A missed call can trigger SMS, receive a reply, detect booking intent, create an appointment, and sync to Google Calendar.
+A missed call triggers SMS, customer replies, AI conversation runs, booking intent is detected, appointment is created, and Google Calendar event appears. Verified with real service calls, not just unit tests.
 
 ## Constraints
 

--- a/project-brain/task_queue.md
+++ b/project-brain/task_queue.md
@@ -11,7 +11,7 @@ missed call → SMS → AI → booking → calendar
 
 ### Ready (can be done now)
 
-1. **Continue TEST workflow refinement** — Improve workflow JSONs for sandbox testing while waiting for credentials
+1. **Strengthen pipeline reliability** — Harden the API endpoints that form the core flow (missed-call-sms, process-sms, booking-intent, appointments, calendar-event) for real-world conditions
 2. **API error handling audit** — Verify all /internal/ endpoints surface clear errors for n8n consumption
 3. **Process-sms endpoint hardening** — POST /internal/process-sms is the newest endpoint; verify edge cases
 


### PR DESCRIPTION
## Summary
- Document `project-brain/` as the canonical shared-memory directory in README.md
- Reframe `current_focus.md` from sub-task level ("LT Proteros sandbox SMS test flows") to product level ("verify core pipeline end-to-end")
- Align task_queue.md top item with pipeline-level focus

## Test plan
- [x] Docs-only change — no code modified
- [x] No stage percentages or project reality changed
- [x] blockers.md already aligned — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)