### PR TITLE
fix: add no-cache headers to apps/web/vercel.json for admin.html

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,23 @@
 {
   "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/admin.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    },
+    {
+      "source": "/internal/admin/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/health", "destination": "https://autoshop-api-7ek9.onrender.com/health" },
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },


### PR DESCRIPTION
## Summary
- `/admin.html` on `autoshopsmsai.com` still returned `Cache-Control: public, max-age=0, must-revalidate`
- Root cause: Vercel uses the `vercel.json` in the `outputDirectory` (`apps/web/`), not the root config
- The root `vercel.json` had `headers` rules but `apps/web/vercel.json` did not
- Added the no-cache `headers` config to `apps/web/vercel.json`

## Test plan
- [ ] After Vercel redeploy, `curl -sI https://autoshopsmsai.com/admin.html` returns `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] `/internal/admin/overview` headers unchanged (still correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)