### PR TITLE
fix: expose build commit in health endpoint for deploy verification

### DIFF
--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -29,6 +29,7 @@ export async function healthRoute(app: FastifyInstance) {
       checks,
       version: process.env.npm_package_version ?? "0.1.0",
       env: process.env.NODE_ENV,
+      commit: process.env.RENDER_GIT_COMMIT ?? "unknown",
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `commit` field to `GET /health` response using Render's built-in `RENDER_GIT_COMMIT` env var
- Enables verifying which exact commit is running in production without needing authenticated admin access
- Also serves as a deploy trigger: once merged, Render redeploy will include both PR #81 fixes and this verification capability

## Context
PR #81 fixed stale Project Ops data (Dockerfile copies, Cache-Control headers), but production verification revealed:
1. Render deploys from `deploy/signup-flow-to-production` branch, NOT `main` (154 commits behind)
2. Deploy branch was fast-forwarded to main but no new Render deploy was triggered
3. Health endpoint has no commit hash — impossible to verify which build is running

## Root cause identified
Render service is configured to deploy from `deploy/signup-flow-to-production` branch instead of `main`. The deploy branch was 154 commits behind main. It has been fast-forwarded, but auto-deploy may be disabled.

**Action required:** Verify in Render Dashboard that auto-deploy is enabled, OR manually trigger a deploy. After deploy, `GET /health` will show the commit hash for verification.

## Test plan
- [x] 247/247 tests pass
- [x] Docker smoke test passes — `commit` field visible in health response
- [x] Lint: 0 errors
- [ ] After merge + Render deploy: verify `GET /health` shows correct commit hash
- [ ] After deploy: verify `/internal/admin/project-status-v2` returns fresh data with `Cache-Control: no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)