### PR TITLE
fix: prevent duplicate message in OpenAI context + process-sms edge cases

### DIFF
--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -93,7 +93,32 @@ export async function processSms(
     return result;
   }
 
-  // ── 2. Log inbound message ───────────────────────────────────────────────
+  // ── 2. Fetch conversation history ────────────────────────────────────────
+  // IMPORTANT: Fetch history BEFORE logging the inbound message to avoid
+  // duplicating the current message in the OpenAI context. The current message
+  // is appended separately when building the messages array.
+  let history: Array<{ role: string; content: string }> = [];
+  try {
+    const rows = await query<{ direction: string; body: string }>(
+      `SELECT direction, body FROM messages
+       WHERE conversation_id = $1 AND tenant_id = $2
+       ORDER BY sent_at DESC LIMIT $3`,
+      [result.conversationId, input.tenantId, HISTORY_LIMIT]
+    );
+
+    // Reverse so oldest first, map to OpenAI format
+    history = rows
+      .reverse()
+      .filter((r) => r.body && r.body.trim())
+      .map((r) => ({
+        role: r.direction === "inbound" ? "user" : "assistant",
+        content: r.body,
+      }));
+  } catch {
+    // Continue with no history — AI will still respond
+  }
+
+  // ── 3. Log inbound message ───────────────────────────────────────────────
   try {
     await query(
       `INSERT INTO messages (tenant_id, conversation_id, direction, body, twilio_sid)
@@ -114,7 +139,7 @@ export async function processSms(
     // Non-fatal
   }
 
-  // ── 3. Soft limit check ──────────────────────────────────────────────────
+  // ── 4. Soft limit check ──────────────────────────────────────────────────
   if (input.atSoftLimit) {
     result.aiResponse = SOFT_LIMIT_RESPONSE;
     const smsResult = await sendTwilioSms(
@@ -139,7 +164,7 @@ export async function processSms(
     return result;
   }
 
-  // ── 4. Fetch system prompt ───────────────────────────────────────────────
+  // ── 5. Fetch system prompt ───────────────────────────────────────────────
   let systemPrompt = DEFAULT_SYSTEM_PROMPT;
   try {
     const rows = await query<{ prompt_text: string }>(
@@ -155,29 +180,7 @@ export async function processSms(
     // Use default prompt if lookup fails
   }
 
-  // ── 5. Fetch conversation history ────────────────────────────────────────
-  let history: Array<{ role: string; content: string }> = [];
-  try {
-    const rows = await query<{ direction: string; body: string }>(
-      `SELECT direction, body FROM messages
-       WHERE conversation_id = $1 AND tenant_id = $2
-       ORDER BY sent_at DESC LIMIT $3`,
-      [result.conversationId, input.tenantId, HISTORY_LIMIT]
-    );
-
-    // Reverse so oldest first, map to OpenAI format
-    history = rows
-      .reverse()
-      .filter((r) => r.body && r.body.trim())
-      .map((r) => ({
-        role: r.direction === "inbound" ? "user" : "assistant",
-        content: r.body,
-      }));
-  } catch {
-    // Continue with no history — AI will still respond
-  }
-
-  // ── 6. Call OpenAI ───────────────────────────────────────────────────────
+  // ── 6. Call OpenAI ──────────────────────────────────────────────────────
   const openaiKey = process.env.OPENAI_API_KEY;
   if (!openaiKey) {
     result.error = "OPENAI_API_KEY not configured";

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -477,6 +477,206 @@ describe("processSms — error handling", () => {
   });
 });
 
+describe("processSms — history ordering (no duplicate messages)", () => {
+  it("does not duplicate current message in OpenAI context", async () => {
+    // History should NOT include the current inbound message because
+    // history is fetched BEFORE the inbound is logged to the DB.
+    let historyCallArgs: unknown[] | undefined;
+    mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("get_or_create_conversation")) {
+        return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+      }
+      // History fetch — capture what gets returned
+      if (sql.includes("SELECT direction, body FROM messages")) {
+        historyCallArgs = params;
+        return [
+          { direction: "outbound", body: "Hi! How can we help?" },
+        ];
+      }
+      if (sql.includes("system_prompts")) return [];
+      return [];
+    });
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput({ body: "I need an oil change" }), fetchMock);
+
+    // Verify OpenAI was called
+    const openaiCall = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("openai.com")
+    );
+    expect(openaiCall).toBeDefined();
+    const body = JSON.parse((openaiCall![1] as { body: string }).body);
+
+    // Should be: system + 1 history message + 1 current message = 3
+    // NOT: system + 1 history + 1 duplicate current + 1 current = 4
+    expect(body.messages.length).toBe(3);
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[1].role).toBe("assistant"); // history
+    expect(body.messages[2].role).toBe("user"); // current
+    expect(body.messages[2].content).toBe("I need an oil change");
+  });
+
+  it("history fetch occurs before inbound message insert", async () => {
+    const callOrder: string[] = [];
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("get_or_create_conversation")) {
+        callOrder.push("get_or_create");
+        return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+      }
+      if (sql.includes("SELECT direction, body FROM messages")) {
+        callOrder.push("fetch_history");
+        return [];
+      }
+      if (sql.includes("INSERT INTO messages") && sql.includes("inbound")) {
+        callOrder.push("insert_inbound");
+        return [];
+      }
+      if (sql.includes("system_prompts")) return [];
+      return [];
+    });
+    const fetchMock = mockFetchAll();
+
+    await processSms(validInput(), fetchMock);
+
+    const histIdx = callOrder.indexOf("fetch_history");
+    const insertIdx = callOrder.indexOf("insert_inbound");
+    expect(histIdx).toBeGreaterThan(-1);
+    expect(insertIdx).toBeGreaterThan(-1);
+    expect(histIdx).toBeLessThan(insertIdx);
+  });
+});
+
+describe("processSms — additional edge cases", () => {
+  it("handles OpenAI returning malformed JSON (no choices)", async () => {
+    setupDbMocks();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("openai.com")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ id: "chatcmpl-xyz" }), // no choices
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({ sid: TWILIO_SID }) };
+    }) as unknown as typeof fetch;
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("empty response");
+  });
+
+  it("handles OpenAI returning empty choices array", async () => {
+    setupDbMocks();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("openai.com")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ choices: [] }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({ sid: TWILIO_SID }) };
+    }) as unknown as typeof fetch;
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("empty response");
+  });
+
+  it("handles appointment creation failure gracefully", async () => {
+    // Simulate DB error during appointment insert
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("get_or_create_conversation")) {
+        return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+      }
+      if (sql.includes("system_prompts")) return [];
+      if (sql.includes("SELECT direction, body FROM messages")) return [];
+      if (sql.includes("SELECT id FROM tenants")) {
+        return [{ id: TENANT_ID }];
+      }
+      if (sql.includes("INSERT INTO appointments")) {
+        throw new Error("unique_violation: duplicate appointment");
+      }
+      return [];
+    });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Friday at 11 AM!",
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    // Should still succeed overall — booking was detected but appointment failed
+    expect(result.success).toBe(true);
+    expect(result.isBooked).toBe(true);
+    expect(result.appointmentId).toBeNull();
+  });
+
+  it("soft limit with Twilio failure still succeeds", async () => {
+    setupDbMocks();
+    const fetchMock = mockFetchAll({ twilioOk: false });
+
+    const result = await processSms(
+      validInput({ atSoftLimit: true }),
+      fetchMock
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.aiResponse).toContain("monthly messaging limit");
+    expect(result.smsSent).toBe(false);
+  });
+
+  it("handles OpenAI fetch throwing non-Error object", async () => {
+    setupDbMocks();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("openai.com")) {
+        throw "network failure"; // non-Error throw
+      }
+      return { ok: true, json: () => Promise.resolve({ sid: TWILIO_SID }) };
+    }) as unknown as typeof fetch;
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("OpenAI request failed");
+  });
+
+  it("booking detected but close_conversation fails is non-fatal", async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("get_or_create_conversation")) {
+        return [{ conversation_id: CONVERSATION_ID, is_new: false }];
+      }
+      if (sql.includes("system_prompts")) return [];
+      if (sql.includes("SELECT direction, body FROM messages")) return [];
+      if (sql.includes("SELECT id FROM tenants")) return [{ id: TENANT_ID }];
+      if (sql.includes("INSERT INTO appointments")) {
+        return [{
+          id: APPOINTMENT_ID, tenant_id: TENANT_ID, conversation_id: CONVERSATION_ID,
+          customer_phone: PHONE, customer_name: null, service_type: "oil change",
+          scheduled_at: new Date().toISOString(), duration_minutes: 60, notes: null,
+          google_event_id: null, calendar_synced: false, created_at: new Date().toISOString(), xmax: "0",
+        }];
+      }
+      if (sql.includes("SELECT google_event_id FROM appointments")) return [];
+      if (sql.includes("SELECT access_token")) return [];
+      if (sql.includes("close_conversation")) {
+        throw new Error("DB connection lost during close");
+      }
+      return [];
+    });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Monday at 2 PM!",
+    });
+
+    const result = await processSms(validInput(), fetchMock);
+
+    expect(result.success).toBe(true);
+    expect(result.isBooked).toBe(true);
+    expect(result.appointmentId).toBe(APPOINTMENT_ID);
+    // Conversation close failed, so conversationClosed should be false
+    expect(result.conversationClosed).toBe(false);
+  });
+});
+
 describe("processSms — message logging", () => {
   it("logs inbound message with twilio_sid", async () => {
     setupDbMocks();


### PR DESCRIPTION
## Summary

- **Bug fix**: History was fetched AFTER logging the inbound message to DB, causing the customer's current message to appear twice in the OpenAI messages array — once from conversation history and once appended explicitly. This wasted tokens and could confuse the AI model. Fixed by reordering operations: fetch history before inserting the inbound message.
- **8 new edge case tests** covering malformed OpenAI responses, appointment creation failures, soft limit + Twilio failure, non-Error throws, and close_conversation DB errors.
- Suite: 247/247 passed (13 test files, up from 214)

## Test plan

- [x] Verify no duplicate messages in OpenAI context (new test)
- [x] Verify history fetch ordering occurs before inbound insert (new test)
- [x] OpenAI malformed response (no choices / empty choices) handled gracefully
- [x] Appointment creation DB failure during booking flow is non-fatal
- [x] Soft limit with Twilio send failure still succeeds
- [x] Non-Error throws from OpenAI fetch handled
- [x] close_conversation failure is non-fatal
- [x] Full test suite: 247/247 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)