### PR TITLE
fix: prevent false booking confirmations before calendar sync

### DIFF
--- a/apps/api/src/services/appointments.ts
+++ b/apps/api/src/services/appointments.ts
@@ -9,6 +9,8 @@
 
 import { query } from "../db/client";
 
+export type BookingState = "CONFIRMED_CALENDAR" | "PENDING_MANUAL_CONFIRMATION" | "FAILED";
+
 export interface CreateAppointmentInput {
   tenantId: string;
   conversationId?: string | null;
@@ -18,6 +20,7 @@ export interface CreateAppointmentInput {
   scheduledAt: string; // ISO 8601
   durationMinutes?: number;
   notes?: string | null;
+  bookingState?: BookingState;
 }
 
 export interface AppointmentRecord {
@@ -32,6 +35,7 @@ export interface AppointmentRecord {
   notes: string | null;
   googleEventId: string | null;
   calendarSynced: boolean;
+  bookingState: BookingState;
   createdAt: string;
 }
 
@@ -81,6 +85,7 @@ export async function createAppointment(
 
   // 2. Insert or upsert appointment
   const duration = input.durationMinutes ?? 60;
+  const bookingState = input.bookingState ?? "CONFIRMED_CALENDAR";
 
   try {
     let rows: Array<{
@@ -95,6 +100,7 @@ export async function createAppointment(
       notes: string | null;
       google_event_id: string | null;
       calendar_synced: boolean;
+      booking_state: string;
       created_at: string;
       xmax: string;
     }>;
@@ -104,15 +110,16 @@ export async function createAppointment(
       rows = await query(
         `INSERT INTO appointments
            (tenant_id, conversation_id, customer_phone, customer_name,
-            service_type, scheduled_at, duration_minutes, notes)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            service_type, scheduled_at, duration_minutes, notes, booking_state)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          ON CONFLICT (conversation_id) DO UPDATE SET
            customer_phone = EXCLUDED.customer_phone,
            customer_name = EXCLUDED.customer_name,
            service_type = EXCLUDED.service_type,
            scheduled_at = EXCLUDED.scheduled_at,
            duration_minutes = EXCLUDED.duration_minutes,
-           notes = EXCLUDED.notes
+           notes = EXCLUDED.notes,
+           booking_state = EXCLUDED.booking_state
          RETURNING *, xmax`,
         [
           input.tenantId,
@@ -123,6 +130,7 @@ export async function createAppointment(
           input.scheduledAt,
           duration,
           input.notes ?? null,
+          bookingState,
         ]
       );
     } else {
@@ -130,8 +138,8 @@ export async function createAppointment(
       rows = await query(
         `INSERT INTO appointments
            (tenant_id, customer_phone, customer_name,
-            service_type, scheduled_at, duration_minutes, notes)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+            service_type, scheduled_at, duration_minutes, notes, booking_state)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *, 0::text AS xmax`,
         [
           input.tenantId,
@@ -141,6 +149,7 @@ export async function createAppointment(
           input.scheduledAt,
           duration,
           input.notes ?? null,
+          bookingState,
         ]
       );
     }
@@ -172,6 +181,7 @@ export async function createAppointment(
         notes: row.notes,
         googleEventId: row.google_event_id,
         calendarSynced: row.calendar_synced,
+        bookingState: row.booking_state as BookingState,
         createdAt: row.created_at,
       },
       upserted,

--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -13,7 +13,7 @@
 
 import { query } from "../db/client";
 import { detectBookingIntent } from "./booking-intent";
-import { createAppointment } from "./appointments";
+import { createAppointment, type BookingState } from "./appointments";
 import { createCalendarEvent } from "./google-calendar";
 import { sendTwilioSms } from "./missed-call-sms";
 
@@ -36,6 +36,7 @@ export interface ProcessSmsResult {
   isBooked: boolean;
   appointmentId: string | null;
   calendarSynced: boolean;
+  bookingState: BookingState | null;
   conversationClosed: boolean;
   error: string | null;
 }
@@ -71,6 +72,7 @@ export async function processSms(
     isBooked: false,
     appointmentId: null,
     calendarSynced: false,
+    bookingState: null,
     conversationClosed: false,
     error: null,
   };
@@ -265,47 +267,18 @@ export async function processSms(
     return result;
   }
 
-  result.aiResponse = aiResponse;
-
   // ── 7. Detect booking intent ─────────────────────────────────────────────
   const intent = detectBookingIntent(aiResponse, input.body);
 
-  // ── 8. Log outbound AI message ───────────────────────────────────────────
-  try {
-    await query(
-      `INSERT INTO messages (tenant_id, conversation_id, direction, body, tokens_used, model_version)
-       VALUES ($1, $2, 'outbound', $3, $4, $5)`,
-      [input.tenantId, result.conversationId, aiResponse, tokensUsed, OPENAI_MODEL]
-    );
-  } catch {
-    // Non-fatal
-  }
+  // ── 8. If booking detected, attempt calendar sync BEFORE sending SMS ────
+  // This prevents false confirmations: the customer must not receive
+  // "appointment confirmed" unless the calendar write actually succeeded.
+  let smsBody = aiResponse; // default: send AI response as-is
 
-  // ── 9. Send SMS reply ────────────────────────────────────────────────────
-  const smsResult = await sendTwilioSms(input.customerPhone, aiResponse, fetchFn);
-  result.smsSent = !!smsResult.sid;
-
-  if (!smsResult.sid) {
-    // AI response was generated but SMS delivery failed
-    result.error = `SMS send failed: ${smsResult.error}`;
-    // Don't return — still process booking intent
-  }
-
-  // Touch conversation again after outbound
-  try {
-    await query(`SELECT touch_conversation($1, $2)`, [
-      result.conversationId,
-      input.tenantId,
-    ]);
-  } catch {
-    // Non-fatal
-  }
-
-  // ── 10. Handle booking ───────────────────────────────────────────────────
   if (intent.isBooked) {
     result.isBooked = true;
 
-    // Create appointment
+    // Create appointment (initially as PENDING until calendar confirms)
     const apptResult = await createAppointment({
       tenantId: input.tenantId,
       conversationId: result.conversationId,
@@ -313,12 +286,13 @@ export async function processSms(
       customerName: intent.customerName,
       serviceType: intent.serviceType,
       scheduledAt: intent.scheduledAt,
+      bookingState: "PENDING_MANUAL_CONFIRMATION",
     });
 
     if (apptResult.success && apptResult.appointment) {
       result.appointmentId = apptResult.appointment.id;
 
-      // Create calendar event
+      // Attempt calendar sync
       const calResult = await createCalendarEvent(
         {
           tenantId: input.tenantId,
@@ -332,33 +306,96 @@ export async function processSms(
       );
 
       result.calendarSynced = calResult.calendarSynced;
-      if (!calResult.calendarSynced && calResult.error) {
-        result.error = result.error
-          ? `${result.error}; Calendar: ${calResult.error}`
-          : `Calendar sync failed: ${calResult.error}`;
 
-        // ── Operator alert: notify shop owner about failed calendar sync ──
-        // Only alert when tokens existed but API failed (not when OAuth is unconfigured)
-        if (ownerPhone && !calResult.error.includes("No calendar tokens")) {
-          const alertBody =
-            `AutoShop AI Alert: New booking from ${input.customerPhone}` +
-            ` for ${intent.serviceType}` +
-            (intent.scheduledAt ? ` on ${intent.scheduledAt}` : "") +
-            ` could NOT be synced to Google Calendar. Please add it manually.`;
-          try {
-            await sendTwilioSms(ownerPhone, alertBody, fetchFn);
-          } catch {
-            // Non-fatal: best-effort alert
+      if (calResult.calendarSynced) {
+        // Calendar write succeeded — upgrade booking state to CONFIRMED
+        result.bookingState = "CONFIRMED_CALENDAR";
+        try {
+          await query(
+            `UPDATE appointments SET booking_state = $1 WHERE id = $2 AND tenant_id = $3`,
+            ["CONFIRMED_CALENDAR", apptResult.appointment.id, input.tenantId]
+          );
+        } catch {
+          // Non-fatal: appointment exists, state is best-effort update
+        }
+        // smsBody stays as AI response (contains confirmation language)
+      } else {
+        // Calendar sync failed — do NOT confirm to customer
+        result.bookingState = "PENDING_MANUAL_CONFIRMATION";
+        const shopLabel = shopName ?? "the shop";
+        const timeLabel = intent.scheduledAt
+          ? ` for ${new Date(intent.scheduledAt).toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
+          : "";
+        smsBody =
+          `Thanks — we've received your booking request${timeLabel}. ` +
+          `${shopLabel} will confirm shortly.`;
+
+        if (calResult.error) {
+          result.error = `Calendar sync failed: ${calResult.error}`;
+
+          // Operator alert (existing mechanism)
+          if (ownerPhone && !calResult.error.includes("No calendar tokens")) {
+            const alertBody =
+              `AutoShop AI Alert: New booking from ${input.customerPhone}` +
+              ` for ${intent.serviceType}` +
+              (intent.scheduledAt ? ` on ${intent.scheduledAt}` : "") +
+              ` could NOT be synced to Google Calendar. Please add it manually.`;
+            try {
+              await sendTwilioSms(ownerPhone, alertBody, fetchFn);
+            } catch {
+              // Non-fatal: best-effort alert
+            }
           }
         }
       }
     } else {
-      result.error = result.error
-        ? `${result.error}; Appointment: ${apptResult.error}`
-        : `Appointment creation failed: ${apptResult.error}`;
+      // Appointment creation itself failed
+      result.bookingState = "FAILED";
+      result.error = `Appointment creation failed: ${apptResult.error}`;
+      // Replace confirmation with a safe fallback
+      const shopLabel = shopName ?? "the shop";
+      smsBody =
+        `Thanks for your interest! Something went wrong on our end. ` +
+        `Please call ${shopLabel} directly to confirm your appointment.`;
     }
+  }
 
-    // Close conversation as booked
+  // ── 9. Log outbound message ────────────────────────────────────────────
+  // Log the actual message being sent (may differ from AI response if
+  // calendar sync failed and we replaced the confirmation)
+  try {
+    await query(
+      `INSERT INTO messages (tenant_id, conversation_id, direction, body, tokens_used, model_version)
+       VALUES ($1, $2, 'outbound', $3, $4, $5)`,
+      [input.tenantId, result.conversationId, smsBody, tokensUsed, OPENAI_MODEL]
+    );
+  } catch {
+    // Non-fatal
+  }
+
+  // ── 10. Send SMS reply ─────────────────────────────────────────────────
+  const smsResult = await sendTwilioSms(input.customerPhone, smsBody, fetchFn);
+  result.smsSent = !!smsResult.sid;
+  result.aiResponse = smsBody;
+
+  if (!smsResult.sid) {
+    result.error = result.error
+      ? `${result.error}; SMS send failed: ${smsResult.error}`
+      : `SMS send failed: ${smsResult.error}`;
+  }
+
+  // Touch conversation again after outbound
+  try {
+    await query(`SELECT touch_conversation($1, $2)`, [
+      result.conversationId,
+      input.tenantId,
+    ]);
+  } catch {
+    // Non-fatal
+  }
+
+  // ── 11. Close conversation if booked ───────────────────────────────────
+  if (intent.isBooked) {
     try {
       await query(`SELECT close_conversation($1, $2, $3, $4)`, [
         result.conversationId,
@@ -372,7 +409,7 @@ export async function processSms(
     }
   }
 
-  // ── 11. Handle user close request ────────────────────────────────────────
+  // ── 12. Handle user close request ────────────────────────────────────────
   if (!intent.isBooked && intent.userWantsClose) {
     try {
       await query(`SELECT close_conversation($1, $2, $3, $4)`, [

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -171,9 +171,15 @@ function setupDbMocks(options: {
         notes: null,
         google_event_id: null,
         calendar_synced: false,
+        booking_state: "PENDING_MANUAL_CONFIRMATION",
         created_at: new Date().toISOString(),
         xmax: "0",
       }];
+    }
+
+    // Update booking_state after calendar sync
+    if (sql.includes("UPDATE appointments SET booking_state")) {
+      return [];
     }
 
     // Calendar token lookup (idempotency check)
@@ -285,7 +291,7 @@ describe("processSms — booking flow", () => {
     expect(result.conversationClosed).toBe(true);
   });
 
-  it("syncs to Google Calendar when tokens available", async () => {
+  it("calendar success → CONFIRMED_CALENDAR state and confirmation message sent", async () => {
     setupDbMocks({ hasCalendarTokens: true });
     const fetchMock = mockFetchAll({
       aiResponse: "Your appointment is confirmed for Tuesday at 10 AM.",
@@ -296,9 +302,12 @@ describe("processSms — booking flow", () => {
 
     expect(result.isBooked).toBe(true);
     expect(result.calendarSynced).toBe(true);
+    expect(result.bookingState).toBe("CONFIRMED_CALENDAR");
+    // Customer receives the original AI confirmation
+    expect(result.aiResponse).toContain("appointment is confirmed");
   });
 
-  it("creates appointment even when calendar sync fails", async () => {
+  it("calendar failure → PENDING_MANUAL_CONFIRMATION state and NO confirmation message", async () => {
     setupDbMocks({ hasCalendarTokens: true });
     const fetchMock = mockFetchAll({
       aiResponse: "Your appointment is confirmed for Wednesday at 3 PM.",
@@ -310,6 +319,11 @@ describe("processSms — booking flow", () => {
     expect(result.isBooked).toBe(true);
     expect(result.appointmentId).toBe(APPOINTMENT_ID);
     expect(result.calendarSynced).toBe(false);
+    expect(result.bookingState).toBe("PENDING_MANUAL_CONFIRMATION");
+    // Customer must NOT receive "confirmed" — gets pending message instead
+    expect(result.aiResponse).not.toContain("confirmed");
+    expect(result.aiResponse).toContain("booking request");
+    expect(result.aiResponse).toContain("confirm shortly");
   });
 
   it("sends operator alert SMS when calendar sync fails and owner_phone exists", async () => {
@@ -323,16 +337,20 @@ describe("processSms — booking flow", () => {
 
     expect(result.isBooked).toBe(true);
     expect(result.calendarSynced).toBe(false);
-    // Should have sent 3 Twilio calls: AI reply SMS + operator alert SMS
+    // Should have sent 2 Twilio calls: operator alert SMS (during booking) + customer pending SMS (after)
     const twilioCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("twilio.com")
     );
     expect(twilioCalls.length).toBe(2);
-    // Second Twilio call should be the operator alert
-    const alertBody = decodeURIComponent(twilioCalls[1][1].body);
+    // First Twilio call is the operator alert (sent during booking processing)
+    const alertBody = decodeURIComponent(twilioCalls[0][1].body);
     expect(alertBody).toContain("AutoShop AI Alert");
     expect(alertBody).toContain("could NOT be synced");
     expect(alertBody).toContain(PHONE); // customer phone
+    // Second Twilio call is the customer pending message (NOT a confirmation)
+    const customerBody = decodeURIComponent(twilioCalls[1][1].body);
+    expect(customerBody).toContain("booking request");
+    expect(customerBody).not.toContain("appointment is confirmed");
   });
 
   it("does not send operator alert when no owner_phone", async () => {
@@ -346,7 +364,7 @@ describe("processSms — booking flow", () => {
 
     expect(result.isBooked).toBe(true);
     expect(result.calendarSynced).toBe(false);
-    // Should have only 1 Twilio call: AI reply SMS (no operator alert)
+    // Should have only 1 Twilio call: customer pending SMS (no operator alert)
     const twilioCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("twilio.com")
     );
@@ -363,14 +381,14 @@ describe("processSms — booking flow", () => {
 
     expect(result.isBooked).toBe(true);
     expect(result.calendarSynced).toBe(false);
-    // Should have only 1 Twilio call: AI reply SMS (no alert for unconfigured OAuth)
+    // Should have only 1 Twilio call: customer pending SMS (no alert for unconfigured OAuth)
     const twilioCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("twilio.com")
     );
     expect(twilioCalls.length).toBe(1);
   });
 
-  it("skips calendar when no tokens for tenant", async () => {
+  it("no calendar tokens → PENDING_MANUAL_CONFIRMATION and pending message", async () => {
     setupDbMocks({ hasCalendarTokens: false });
     const fetchMock = mockFetchAll({
       aiResponse: "Booking confirmed for Thursday at 9 AM.",
@@ -380,6 +398,37 @@ describe("processSms — booking flow", () => {
 
     expect(result.isBooked).toBe(true);
     expect(result.calendarSynced).toBe(false);
+    expect(result.bookingState).toBe("PENDING_MANUAL_CONFIRMATION");
+    // Customer must NOT receive confirmation language
+    expect(result.aiResponse).toContain("booking request");
+  });
+
+  it("booking_state persisted in appointment record", async () => {
+    setupDbMocks({ hasCalendarTokens: true });
+    const fetchMock = mockFetchAll({
+      aiResponse: "Your appointment is confirmed for Friday at 11 AM.",
+      googleOk: true,
+    });
+
+    await processSms(validInput(), fetchMock);
+
+    // Verify appointment was created with booking_state
+    const apptInsert = mocks.query.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO appointments")
+    );
+    expect(apptInsert).toBeDefined();
+    // booking_state should be passed as parameter (PENDING initially, then upgraded)
+    expect(apptInsert![1]).toContain("PENDING_MANUAL_CONFIRMATION");
+
+    // Verify upgrade to CONFIRMED_CALENDAR after calendar success
+    const stateUpdate = mocks.query.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        (call[0] as string).includes("UPDATE appointments SET booking_state")
+    );
+    expect(stateUpdate).toBeDefined();
+    expect(stateUpdate![1]).toContain("CONFIRMED_CALENDAR");
   });
 });
 
@@ -660,6 +709,9 @@ describe("processSms — additional edge cases", () => {
       }
       if (sql.includes("system_prompts")) return [];
       if (sql.includes("SELECT direction, body FROM messages")) return [];
+      if (sql.includes("SELECT shop_name, business_hours")) {
+        return [{ shop_name: "Joe's Auto", business_hours: null, services_description: null, owner_phone: null }];
+      }
       if (sql.includes("SELECT id FROM tenants")) {
         return [{ id: TENANT_ID }];
       }
@@ -678,6 +730,10 @@ describe("processSms — additional edge cases", () => {
     expect(result.success).toBe(true);
     expect(result.isBooked).toBe(true);
     expect(result.appointmentId).toBeNull();
+    expect(result.bookingState).toBe("FAILED");
+    // Customer should NOT receive confirmation — gets fallback message
+    expect(result.aiResponse).not.toContain("appointment is confirmed");
+    expect(result.aiResponse).toContain("call");
   });
 
   it("soft limit with Twilio failure still succeeds", async () => {
@@ -716,17 +772,22 @@ describe("processSms — additional edge cases", () => {
       }
       if (sql.includes("system_prompts")) return [];
       if (sql.includes("SELECT direction, body FROM messages")) return [];
+      if (sql.includes("SELECT shop_name, business_hours")) {
+        return [{ shop_name: "Joe's Auto", business_hours: null, services_description: null, owner_phone: null }];
+      }
       if (sql.includes("SELECT id FROM tenants")) return [{ id: TENANT_ID }];
       if (sql.includes("INSERT INTO appointments")) {
         return [{
           id: APPOINTMENT_ID, tenant_id: TENANT_ID, conversation_id: CONVERSATION_ID,
           customer_phone: PHONE, customer_name: null, service_type: "oil change",
           scheduled_at: new Date().toISOString(), duration_minutes: 60, notes: null,
-          google_event_id: null, calendar_synced: false, created_at: new Date().toISOString(), xmax: "0",
+          google_event_id: null, calendar_synced: false, booking_state: "PENDING_MANUAL_CONFIRMATION",
+          created_at: new Date().toISOString(), xmax: "0",
         }];
       }
       if (sql.includes("SELECT google_event_id FROM appointments")) return [];
       if (sql.includes("SELECT access_token")) return [];
+      if (sql.includes("UPDATE appointments SET booking_state")) return [];
       if (sql.includes("close_conversation")) {
         throw new Error("DB connection lost during close");
       }

--- a/db/migrations/017_booking_state.sql
+++ b/db/migrations/017_booking_state.sql
@@ -1,0 +1,15 @@
+-- Add booking_state column to appointments
+-- Tracks whether the booking was confirmed via calendar or requires manual confirmation.
+--
+-- Values:
+--   CONFIRMED_CALENDAR         — Google Calendar event created successfully
+--   PENDING_MANUAL_CONFIRMATION — Calendar sync failed; shop must confirm manually
+--   FAILED                     — Appointment creation or critical step failed
+
+ALTER TABLE appointments
+  ADD COLUMN booking_state TEXT NOT NULL DEFAULT 'CONFIRMED_CALENDAR';
+
+-- Backfill: existing rows with calendar_synced = FALSE should be PENDING
+UPDATE appointments
+  SET booking_state = 'PENDING_MANUAL_CONFIRMATION'
+  WHERE calendar_synced = FALSE AND google_event_id IS NULL;


### PR DESCRIPTION
## Summary

- **Fixes a critical live-path correctness bug**: the AI told customers "appointment confirmed" *before* Google Calendar sync succeeded. If sync failed, the customer believed they had a booking that didn't exist on the shop calendar.
- Restructured `process-sms` flow so appointment creation + calendar sync happen **before** sending the customer SMS. Calendar success → confirmation message. Calendar failure → "we've received your request, the shop will confirm shortly."
- Introduced `booking_state` column (`CONFIRMED_CALENDAR` | `PENDING_MANUAL_CONFIRMATION` | `FAILED`) on the appointments table to durably track the true state of each booking.
- Operator SMS alert on calendar failure is preserved (existing mechanism).
- No silent failure paths: every booking outcome is tracked and the customer always receives an honest message.

## Files changed

| File | Change |
|------|--------|
| `apps/api/src/services/process-sms.ts` | Reorder: calendar sync before SMS send; replace confirmation on failure |
| `apps/api/src/services/appointments.ts` | Add `BookingState` type and `bookingState` field |
| `apps/api/src/tests/process-sms.test.ts` | Add tests for confirmed/pending/failed states; update existing booking tests |
| `db/migrations/017_booking_state.sql` | Add `booking_state` column with backfill |

## Test plan

- [x] Calendar sync success → `CONFIRMED_CALENDAR` state, confirmation message sent
- [x] Calendar sync failure → `PENDING_MANUAL_CONFIRMATION` state, pending message sent (no "confirmed")
- [x] Appointment creation failure → `FAILED` state, safe fallback message
- [x] Operator SMS alert still triggered on calendar failure
- [x] `booking_state` persisted correctly in appointment record
- [x] Full test suite: 18 files, 293/293 tests passed
- [x] Lint: 0 errors
- [x] Build (tsc): passed
- [x] Docker build: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)