### PR TITLE
feat: add admin-bootstrap endpoint to fix admin auth 401

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,56 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: fix-admin-auth — 2026-03-15
+
+**Branch:** ai/fix-admin-auth
+**Status:** COMPLETE — Admin bootstrap endpoint added to enable admin login
+
+### Root Cause
+The admin tenant (mantas@autoshopsmsai.com) has no `password_hash` set in the production database. The `POST /auth/login` endpoint (login.ts:49-55) explicitly rejects accounts with null `password_hash`, returning 401. Without a successful login, no JWT is issued, so all admin endpoints (including `/internal/admin/project-status-v2`) return 401.
+
+### What Was Done
+1. Traced full auth flow: login.html → POST /auth/login → JWT stored in localStorage → apiFetch sends Bearer token → adminGuard verifies JWT + ADMIN_EMAILS
+2. Confirmed root cause: login endpoint rejects null password_hash → no token → all admin endpoints 401
+3. Added `POST /auth/admin-bootstrap` endpoint protected by `INTERNAL_API_KEY` (x-internal-key header)
+4. Endpoint validates email is in ADMIN_EMAILS, then either:
+   - Sets password_hash on existing tenant (if password_hash is null)
+   - Creates new admin tenant (if tenant doesn't exist)
+   - Returns 409 if password already set (prevents re-use)
+5. Registered route in index.ts
+6. Added 11 tests covering all security guards and happy paths
+
+### Files Changed
+- `apps/api/src/routes/auth/admin-bootstrap.ts` (new — bootstrap endpoint)
+- `apps/api/src/index.ts` (route registration)
+- `apps/api/src/tests/admin-bootstrap.test.ts` (new — 11 tests)
+
+### Production Deployment Steps Required
+After merging and deploying:
+1. Get INTERNAL_API_KEY value from Render Dashboard → Environment
+2. Run bootstrap:
+   ```
+   curl -X POST https://autoshopsmsai.com/auth/admin-bootstrap \
+     -H "Content-Type: application/json" \
+     -H "x-internal-key: <INTERNAL_API_KEY>" \
+     -d '{"email":"mantas@autoshopsmsai.com","password":"<chosen-password>"}'
+   ```
+3. Log in at https://autoshopsmsai.com/login.html
+4. Verify Project Ops loads at admin.html → Project Ops tab
+5. Verify `GET /internal/admin/project-status-v2` returns 200 with Bearer token
+
+### Verification
+```
+VERIFICATION
+EXIT_CODE=0
+TEST_FILES=14
+TESTS_TOTAL=258
+TESTS_FAILED=0
+DURATION=5.94s
+```
+
+---
+
 ## TASK: admin-stale-data-verify — 2026-03-15
 
 **Branch:** ai/admin-stale-data-verify

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,7 @@ import { projectStatusRoute } from "./routes/internal/project-status";
 import { googleAuthRoute } from "./routes/auth/google";
 import { loginRoute } from "./routes/auth/login";
 import { signupRoute } from "./routes/auth/signup";
+import { adminBootstrapRoute } from "./routes/auth/admin-bootstrap";
 import { billingCheckoutRoute } from "./routes/billing/checkout";
 import { billingPortalRoute } from "./routes/billing/portal";
 import { tenantDashboardRoute } from "./routes/tenant/dashboard";
@@ -84,6 +85,7 @@ async function bootstrap() {
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });
+  await app.register(adminBootstrapRoute, { prefix: "/auth" });
   await app.register(billingCheckoutRoute, { prefix: "/billing" });
   await app.register(billingPortalRoute, { prefix: "/billing" });
   await app.register(tenantDashboardRoute, { prefix: "/tenant" });

--- a/apps/api/src/routes/auth/admin-bootstrap.ts
+++ b/apps/api/src/routes/auth/admin-bootstrap.ts
@@ -1,0 +1,139 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as bcrypt from "bcryptjs";
+import { query } from "../../db/client";
+
+const BootstrapBody = z.object({
+  email: z.string().email(),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+/**
+ * POST /auth/admin-bootstrap
+ *
+ * One-time endpoint to set a password on an admin tenant that has no
+ * password_hash (e.g. manually-created pilot accounts).
+ *
+ * Protected by INTERNAL_API_KEY header — only callable by the server operator.
+ *
+ * If the tenant exists with that email but has no password_hash, sets it.
+ * If the tenant doesn't exist, creates a minimal admin tenant.
+ *
+ * Returns 200 on success, 409 if the tenant already has a password set.
+ */
+export async function adminBootstrapRoute(app: FastifyInstance) {
+  app.post("/admin-bootstrap", async (request, reply) => {
+    // ── Verify INTERNAL_API_KEY ──────────────────────────────────────────────
+    const internalKey = process.env.INTERNAL_API_KEY;
+    if (!internalKey) {
+      return reply.status(503).send({
+        error: "INTERNAL_API_KEY not configured on the server",
+      });
+    }
+
+    const provided =
+      (request.headers["x-internal-key"] as string) ??
+      (request.headers["authorization"] as string)?.replace(/^Bearer\s+/i, "");
+
+    if (!provided || provided !== internalKey) {
+      return reply.status(401).send({ error: "Invalid or missing internal API key" });
+    }
+
+    // ── Validate body ────────────────────────────────────────────────────────
+    const parsed = BootstrapBody.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "email and password (min 8 chars) are required",
+      });
+    }
+
+    const { email, password } = parsed.data;
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // ── Verify email is in ADMIN_EMAILS allowlist ────────────────────────────
+    const adminEmails = new Set(
+      (process.env.ADMIN_EMAILS ?? "")
+        .split(",")
+        .map((e) => e.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    if (adminEmails.size === 0) {
+      return reply.status(503).send({
+        error: "ADMIN_EMAILS env var not configured",
+      });
+    }
+    if (!adminEmails.has(normalizedEmail)) {
+      return reply.status(403).send({
+        error: "Email is not in the ADMIN_EMAILS allowlist",
+      });
+    }
+
+    // ── Hash password ────────────────────────────────────────────────────────
+    const passwordHash = await bcrypt.hash(password, 12);
+
+    // ── Check if tenant exists ───────────────────────────────────────────────
+    const existing = await query<{
+      id: string;
+      shop_name: string;
+      password_hash: string | null;
+    }>(
+      "SELECT id, shop_name, password_hash FROM tenants WHERE owner_email = $1 LIMIT 1",
+      [normalizedEmail],
+    );
+
+    if (existing.length > 0) {
+      const tenant = existing[0];
+
+      if (tenant.password_hash) {
+        return reply.status(409).send({
+          error: "This tenant already has a password set. Use the login flow.",
+          tenantId: tenant.id,
+        });
+      }
+
+      // Set password on existing tenant
+      await query(
+        "UPDATE tenants SET password_hash = $1 WHERE id = $2",
+        [passwordHash, tenant.id],
+      );
+
+      request.log.info(
+        { tenantId: tenant.id, email: normalizedEmail },
+        "Admin bootstrap: password_hash set on existing tenant",
+      );
+
+      return reply.status(200).send({
+        ok: true,
+        action: "password_set",
+        tenantId: tenant.id,
+        shopName: tenant.shop_name,
+        message: "Password set. You can now log in at /login.html",
+      });
+    }
+
+    // ── Create minimal admin tenant ──────────────────────────────────────────
+    const rows = await query<{ id: string }>(
+      `INSERT INTO tenants
+         (shop_name, owner_email, password_hash, billing_status,
+          trial_started_at, trial_ends_at, trial_conv_limit,
+          conv_limit_this_cycle, conv_used_this_cycle)
+       VALUES ('Admin', $1, $2, 'trial',
+               NOW(), NOW() + INTERVAL '365 days', 9999,
+               9999, 0)
+       RETURNING id`,
+      [normalizedEmail, passwordHash],
+    );
+
+    request.log.info(
+      { tenantId: rows[0].id, email: normalizedEmail },
+      "Admin bootstrap: new admin tenant created",
+    );
+
+    return reply.status(201).send({
+      ok: true,
+      action: "tenant_created",
+      tenantId: rows[0].id,
+      message: "Admin tenant created with password. You can now log in at /login.html",
+    });
+  });
+}

--- a/apps/api/src/tests/admin-bootstrap.test.ts
+++ b/apps/api/src/tests/admin-bootstrap.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn().mockResolvedValue([]),
+  compare: vi.fn().mockResolvedValue(true),
+  hash: vi.fn().mockResolvedValue("$2a$12$hashedpassword"),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+vi.mock("bcryptjs", () => ({
+  compare: mocks.compare,
+  hash: mocks.hash,
+}));
+
+import { adminBootstrapRoute } from "../routes/auth/admin-bootstrap";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const INTERNAL_KEY = "test-internal-key-12345";
+const ADMIN_EMAIL = "admin@autoshop.test";
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+  app.register(adminBootstrapRoute, { prefix: "/auth" });
+  return app;
+}
+
+function post(app: ReturnType<typeof Fastify>, body: object, headers: Record<string, string> = {}) {
+  return app.inject({
+    method: "POST",
+    url: "/auth/admin-bootstrap",
+    headers: { "content-type": "application/json", ...headers },
+    payload: body,
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /auth/admin-bootstrap", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.hash.mockResolvedValue("$2a$12$hashedpassword");
+    process.env.INTERNAL_API_KEY = INTERNAL_KEY;
+    process.env.ADMIN_EMAILS = ADMIN_EMAIL;
+  });
+
+  it("rejects request when INTERNAL_API_KEY is not configured", async () => {
+    delete process.env.INTERNAL_API_KEY;
+    const app = buildApp();
+    const res = await post(app, { email: ADMIN_EMAIL, password: "securepass1" });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("rejects request with missing internal key", async () => {
+    const app = buildApp();
+    const res = await post(app, { email: ADMIN_EMAIL, password: "securepass1" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects request with wrong internal key", async () => {
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { "x-internal-key": "wrong-key" },
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects invalid body (missing password)", async () => {
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects password shorter than 8 chars", async () => {
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "short" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects email not in ADMIN_EMAILS", async () => {
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: "notadmin@example.com", password: "securepass1" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects when ADMIN_EMAILS is not set", async () => {
+    delete process.env.ADMIN_EMAILS;
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("sets password_hash on existing tenant with no password", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Test Shop", password_hash: null },
+    ]);
+    mocks.query.mockResolvedValueOnce([]); // UPDATE result
+
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("password_set");
+    expect(body.tenantId).toBe(TENANT_ID);
+
+    // Verify UPDATE was called with the hash
+    expect(mocks.query).toHaveBeenCalledWith(
+      "UPDATE tenants SET password_hash = $1 WHERE id = $2",
+      ["$2a$12$hashedpassword", TENANT_ID],
+    );
+  });
+
+  it("returns 409 if tenant already has a password", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Test Shop", password_hash: "$2a$12$existing" },
+    ]);
+
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("creates new tenant when none exists", async () => {
+    mocks.query.mockResolvedValueOnce([]); // No existing tenant
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // INSERT result
+
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { "x-internal-key": INTERNAL_KEY },
+    );
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("tenant_created");
+    expect(body.tenantId).toBe(TENANT_ID);
+  });
+
+  it("accepts internal key via Authorization Bearer header", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Test Shop", password_hash: null },
+    ]);
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = buildApp();
+    const res = await post(
+      app,
+      { email: ADMIN_EMAIL, password: "securepass1" },
+      { authorization: `Bearer ${INTERNAL_KEY}` },
+    );
+
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause:** Admin tenant has no `password_hash` in production DB → `POST /auth/login` rejects with 401 → no JWT → all admin endpoints (including `/internal/admin/project-status-v2`) return 401
- **Fix:** Added `POST /auth/admin-bootstrap` endpoint protected by `INTERNAL_API_KEY` header that securely sets `password_hash` on admin tenants
- **Tests:** 11 new tests covering security guards, happy paths, and edge cases. Full suite: 258/258 passed

## Post-Deploy Steps
1. Get `INTERNAL_API_KEY` from Render Dashboard → Environment
2. Call bootstrap: `curl -X POST https://autoshopsmsai.com/auth/admin-bootstrap -H "Content-Type: application/json" -H "x-internal-key: <KEY>" -d '{"email":"mantas@autoshopsmsai.com","password":"<password>"}'`
3. Log in at `/login.html` → navigate to admin → verify Project Ops loads

## Test plan
- [x] TypeScript compiles without errors
- [x] 258/258 tests pass (14 test files)
- [x] Docker build succeeds
- [x] Health check passes in Docker
- [ ] Deploy to production
- [ ] Call bootstrap endpoint with INTERNAL_API_KEY
- [ ] Verify login works at /login.html
- [ ] Verify /internal/admin/project-status-v2 returns 200 with Bearer token
- [ ] Verify Project Ops tab renders data in admin.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)