### PR TITLE
fix: proxy /admin.html through Render to get correct no-cache headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     }
   ],
   "rewrites": [
+    { "source": "/admin.html", "destination": "https://autoshop-api-7ek9.onrender.com/admin.html" },
     { "source": "/health", "destination": "https://autoshop-api-7ek9.onrender.com/health" },
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },
     { "source": "/billing/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/billing/:path*" },


### PR DESCRIPTION
## Summary
- `/admin.html` on `autoshopsmsai.com` was returning `Cache-Control: public, max-age=0, must-revalidate` from Vercel's static CDN layer
- Vercel's `headers` config in `vercel.json` does **not** override static asset Cache-Control headers
- Render already serves `/admin.html` with correct `no-store, no-cache, must-revalidate` headers
- Fix: add a rewrite rule so Vercel proxies `/admin.html` to Render instead of serving from its static layer

## Evidence
- Before: `Cache-Control: public, max-age=0, must-revalidate` + `X-Vercel-Cache: HIT`
- After (expected): `Cache-Control: no-store, no-cache, must-revalidate` + `Pragma: no-cache` + `Expires: 0`

## Test plan
- [ ] After Vercel redeploys, verify `curl -sI https://autoshopsmsai.com/admin.html` returns no-cache headers
- [ ] Verify `/internal/admin/overview` still returns no-cache headers (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)