### PR TITLE
fix: production Twilio wiring — phone registration, config fallback

### DIFF
--- a/apps/api/src/db/app-config.ts
+++ b/apps/api/src/db/app-config.ts
@@ -1,0 +1,23 @@
+import { query } from "./client";
+
+/**
+ * Gets a configuration value: checks env var first, then falls back to DB app_config table.
+ * Returns null if not found in either location.
+ */
+export async function getConfig(key: string): Promise<string | null> {
+  // Env var takes priority
+  const envVal = process.env[key];
+  if (envVal) return envVal;
+
+  // Fallback to DB
+  try {
+    const rows = await query<{ value: string }>(
+      "SELECT value FROM app_config WHERE key = $1",
+      [key]
+    );
+    return rows[0]?.value ?? null;
+  } catch {
+    // Table might not exist yet (pre-migration)
+    return null;
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,6 +27,7 @@ import { calendarEventRoute } from "./routes/internal/calendar-event";
 import { appointmentsRoute } from "./routes/internal/appointments";
 import { missedCallSmsRoute } from "./routes/internal/missed-call-sms";
 import { processSmsRoute } from "./routes/internal/process-sms";
+import { configRoute } from "./routes/internal/config";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { startSmsInboundWorker } from "./workers/sms-inbound.worker";
@@ -82,6 +83,7 @@ async function bootstrap() {
   await app.register(appointmentsRoute, { prefix: "/internal" });
   await app.register(missedCallSmsRoute, { prefix: "/internal" });
   await app.register(processSmsRoute, { prefix: "/internal" });
+  await app.register(configRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });

--- a/apps/api/src/middleware/twilio-validate.ts
+++ b/apps/api/src/middleware/twilio-validate.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import twilio from "twilio";
+import { getConfig } from "../db/app-config";
 
 /**
  * Validates Twilio webhook signature.
@@ -12,7 +13,7 @@ export async function validateTwilioSignature(
   request: FastifyRequest,
   reply: FastifyReply
 ): Promise<void> {
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const authToken = await getConfig("TWILIO_AUTH_TOKEN");
 
   if (!authToken) {
     request.log.error("TWILIO_AUTH_TOKEN not set — rejecting webhook");

--- a/apps/api/src/routes/internal/config.ts
+++ b/apps/api/src/routes/internal/config.ts
@@ -1,0 +1,61 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+
+const SetConfigBody = z.object({
+  key: z.string().min(1),
+  value: z.string().min(1),
+});
+
+const ALLOWED_KEYS = new Set([
+  "TWILIO_ACCOUNT_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_MESSAGING_SERVICE_SID",
+]);
+
+/**
+ * POST /internal/config
+ * GET  /internal/config/:key
+ *
+ * Runtime configuration endpoint for secrets that can't be set via env vars.
+ * Only allows a whitelist of keys to prevent misuse.
+ * Internal only — NOT exposed externally.
+ */
+export async function configRoute(app: FastifyInstance) {
+  app.post("/config", async (request, reply) => {
+    const parsed = SetConfigBody.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "key and value required" });
+    }
+
+    const { key, value } = parsed.data;
+
+    if (!ALLOWED_KEYS.has(key)) {
+      return reply
+        .status(403)
+        .send({ error: `Key '${key}' is not in the allowed list` });
+    }
+
+    await query(
+      `INSERT INTO app_config (key, value, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`,
+      [key, value]
+    );
+
+    request.log.info({ key }, "Config key set");
+    return reply.status(200).send({ ok: true, key });
+  });
+
+  app.get("/config/:key", async (request, reply) => {
+    const { key } = request.params as { key: string };
+    const rows = await query<{ value: string }>(
+      "SELECT value FROM app_config WHERE key = $1",
+      [key]
+    );
+    if (rows.length === 0) {
+      return reply.status(404).send({ error: "Key not found" });
+    }
+    return reply.send({ key, value: rows[0].value });
+  });
+}

--- a/apps/api/src/services/missed-call-sms.ts
+++ b/apps/api/src/services/missed-call-sms.ts
@@ -15,6 +15,7 @@
  */
 
 import { query } from "../db/client";
+import { getConfig } from "../db/app-config";
 
 export interface MissedCallInput {
   tenantId: string;
@@ -53,9 +54,9 @@ export async function sendTwilioSms(
   body: string,
   fetchFn: typeof fetch = fetch
 ): Promise<{ sid: string | null; error: string | null }> {
-  const accountSid = process.env.TWILIO_ACCOUNT_SID;
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
-  const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+  const accountSid = await getConfig("TWILIO_ACCOUNT_SID");
+  const authToken = await getConfig("TWILIO_AUTH_TOKEN");
+  const messagingServiceSid = await getConfig("TWILIO_MESSAGING_SERVICE_SID");
 
   if (!accountSid || !authToken || !messagingServiceSid) {
     return { sid: null, error: "Twilio credentials not configured" };

--- a/db/migrations/012_register_twilio_phone.sql
+++ b/db/migrations/012_register_twilio_phone.sql
@@ -1,0 +1,17 @@
+-- Register production Twilio phone number for the admin tenant.
+-- Idempotent: skips if phone number already exists.
+-- Tenant: mantas.gipiskis@gmail.com (90d1e2f2-b499-4710-9134-bab0a9a5ab4c)
+-- Phone: +13257523890 (Texas 325 area code)
+-- Twilio SID: PNf77089f763ad788a2ea7bf65e71c181a
+
+INSERT INTO tenant_phone_numbers (tenant_id, twilio_sid, phone_number, status)
+VALUES (
+  '90d1e2f2-b499-4710-9134-bab0a9a5ab4c',
+  'PNf77089f763ad788a2ea7bf65e71c181a',
+  '+13257523890',
+  'active'
+)
+ON CONFLICT (phone_number) DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  twilio_sid = EXCLUDED.twilio_sid,
+  status = 'active';

--- a/db/migrations/013_app_config.sql
+++ b/db/migrations/013_app_config.sql
@@ -1,0 +1,9 @@
+-- App configuration table for runtime secrets that can be set via API.
+-- Used as fallback when env vars are not available (e.g., Render Dashboard not configured).
+-- Keys are unique; updates overwrite.
+
+CREATE TABLE IF NOT EXISTS app_config (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- **Migration 012**: Registers Twilio number +13257523890 in `tenant_phone_numbers` for the admin tenant. Required for webhook routing (tenant lookup by phone number).
- **Migration 013**: Creates `app_config` table for runtime secrets that can be set via API call.
- **DB-backed config fallback**: `getConfig()` checks env var first, then `app_config` table. Allows injecting Twilio credentials when Render env vars aren't set.
- **POST /internal/config**: Whitelisted endpoint for setting TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID at runtime.
- **sendTwilioSms + validateTwilioSignature**: Now use `getConfig()` for credential resolution with DB fallback.

## Twilio Webhook URLs (updated via Twilio API)
| Endpoint | Before | After |
|----------|--------|-------|
| Messaging Service inbound | `bandomasis.app.n8n.cloud/...` | `autoshop-api-7ek9.onrender.com/webhooks/twilio/sms` |
| Phone SMS URL | `older-interlobate-jacoby.ngrok-free.dev/...` | `autoshop-api-7ek9.onrender.com/webhooks/twilio/sms` |
| Voice status callback | `bandomasis.app.n8n.cloud/...` | `autoshop-api-7ek9.onrender.com/webhooks/twilio/voice-status` |

## Test plan
- [x] 258/258 tests pass
- [ ] After merge: inject Twilio credentials via POST /internal/config
- [ ] After merge: send real SMS to +13257523890 and verify full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)