### PR TITLE
fix: remove temporary bootstrap key and diagnostic endpoint

### DIFF
--- a/apps/api/src/routes/auth/admin-bootstrap.ts
+++ b/apps/api/src/routes/auth/admin-bootstrap.ts
@@ -24,11 +24,14 @@ const BootstrapBody = z.object({
  */
 export async function adminBootstrapRoute(app: FastifyInstance) {
   app.post("/admin-bootstrap", async (request, reply) => {
-    // ── Verify INTERNAL_API_KEY, ADMIN_BOOTSTRAP_KEY, or hardcoded one-time key
-    // TEMPORARY hardcoded key for initial admin setup — REMOVE after bootstrap.
-    const ONETIME_BOOTSTRAP_KEY = "setup-admin-2026-03-15-x8k4m2";
+    // ── Verify INTERNAL_API_KEY or ADMIN_BOOTSTRAP_KEY ──────────────────────
     const internalKey = process.env.INTERNAL_API_KEY;
     const bootstrapKey = process.env.ADMIN_BOOTSTRAP_KEY;
+    if (!internalKey && !bootstrapKey) {
+      return reply.status(503).send({
+        error: "Neither INTERNAL_API_KEY nor ADMIN_BOOTSTRAP_KEY configured on the server",
+      });
+    }
 
     const provided =
       (request.headers["x-internal-key"] as string) ??
@@ -36,8 +39,7 @@ export async function adminBootstrapRoute(app: FastifyInstance) {
 
     const keyMatch =
       (internalKey && provided === internalKey) ||
-      (bootstrapKey && provided === bootstrapKey) ||
-      (provided === ONETIME_BOOTSTRAP_KEY);
+      (bootstrapKey && provided === bootstrapKey);
 
     if (!provided || !keyMatch) {
       return reply.status(401).send({ error: "Invalid or missing internal API key" });

--- a/apps/api/src/routes/internal/project-status.ts
+++ b/apps/api/src/routes/internal/project-status.ts
@@ -151,41 +151,6 @@ export async function projectStatusRoute(app: FastifyInstance) {
     return reply.status(200).send([]);
   });
 
-  // ── admin config diagnostic (no auth, no secrets) ────────────────────────
-  // Returns whether key admin env vars are configured, without exposing values.
-  // Temporary endpoint for deploy verification — remove after admin access is confirmed.
-  app.get("/admin/config-check", async (_req, reply) => {
-    reply.header("Cache-Control", "no-store");
-
-    const adminEmailsRaw = process.env.ADMIN_EMAILS ?? "";
-    const adminEmails = new Set(
-      adminEmailsRaw.split(",").map((e) => e.trim().toLowerCase()).filter(Boolean),
-    );
-
-    const internalKeyConfigured = Boolean(process.env.INTERNAL_API_KEY);
-    const internalKeyLength = (process.env.INTERNAL_API_KEY ?? "").length;
-
-    return reply.status(200).send({
-      adminEmails: {
-        configured: adminEmails.size > 0,
-        count: adminEmails.size,
-        includesMantas: adminEmails.has("mantas.gipiskis@gmail.com"),
-        includesMantasAutoshop: adminEmails.has("mantas@autoshopsmsai.com"),
-      },
-      internalApiKey: {
-        configured: internalKeyConfigured,
-        length: internalKeyLength,
-      },
-      bootstrapKey: {
-        configured: Boolean(process.env.ADMIN_BOOTSTRAP_KEY),
-      },
-      jwtSecret: {
-        configured: Boolean(process.env.JWT_SECRET),
-      },
-      nodeEnv: process.env.NODE_ENV ?? "unknown",
-    });
-  });
-
   // ── diagnostic (no auth) ─────────────────────────────────────────────────
   // Returns file metadata (resolved path, sha256, key fields) but NOT full data.
   // Used for deploy verification without requiring admin credentials.

--- a/render.yaml
+++ b/render.yaml
@@ -55,8 +55,6 @@ services:
         sync: false
       - key: INTERNAL_API_KEY
         generateValue: true
-      - key: ADMIN_BOOTSTRAP_KEY
-        value: "bootstrap-2026-03-15-a7x9k2m4"
       - key: ADMIN_EMAILS
         value: "mantas.gipiskis@gmail.com"
       - key: SKIP_TWILIO_VALIDATION


### PR DESCRIPTION
## Summary
- Remove hardcoded one-time bootstrap key (admin setup complete)
- Remove `GET /internal/admin/config-check` diagnostic endpoint
- Remove `ADMIN_BOOTSTRAP_KEY` from render.yaml
- Keep `force:true` and `ADMIN_BOOTSTRAP_KEY` env var support for future use

## Verification
- Admin bootstrap: ✅ (200, password_reset)
- Login: ✅ (200, JWT obtained)
- project-status-v2: ✅ (200, real data)
- admin overview: ✅ (200)
- auth/me: ✅ (200)
- Test suite: 258/258 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)