### PR TITLE
fix: make lint a real verification gate in ai-verify.sh

### DIFF
--- a/apps/api/.eslintrc.json
+++ b/apps/api/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
 import { query } from "../../db/client";
 import { requireAuth } from "../../middleware/require-auth";
 
@@ -14,7 +14,6 @@ function getEncryptionKey(): Buffer {
   const secret = process.env.ENCRYPTION_KEY ?? process.env.JWT_SECRET ?? "";
   if (!secret) throw new Error("ENCRYPTION_KEY or JWT_SECRET is required");
   // Derive a 32-byte key by hashing the secret
-  const { createHash } = require("crypto");
   return createHash("sha256").update(secret).digest();
 }
 

--- a/apps/api/src/routes/internal/calendar-tokens.ts
+++ b/apps/api/src/routes/internal/calendar-tokens.ts
@@ -14,7 +14,7 @@ async function refreshAccessToken(
   tenantId: string,
   encryptedRefreshToken: string,
   calendarId: string,
-  log: { info: Function; error: Function }
+  log: { info: (...args: unknown[]) => void; error: (...args: unknown[]) => void }
 ): Promise<{ access_token: string; token_expiry: string } | null> {
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -455,7 +455,7 @@ describe("processSms — error handling", () => {
   });
 
   it("continues with empty history when history query fails", async () => {
-    let callCount = 0;
+    const callCount = 0;
     mocks.query.mockImplementation(async (sql: string) => {
       if (sql.includes("get_or_create_conversation")) {
         return [{ conversation_id: CONVERSATION_ID, is_new: false }];

--- a/scripts/ai-verify.sh
+++ b/scripts/ai-verify.sh
@@ -17,13 +17,13 @@ echo "Install deps"
 npm ci
 
 echo "Lint"
-npm run lint --if-present || true
+npm run lint
 
 echo "Build"
 npm run build
 
 echo "Tests"
-npm test --if-present || true
+npm test
 
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
## Summary
- **Root cause**: `ai-verify.sh` used `|| true` on both lint and test steps, silently swallowing all failures. Additionally, `apps/api` had no ESLint config file, so lint always errored and was always hidden.
- **Fix**: Added `.eslintrc.json` with TypeScript-ESLint recommended config, removed `|| true` from lint and test steps so failures halt the script (as `set -e` intends), fixed 4 pre-existing lint errors.
- No product logic changes — only lint config, type annotations, and the verify script.

## Test plan
- [x] `npm run lint` exits 0 (0 errors, 56 warnings)
- [x] `npm run build` exits 0
- [x] `npm test` — 247/247 passed across 13 test files
- [x] Verified `ai-verify.sh` no longer contains `|| true` on lint/test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)