### PR TITLE
fix: add no-cache headers for admin paths in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,24 @@
 {
   "outputDirectory": "apps/web",
   "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/admin.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    },
+    {
+      "source": "/internal/admin/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/health", "destination": "https://autoshop-api-7ek9.onrender.com/health" },
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },


### PR DESCRIPTION
## Summary
- Vercel CDN serves `admin.html` and proxies `/internal/admin/*` — the Fastify `setHeaders`/`onSend` hooks from PR #102 only apply when hitting Render directly
- This adds `Cache-Control: no-store, no-cache, must-revalidate` + `Pragma: no-cache` + `Expires: 0` headers in `vercel.json` for `/admin.html` and `/internal/admin/*`
- Ensures no stale admin content regardless of whether request goes through Vercel CDN or directly to Render

## Test plan
- [ ] After deploy, `curl -I https://autoshopsmsai.com/admin.html` shows `Cache-Control: no-store`
- [ ] `curl -I https://autoshopsmsai.com/internal/admin/overview` shows `Cache-Control: no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)