### PR TITLE
fix: widen header type in admin-freshness test for Render build

### DIFF
--- a/apps/api/src/tests/admin-freshness-e2e.test.ts
+++ b/apps/api/src/tests/admin-freshness-e2e.test.ts
@@ -66,7 +66,7 @@ function mockOverviewWithCount(count: number) {
   });
 }
 
-function assertNoCacheHeaders(headers: Record<string, string | string[] | undefined>) {
+function assertNoCacheHeaders(headers: Record<string, string | number | string[] | undefined>) {
   expect(headers["cache-control"]).toContain("no-store");
   expect(headers["cache-control"]).toContain("no-cache");
   expect(headers["cache-control"]).toContain("must-revalidate");


### PR DESCRIPTION
## Summary
- Fastify `inject()` returns `OutgoingHttpHeaders` which includes `number` in the value union
- `assertNoCacheHeaders()` only accepted `string | string[] | undefined`, causing `tsc --noEmit` to fail on Render
- Added `number` to the type union to match the real Fastify header type

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] `npx vitest run` — 16 test files, 263 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)