### PR TITLE
feat: pilot-shop configurable messaging and AI settings

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from "fastify";
 import * as bcrypt from "bcryptjs";
+import { z } from "zod";
 import { query } from "../../db/client";
 import { adminGuard } from "../../middleware/admin-guard";
 
@@ -685,5 +686,125 @@ export async function adminRoute(app: FastifyInstance) {
         booked: r.booked,
       })),
     });
+  });
+
+  // ── GET /internal/admin/tenants/:id/settings ────────────────────────────
+  app.get("/admin/tenants/:id/settings", { preHandler: [adminGuard] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    const [tenantRows, promptRows] = await Promise.all([
+      query<{
+        shop_name: string | null;
+        missed_call_sms_template: string | null;
+        business_hours: string | null;
+        services_description: string | null;
+      }>(
+        `SELECT shop_name, missed_call_sms_template, business_hours, services_description
+         FROM tenants WHERE id = $1`,
+        [id]
+      ),
+      query<{ prompt_text: string }>(
+        `SELECT prompt_text FROM system_prompts
+         WHERE tenant_id = $1 AND is_active = TRUE
+         ORDER BY version DESC LIMIT 1`,
+        [id]
+      ),
+    ]);
+
+    if ((tenantRows as any[]).length === 0) {
+      return reply.status(404).send({ error: "Tenant not found" });
+    }
+
+    const tenant = (tenantRows as any[])[0];
+    return reply.status(200).send({
+      shop_name: tenant.shop_name,
+      missed_call_sms_template: tenant.missed_call_sms_template,
+      ai_system_prompt: (promptRows as any[])[0]?.prompt_text ?? null,
+      business_hours: tenant.business_hours,
+      services_description: tenant.services_description,
+    });
+  });
+
+  // ── PUT /internal/admin/tenants/:id/settings ────────────────────────────
+  const SettingsSchema = z.object({
+    shop_name: z.string().min(1).max(200).optional(),
+    missed_call_sms_template: z.string().max(500).nullable().optional(),
+    ai_system_prompt: z.string().max(2000).nullable().optional(),
+    business_hours: z.string().max(500).nullable().optional(),
+    services_description: z.string().max(1000).nullable().optional(),
+  });
+
+  app.put("/admin/tenants/:id/settings", { preHandler: [adminGuard] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const parsed = SettingsSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`),
+      });
+    }
+
+    // Check tenant exists
+    const existing = await query(`SELECT id FROM tenants WHERE id = $1`, [id]);
+    if ((existing as any[]).length === 0) {
+      return reply.status(404).send({ error: "Tenant not found" });
+    }
+
+    const data = parsed.data;
+
+    // Update tenant columns (shop_name, missed_call_sms_template, business_hours, services_description)
+    const tenantUpdates: string[] = [];
+    const tenantValues: (string | null)[] = [];
+    let paramIdx = 1;
+
+    if (data.shop_name !== undefined) {
+      tenantUpdates.push(`shop_name = $${paramIdx++}`);
+      tenantValues.push(data.shop_name);
+    }
+    if (data.missed_call_sms_template !== undefined) {
+      tenantUpdates.push(`missed_call_sms_template = $${paramIdx++}`);
+      tenantValues.push(data.missed_call_sms_template);
+    }
+    if (data.business_hours !== undefined) {
+      tenantUpdates.push(`business_hours = $${paramIdx++}`);
+      tenantValues.push(data.business_hours);
+    }
+    if (data.services_description !== undefined) {
+      tenantUpdates.push(`services_description = $${paramIdx++}`);
+      tenantValues.push(data.services_description);
+    }
+
+    if (tenantUpdates.length > 0) {
+      tenantUpdates.push(`updated_at = NOW()`);
+      await query(
+        `UPDATE tenants SET ${tenantUpdates.join(", ")} WHERE id = $${paramIdx}`,
+        [...tenantValues, id]
+      );
+    }
+
+    // Update ai_system_prompt in system_prompts table
+    if (data.ai_system_prompt !== undefined) {
+      if (data.ai_system_prompt === null || data.ai_system_prompt.trim() === "") {
+        // Deactivate existing prompts
+        await query(
+          `UPDATE system_prompts SET is_active = FALSE WHERE tenant_id = $1`,
+          [id]
+        );
+      } else {
+        // Deactivate old, insert new version
+        await query(
+          `UPDATE system_prompts SET is_active = FALSE WHERE tenant_id = $1`,
+          [id]
+        );
+        await query(
+          `INSERT INTO system_prompts (tenant_id, version, prompt_text, is_active)
+           VALUES ($1, (SELECT COALESCE(MAX(version), 0) + 1 FROM system_prompts WHERE tenant_id = $1), $2, TRUE)`,
+          [id, data.ai_system_prompt.trim()]
+        );
+      }
+    }
+
+    return reply.status(200).send({ success: true });
   });
 }

--- a/apps/api/src/services/missed-call-sms.ts
+++ b/apps/api/src/services/missed-call-sms.ts
@@ -37,8 +37,16 @@ export interface MissedCallResult {
  * Builds the initial SMS text for a missed call.
  * Uses the shop name if available for a personal touch.
  */
-export function buildMissedCallSms(shopName: string | null): string {
+export function buildMissedCallSms(
+  shopName: string | null,
+  template: string | null = null
+): string {
   const name = shopName || "our shop";
+
+  if (template && template.trim()) {
+    return template.replace(/\{shop_name\}/gi, name);
+  }
+
   return (
     `Hi! We noticed you just called ${name} but we couldn't pick up. ` +
     `How can we help you today? Reply here and we'll get you taken care of.`
@@ -108,16 +116,18 @@ export async function handleMissedCallSms(
   input: MissedCallInput,
   fetchFn: typeof fetch = fetch
 ): Promise<MissedCallResult> {
-  // 1. Validate tenant and get shop info
+  // 1. Validate tenant and get shop info + messaging config
   let shopName: string | null = null;
   let billingStatus: string = "unknown";
+  let missedCallTemplate: string | null = null;
   try {
     const rows = await query<{
       id: string;
       shop_name: string | null;
       billing_status: string;
+      missed_call_sms_template: string | null;
     }>(
-      `SELECT id, shop_name, billing_status FROM tenants WHERE id = $1`,
+      `SELECT id, shop_name, billing_status, missed_call_sms_template FROM tenants WHERE id = $1`,
       [input.tenantId]
     );
 
@@ -133,6 +143,7 @@ export async function handleMissedCallSms(
 
     shopName = rows[0].shop_name;
     billingStatus = rows[0].billing_status;
+    missedCallTemplate = rows[0].missed_call_sms_template;
   } catch (err) {
     return {
       success: false,
@@ -200,8 +211,8 @@ export async function handleMissedCallSms(
     // Non-fatal — continue with SMS even if logging fails
   }
 
-  // 5. Send the initial outbound SMS
-  const smsBody = buildMissedCallSms(shopName);
+  // 5. Send the initial outbound SMS (use tenant template if configured)
+  const smsBody = buildMissedCallSms(shopName, missedCallTemplate);
   const twilioResult = await sendTwilioSms(
     input.customerPhone,
     smsBody,

--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -164,7 +164,7 @@ export async function processSms(
     return result;
   }
 
-  // ── 5. Fetch system prompt ───────────────────────────────────────────────
+  // ── 5. Fetch system prompt + tenant context ────────────────────────────
   let systemPrompt = DEFAULT_SYSTEM_PROMPT;
   try {
     const rows = await query<{ prompt_text: string }>(
@@ -178,6 +178,30 @@ export async function processSms(
     }
   } catch {
     // Use default prompt if lookup fails
+  }
+
+  // Inject tenant shop context (business_hours, services_description) into prompt
+  try {
+    const tenantRows = await query<{
+      shop_name: string | null;
+      business_hours: string | null;
+      services_description: string | null;
+    }>(
+      `SELECT shop_name, business_hours, services_description FROM tenants WHERE id = $1`,
+      [input.tenantId]
+    );
+    if (tenantRows.length > 0) {
+      const t = tenantRows[0];
+      const contextParts: string[] = [];
+      if (t.shop_name) contextParts.push(`Shop name: ${t.shop_name}`);
+      if (t.business_hours) contextParts.push(`Business hours: ${t.business_hours}`);
+      if (t.services_description) contextParts.push(`Services offered: ${t.services_description}`);
+      if (contextParts.length > 0) {
+        systemPrompt += "\n\n" + contextParts.join("\n");
+      }
+    }
+  } catch {
+    // Non-fatal: continue with base prompt if tenant lookup fails
   }
 
   // ── 6. Call OpenAI ──────────────────────────────────────────────────────

--- a/apps/api/src/tests/tenant-settings.test.ts
+++ b/apps/api/src/tests/tenant-settings.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+vi.mock("../middleware/admin-guard", () => ({
+  adminGuard: async () => {},
+}));
+
+import { adminRoute } from "../routes/internal/admin";
+import { buildMissedCallSms } from "../services/missed-call-sms";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminRoute, { prefix: "/internal" });
+  return app;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildMissedCallSms — template support
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("buildMissedCallSms with template", () => {
+  it("uses custom template when provided", () => {
+    const sms = buildMissedCallSms("Joe's Auto", "Hello from {shop_name}! We missed your call.");
+    expect(sms).toBe("Hello from Joe's Auto! We missed your call.");
+  });
+
+  it("replaces {shop_name} placeholder case-insensitively", () => {
+    const sms = buildMissedCallSms("Joe's Auto", "Hi from {Shop_Name}!");
+    expect(sms).toBe("Hi from Joe's Auto!");
+  });
+
+  it("uses default shop name when shop_name is null", () => {
+    const sms = buildMissedCallSms(null, "Call from {shop_name} missed.");
+    expect(sms).toBe("Call from our shop missed.");
+  });
+
+  it("falls back to default SMS when template is null", () => {
+    const sms = buildMissedCallSms("Joe's Auto", null);
+    expect(sms).toContain("Joe's Auto");
+    expect(sms).toContain("couldn't pick up");
+  });
+
+  it("falls back to default SMS when template is empty", () => {
+    const sms = buildMissedCallSms("Joe's Auto", "   ");
+    expect(sms).toContain("Joe's Auto");
+    expect(sms).toContain("couldn't pick up");
+  });
+
+  it("falls back to default SMS when template is undefined", () => {
+    const sms = buildMissedCallSms("Joe's Auto");
+    expect(sms).toContain("Joe's Auto");
+    expect(sms).toContain("couldn't pick up");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /internal/admin/tenants/:id/settings
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /internal/admin/tenants/:id/settings", () => {
+  it("returns tenant settings with system prompt", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{
+        shop_name: "Joe's Auto",
+        missed_call_sms_template: "Hey {shop_name} missed you!",
+        business_hours: "Mon-Fri 8-6",
+        services_description: "Oil changes, brakes",
+      }])
+      .mockResolvedValueOnce([{ prompt_text: "You are Joe's assistant." }]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.shop_name).toBe("Joe's Auto");
+    expect(body.missed_call_sms_template).toBe("Hey {shop_name} missed you!");
+    expect(body.ai_system_prompt).toBe("You are Joe's assistant.");
+    expect(body.business_hours).toBe("Mon-Fri 8-6");
+    expect(body.services_description).toBe("Oil changes, brakes");
+  });
+
+  it("returns nulls when no settings configured", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{
+        shop_name: "Default Shop",
+        missed_call_sms_template: null,
+        business_hours: null,
+        services_description: null,
+      }])
+      .mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.missed_call_sms_template).toBeNull();
+    expect(body.ai_system_prompt).toBeNull();
+    expect(body.business_hours).toBeNull();
+    expect(body.services_description).toBeNull();
+  });
+
+  it("returns 404 for unknown tenant", async () => {
+    mocks.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PUT /internal/admin/tenants/:id/settings
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("PUT /internal/admin/tenants/:id/settings", () => {
+  it("updates tenant columns and system prompt", async () => {
+    // exists check
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]);
+    // tenant UPDATE
+    mocks.query.mockResolvedValueOnce([]);
+    // deactivate old prompts
+    mocks.query.mockResolvedValueOnce([]);
+    // insert new prompt
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: {
+        shop_name: "New Name",
+        missed_call_sms_template: "Hello from {shop_name}!",
+        ai_system_prompt: "Be helpful.",
+        business_hours: "Mon-Sat 9-5",
+        services_description: "Full service auto repair",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.success).toBe(true);
+
+    // Verify tenant UPDATE was called with all fields
+    const updateCall = mocks.query.mock.calls[1];
+    expect(updateCall[0]).toContain("shop_name");
+    expect(updateCall[0]).toContain("missed_call_sms_template");
+    expect(updateCall[0]).toContain("business_hours");
+    expect(updateCall[0]).toContain("services_description");
+
+    // Verify system prompt insert
+    const insertCall = mocks.query.mock.calls[3];
+    expect(insertCall[0]).toContain("INSERT INTO system_prompts");
+    expect(insertCall[1]).toContain("Be helpful.");
+  });
+
+  it("clears system prompt when null", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]);
+    // deactivate prompts
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { ai_system_prompt: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // Should have called deactivate but not insert
+    const deactivateCall = mocks.query.mock.calls[1];
+    expect(deactivateCall[0]).toContain("SET is_active = FALSE");
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 404 for unknown tenant", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { shop_name: "New" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { shop_name: "" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("handles partial updates (only some fields)", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]);
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { business_hours: "24/7" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mocks.query.mock.calls[1];
+    expect(updateCall[0]).toContain("business_hours");
+    expect(updateCall[0]).not.toContain("shop_name");
+  });
+
+  it("allows clearing template with null", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]);
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { missed_call_sms_template: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mocks.query.mock.calls[1];
+    expect(updateCall[0]).toContain("missed_call_sms_template");
+    expect(updateCall[1]).toContain(null);
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -775,9 +775,9 @@ async function loadAccountDetail(id) {
 
 function renderAccountDetail(d) {
   const t = d.tenant;
-  const tabs = ['summary','usage','billing','conversations','bookings','integrations','billing_events','audit'];
+  const tabs = ['summary','settings','usage','billing','conversations','bookings','integrations','billing_events','audit'];
   const tabLabels = {
-    summary:'Summary', usage:'Usage', billing:'Billing', conversations:'Conversations',
+    summary:'Summary', settings:'Settings', usage:'Usage', billing:'Billing', conversations:'Conversations',
     bookings:'Bookings', integrations:'Integrations', billing_events:'Billing Events', audit:'Audit Log'
   };
 
@@ -814,6 +814,18 @@ function renderAccountDetail(d) {
             </div>
           </div>
         </div>`;
+      break;
+
+    case 'settings':
+      tabContent = `
+        <div class="panel" id="settingsPanel">
+          <div class="panel-header"><span class="panel-title">Messaging & AI Settings</span></div>
+          <div class="panel-body" id="settingsBody">
+            <div class="loading"><div class="spinner"></div> Loading settings...</div>
+          </div>
+        </div>`;
+      // Load settings async after render
+      setTimeout(() => loadTenantSettings(t.id), 0);
       break;
 
     case 'usage':
@@ -997,6 +1009,80 @@ function renderAccountDetail(d) {
 function switchAccountTab(tab) {
   accountDetailTab = tab;
   renderAccountDetail(window._accountDetailData);
+}
+
+// ── TENANT SETTINGS ─────────────────────────────────────────────────────────
+async function loadTenantSettings(tenantId) {
+  const body = document.getElementById('settingsBody');
+  if (!body) return;
+  try {
+    const s = await apiFetch(`/internal/admin/tenants/${tenantId}/settings`);
+    body.innerHTML = `
+      <div style="display:flex;flex-direction:column;gap:20px;max-width:640px">
+        <div>
+          <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Shop Name</label>
+          <input type="text" id="set_shop_name" value="${escHtml(s.shop_name || '')}"
+            style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--body);font-size:14px;background:var(--bg);color:var(--white)" />
+        </div>
+        <div>
+          <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Missed Call SMS Template</label>
+          <div style="font-size:11px;color:var(--steel);margin-bottom:4px">Use {shop_name} as placeholder. Leave empty for default.</div>
+          <textarea id="set_missed_call_sms" rows="3"
+            style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--body);font-size:14px;background:var(--bg);color:var(--white);resize:vertical">${escHtml(s.missed_call_sms_template || '')}</textarea>
+        </div>
+        <div>
+          <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">AI System Prompt</label>
+          <div style="font-size:11px;color:var(--steel);margin-bottom:4px">Custom instructions for the AI conversation. Leave empty for default.</div>
+          <textarea id="set_ai_prompt" rows="5"
+            style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--mono);font-size:13px;background:var(--bg);color:var(--white);resize:vertical">${escHtml(s.ai_system_prompt || '')}</textarea>
+        </div>
+        <div>
+          <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Business Hours</label>
+          <input type="text" id="set_business_hours" value="${escHtml(s.business_hours || '')}"
+            placeholder="e.g. Mon-Fri 8am-6pm, Sat 9am-2pm"
+            style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--body);font-size:14px;background:var(--bg);color:var(--white)" />
+        </div>
+        <div>
+          <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Services Description</label>
+          <textarea id="set_services" rows="3" placeholder="e.g. Oil changes, brake repair, tire rotation, AC service, engine diagnostics"
+            style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--body);font-size:14px;background:var(--bg);color:var(--white);resize:vertical">${escHtml(s.services_description || '')}</textarea>
+        </div>
+        <div style="display:flex;gap:12px;align-items:center">
+          <button class="btn-sm primary" onclick="saveTenantSettings('${tenantId}')">Save Settings</button>
+          <span id="settingsSaveStatus" style="font-size:13px;color:var(--green)"></span>
+        </div>
+      </div>`;
+  } catch (err) {
+    body.innerHTML = renderError(err);
+  }
+}
+
+async function saveTenantSettings(tenantId) {
+  const status = document.getElementById('settingsSaveStatus');
+  if (status) status.textContent = 'Saving...';
+  try {
+    const payload = {
+      shop_name: document.getElementById('set_shop_name').value || undefined,
+      missed_call_sms_template: document.getElementById('set_missed_call_sms').value || null,
+      ai_system_prompt: document.getElementById('set_ai_prompt').value || null,
+      business_hours: document.getElementById('set_business_hours').value || null,
+      services_description: document.getElementById('set_services').value || null,
+    };
+    const token = localStorage.getItem('autoshop_jwt') || '';
+    const res = await fetch(API + `/internal/admin/tenants/${tenantId}/settings`, {
+      method: 'PUT',
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) { const text = await res.text().catch(() => ''); throw new Error(text || res.statusText); }
+    if (status) { status.textContent = 'Saved!'; status.style.color = 'var(--green)'; }
+    // Update cached tenant data
+    if (window._accountDetailData && window._accountDetailData.tenant) {
+      if (payload.shop_name) window._accountDetailData.tenant.shop_name = payload.shop_name;
+    }
+  } catch (err) {
+    if (status) { status.textContent = 'Error: ' + err.message; status.style.color = 'var(--red)'; }
+  }
 }
 
 // ── SECTION 4: CONVERSATIONS ─────────────────────────────────────────────────

--- a/db/migrations/014_tenant_messaging_config.sql
+++ b/db/migrations/014_tenant_messaging_config.sql
@@ -1,0 +1,18 @@
+-- Migration 014: Add pilot-shop messaging configuration fields to tenants
+--
+-- Adds per-tenant configurable messaging fields:
+--   missed_call_sms_template  — the first SMS sent after a missed call
+--   business_hours            — shop hours for AI context
+--   services_description      — services offered for AI context
+--
+-- ai_system_prompt is already handled by the system_prompts table.
+-- shop_name already exists on tenants.
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS missed_call_sms_template TEXT,
+  ADD COLUMN IF NOT EXISTS business_hours TEXT,
+  ADD COLUMN IF NOT EXISTS services_description TEXT;
+
+COMMENT ON COLUMN tenants.missed_call_sms_template IS 'Custom SMS template for missed calls. Supports {shop_name} placeholder. Falls back to default if NULL.';
+COMMENT ON COLUMN tenants.business_hours IS 'Human-readable business hours, injected into AI system prompt context.';
+COMMENT ON COLUMN tenants.services_description IS 'Description of services offered, injected into AI system prompt context.';


### PR DESCRIPTION
## Summary
- Adds per-tenant configurable messaging for pilot shop deployment
- Missed call SMS uses tenant's custom template (with `{shop_name}` placeholder), falls back to default
- AI conversation system prompt is enriched with tenant's business hours and services description
- Admin UI gets a new "Settings" tab on account detail for editing all five fields
- Migration 014 adds `missed_call_sms_template`, `business_hours`, `services_description` to tenants table
- `system_prompts` table (already existing) handles custom AI system prompt per tenant

## Changes
- `db/migrations/014_tenant_messaging_config.sql` — new columns on tenants
- `services/missed-call-sms.ts` — template support in `buildMissedCallSms()` + fetch from tenant
- `services/process-sms.ts` — inject tenant context (shop name, hours, services) into AI prompt
- `routes/internal/admin.ts` — GET/PUT `/admin/tenants/:id/settings` endpoints
- `apps/web/admin.html` — Settings tab in account detail view
- `tests/tenant-settings.test.ts` — 15 new tests

## Safety
- Does NOT modify: Twilio webhooks, booking detection, appointment creation, Google Calendar, BullMQ pipeline
- Only extends configuration reads where needed
- All existing 263 tests continue passing + 15 new = 278 total

## Test plan
- [x] 15 new tests for template interpolation, settings GET/PUT, validation
- [x] Full suite: 278/278 passing
- [x] Build: TypeScript compiles clean
- [x] Docker: image builds successfully
- [ ] Manual: verify Settings tab renders in admin UI
- [ ] Manual: verify saved settings are used in missed call SMS flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)