### PR TITLE
fix: resolve production auth — login normalization + Google OAuth config

### DIFF
--- a/apps/api/src/routes/auth/admin-bootstrap.ts
+++ b/apps/api/src/routes/auth/admin-bootstrap.ts
@@ -120,10 +120,10 @@ export async function adminBootstrapRoute(app: FastifyInstance) {
     // ── Create minimal admin tenant ──────────────────────────────────────────
     const rows = await query<{ id: string }>(
       `INSERT INTO tenants
-         (shop_name, owner_email, password_hash, billing_status,
+         (shop_name, owner_name, owner_email, password_hash, billing_status,
           trial_started_at, trial_ends_at, trial_conv_limit,
           conv_limit_this_cycle, conv_used_this_cycle)
-       VALUES ('Admin', $1, $2, 'trial',
+       VALUES ('Admin', 'Admin', $1, $2, 'trial',
                NOW(), NOW() + INTERVAL '365 days', 9999,
                9999, 0)
        RETURNING id`,

--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -92,7 +92,7 @@ const CallbackQuerySchema = z.object({
   code: z.string().min(1).optional(),
   state: z.string().uuid(), // tenantId passed as state
   error: z.string().optional(),
-});
+}).passthrough(); // Google sends extra params (scope, authuser, hd, prompt)
 
 export async function googleAuthRoute(app: FastifyInstance) {
   const clientId = process.env.GOOGLE_CLIENT_ID;

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -30,6 +30,7 @@ export async function loginRoute(app: FastifyInstance) {
     }
 
     const { email, password } = parsed.data;
+    const normalizedEmail = email.toLowerCase().trim();
 
     const rows = await query<{
       id: string;
@@ -38,7 +39,7 @@ export async function loginRoute(app: FastifyInstance) {
       password_hash: string | null;
     }>(
       "SELECT id, shop_name, owner_email, password_hash FROM tenants WHERE owner_email = $1 LIMIT 1",
-      [email]
+      [normalizedEmail]
     );
     const tenant = rows[0];
 

--- a/db/migrations/011_admin_password_reset.sql
+++ b/db/migrations/011_admin_password_reset.sql
@@ -1,0 +1,23 @@
+-- One-time admin password reset for mantas.gipiskis@gmail.com
+-- Sets password to the value provided by the project owner.
+-- Idempotent: only updates if tenant exists; creates if not.
+
+DO $$
+BEGIN
+  -- Try to update existing tenant's password
+  IF EXISTS (SELECT 1 FROM tenants WHERE owner_email = 'mantas.gipiskis@gmail.com') THEN
+    UPDATE tenants
+    SET password_hash = '$2b$12$Yg24uuzAaf08nx3mnSWaWeyqD7OJ.7S9/GhqeT93ovOx/mAgW3TB6'
+    WHERE owner_email = 'mantas.gipiskis@gmail.com';
+    RAISE NOTICE 'Admin password updated for mantas.gipiskis@gmail.com';
+  ELSE
+    -- Create admin tenant if it doesn't exist
+    INSERT INTO tenants (shop_name, owner_name, owner_email, password_hash, billing_status,
+                         trial_started_at, trial_ends_at, trial_conv_limit,
+                         conv_limit_this_cycle, conv_used_this_cycle)
+    VALUES ('Admin', 'Admin', 'mantas.gipiskis@gmail.com',
+            '$2b$12$Yg24uuzAaf08nx3mnSWaWeyqD7OJ.7S9/GhqeT93ovOx/mAgW3TB6',
+            'trial', NOW(), NOW() + INTERVAL '365 days', 9999, 9999, 0);
+    RAISE NOTICE 'Admin tenant created for mantas.gipiskis@gmail.com';
+  END IF;
+END $$;

--- a/render.yaml
+++ b/render.yaml
@@ -62,6 +62,20 @@ services:
       - key: CORS_ORIGINS
         value: "https://autoshopsmsai.com"
 
+      # ── Google OAuth (set in Render Dashboard) ──────────────────────────
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false
+      - key: GOOGLE_REDIRECT_URI
+        value: "https://autoshopsmsai.com/auth/google/callback"
+      - key: PUBLIC_ORIGIN
+        value: "https://autoshopsmsai.com"
+
+      # ── Admin bootstrap key (set in Render Dashboard) ───────────────────
+      - key: ADMIN_BOOTSTRAP_KEY
+        sync: false
+
   # ── Redis ───────────────────────────────────────────────────────────────────
   - type: redis
     name: autoshop-redis


### PR DESCRIPTION
## Summary

- **Email login fix**: `login.ts` now normalizes email to lowercase before DB query (matching how `admin-bootstrap` stores emails). This was the root cause of "Invalid credentials" for `mantas.gipiskis@gmail.com`.
- **Google OAuth fix**: Added missing env vars to `render.yaml` (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `PUBLIC_ORIGIN`, `ADMIN_BOOTSTRAP_KEY`). Production had OAuth completely unconfigured.
- **Callback resilience**: Added `.passthrough()` to Google callback Zod schema so extra Google query params don't cause validation failures.
- **Admin bootstrap fix**: Fixed INSERT to include required `owner_name` column (was causing silent failures on new tenant creation).
- **Password migration**: Added `011_admin_password_reset.sql` to set admin password on next deployment.

## Root causes

1. `login.ts` queried with raw email, `admin-bootstrap.ts` stored lowercase → case mismatch = "Invalid credentials"
2. `render.yaml` missing all Google OAuth env vars → OAuth 503/400 in production
3. `admin-bootstrap.ts` INSERT missing `owner_name NOT NULL` column → tenant creation silently failed

## Post-deploy required

After merge and Render deployment:
- Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in Render Dashboard (values from `.env`)
- Set `ADMIN_BOOTSTRAP_KEY` in Render Dashboard (any secure random value)

## Test plan

- [x] All 258 tests pass (14 source test files)
- [ ] After deploy: POST /auth/login returns 200 for mantas.gipiskis@gmail.com
- [ ] After deploy: /auth/me returns user info with token
- [ ] After deploy: /internal/admin/project-status-v2 returns 200
- [ ] After deploy: Google OAuth callback no longer returns "Invalid callback parameters"

🤖 Generated with [Claude Code](https://claude.com/claude-code)