### PR TITLE
feat: temporary hardcoded bootstrap key for admin setup

### DIFF
--- a/apps/api/src/routes/auth/admin-bootstrap.ts
+++ b/apps/api/src/routes/auth/admin-bootstrap.ts
@@ -23,14 +23,11 @@ const BootstrapBody = z.object({
  */
 export async function adminBootstrapRoute(app: FastifyInstance) {
   app.post("/admin-bootstrap", async (request, reply) => {
-    // ── Verify INTERNAL_API_KEY or ADMIN_BOOTSTRAP_KEY ──────────────────────
+    // ── Verify INTERNAL_API_KEY, ADMIN_BOOTSTRAP_KEY, or hardcoded one-time key
+    // TEMPORARY hardcoded key for initial admin setup — REMOVE after bootstrap.
+    const ONETIME_BOOTSTRAP_KEY = "setup-admin-2026-03-15-x8k4m2";
     const internalKey = process.env.INTERNAL_API_KEY;
     const bootstrapKey = process.env.ADMIN_BOOTSTRAP_KEY;
-    if (!internalKey && !bootstrapKey) {
-      return reply.status(503).send({
-        error: "Neither INTERNAL_API_KEY nor ADMIN_BOOTSTRAP_KEY configured on the server",
-      });
-    }
 
     const provided =
       (request.headers["x-internal-key"] as string) ??
@@ -38,7 +35,8 @@ export async function adminBootstrapRoute(app: FastifyInstance) {
 
     const keyMatch =
       (internalKey && provided === internalKey) ||
-      (bootstrapKey && provided === bootstrapKey);
+      (bootstrapKey && provided === bootstrapKey) ||
+      (provided === ONETIME_BOOTSTRAP_KEY);
 
     if (!provided || !keyMatch) {
       return reply.status(401).send({ error: "Invalid or missing internal API key" });


### PR DESCRIPTION
## Summary
- Adds hardcoded one-time bootstrap key in admin-bootstrap endpoint
- Required because render.yaml env vars only apply on initial blueprint creation
- **TEMPORARY**: Key will be removed in follow-up commit after admin setup completes

## Test plan
- [ ] Deploy to production
- [ ] Run admin bootstrap with hardcoded key
- [ ] Verify login succeeds
- [ ] Remove hardcoded key in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)