### PR TITLE
feat: surface booking_state in admin dashboard and tenant app

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -110,6 +110,8 @@ export async function adminRoute(app: FastifyInstance) {
       needsAttentionRows,
       recentBillingEventsRows,
       recentConversationsRows,
+      pendingManualRows,
+      failedBookingsRows,
     ] = await Promise.all([
       query(`SELECT billing_status, COUNT(*) as count FROM tenants WHERE is_test = FALSE GROUP BY billing_status`),
       query(`SELECT COUNT(*)::int FROM tenants WHERE created_at > NOW() - INTERVAL '7 days' AND is_test = FALSE`),
@@ -140,6 +142,8 @@ export async function adminRoute(app: FastifyInstance) {
          FROM conversations c JOIN tenants t ON t.id = c.tenant_id
          WHERE t.is_test = FALSE
          ORDER BY c.opened_at DESC LIMIT 5`),
+      query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.booking_state = 'PENDING_MANUAL_CONFIRMATION'`),
+      query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.booking_state = 'FAILED'`),
     ]);
 
     // Build status map
@@ -166,6 +170,8 @@ export async function adminRoute(app: FastifyInstance) {
       needs_attention: needsAttentionRows,
       recent_billing_events: recentBillingEventsRows,
       recent_conversations: recentConversationsRows,
+      pending_manual_bookings: (pendingManualRows as any[])[0]?.count ?? 0,
+      failed_bookings: (failedBookingsRows as any[])[0]?.count ?? 0,
     });
   });
 
@@ -255,7 +261,7 @@ export async function adminRoute(app: FastifyInstance) {
       query(`SELECT id, calendar_id, connected_at, last_refreshed, token_expiry FROM tenant_calendar_tokens WHERE tenant_id = $1`, [id]),
       query(`SELECT id, customer_phone, status, turn_count, opened_at, last_message_at, closed_at, close_reason
          FROM conversations WHERE tenant_id = $1 ORDER BY opened_at DESC LIMIT 20`, [id]),
-      query(`SELECT id, customer_phone, customer_name, service_type, scheduled_at, calendar_synced, google_event_id, created_at
+      query(`SELECT id, customer_phone, customer_name, service_type, scheduled_at, calendar_synced, google_event_id, booking_state, created_at
          FROM appointments WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 10`, [id]),
       query(`SELECT id, event_type, processed_at, payload FROM billing_events WHERE tenant_id = $1 ORDER BY processed_at DESC LIMIT 20`, [id]),
       query(`SELECT id, event_type, actor, metadata, created_at FROM audit_log WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 20`, [id]),
@@ -293,6 +299,7 @@ export async function adminRoute(app: FastifyInstance) {
          c.opened_at, c.last_message_at, c.closed_at, c.close_reason,
          EXISTS(SELECT 1 FROM appointments a WHERE a.conversation_id = c.id) as has_booking,
          (SELECT calendar_synced FROM appointments a WHERE a.conversation_id = c.id LIMIT 1) as booking_synced,
+         (SELECT booking_state FROM appointments a WHERE a.conversation_id = c.id LIMIT 1) as booking_state,
          (SELECT COUNT(*)::int FROM messages m WHERE m.conversation_id = c.id) as message_count
        FROM conversations c
        JOIN tenants t ON t.id = c.tenant_id
@@ -337,7 +344,7 @@ export async function adminRoute(app: FastifyInstance) {
     const bookings = await query(
       `SELECT a.id, a.tenant_id, t.shop_name, a.customer_phone, a.customer_name,
          a.service_type, a.scheduled_at, a.calendar_synced, a.google_event_id, a.created_at,
-         a.conversation_id,
+         a.conversation_id, a.booking_state,
          CASE WHEN NOT a.calendar_synced AND a.google_event_id IS NULL THEN 'sync_failed'
               WHEN NOT a.calendar_synced THEN 'pending'
               ELSE 'synced' END as sync_status

--- a/apps/api/src/routes/tenant/dashboard.ts
+++ b/apps/api/src/routes/tenant/dashboard.ts
@@ -104,7 +104,7 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
       query(
         `SELECT id, conversation_id, customer_phone, customer_name,
                 service_type, scheduled_at, calendar_synced,
-                google_event_id, created_at
+                google_event_id, booking_state, created_at
          FROM appointments
          WHERE tenant_id = $1
          ORDER BY created_at DESC LIMIT 20`,

--- a/apps/api/src/tests/admin-booking-state.test.ts
+++ b/apps/api/src/tests/admin-booking-state.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+vi.mock("bcryptjs", () => ({
+  compare: vi.fn().mockResolvedValue(true),
+  hash: vi.fn().mockResolvedValue("$2a$12$hashed"),
+}));
+
+// Bypass adminGuard — it requires JWT verification which isn't relevant here
+vi.mock("../middleware/admin-guard", () => ({
+  adminGuard: async () => {},
+}));
+
+import { adminRoute } from "../routes/internal/admin";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+
+  // Stub adminGuard to always pass
+  app.decorate("adminGuard", async () => {});
+  app.register(
+    async (instance) => {
+      await adminRoute(instance);
+    },
+    { prefix: "/internal" },
+  );
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /internal/admin/bookings — booking_state visibility", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("returns booking_state for each booking row", async () => {
+    const fakeBookings = [
+      {
+        id: "b1",
+        tenant_id: "t1",
+        shop_name: "Shop A",
+        customer_phone: "+1111",
+        customer_name: "Alice",
+        service_type: "Oil Change",
+        scheduled_at: "2026-03-15T10:00:00Z",
+        calendar_synced: true,
+        google_event_id: "evt1",
+        created_at: "2026-03-15T09:00:00Z",
+        conversation_id: "c1",
+        booking_state: "CONFIRMED_CALENDAR",
+        sync_status: "synced",
+      },
+      {
+        id: "b2",
+        tenant_id: "t1",
+        shop_name: "Shop A",
+        customer_phone: "+2222",
+        customer_name: "Bob",
+        service_type: "Brake Repair",
+        scheduled_at: "2026-03-15T14:00:00Z",
+        calendar_synced: false,
+        google_event_id: null,
+        created_at: "2026-03-15T13:00:00Z",
+        conversation_id: "c2",
+        booking_state: "PENDING_MANUAL_CONFIRMATION",
+        sync_status: "sync_failed",
+      },
+      {
+        id: "b3",
+        tenant_id: "t2",
+        shop_name: "Shop B",
+        customer_phone: "+3333",
+        customer_name: "Carol",
+        service_type: "Tire Rotation",
+        scheduled_at: "2026-03-15T16:00:00Z",
+        calendar_synced: false,
+        google_event_id: null,
+        created_at: "2026-03-15T15:00:00Z",
+        conversation_id: "c3",
+        booking_state: "FAILED",
+        sync_status: "sync_failed",
+      },
+    ];
+    mocks.query.mockResolvedValueOnce(fakeBookings);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/admin/bookings",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.bookings).toHaveLength(3);
+
+    // CONFIRMED_CALENDAR is returned
+    expect(body.bookings[0].booking_state).toBe("CONFIRMED_CALENDAR");
+
+    // PENDING_MANUAL_CONFIRMATION is returned
+    expect(body.bookings[1].booking_state).toBe("PENDING_MANUAL_CONFIRMATION");
+
+    // FAILED is returned
+    expect(body.bookings[2].booking_state).toBe("FAILED");
+  });
+});
+
+describe("GET /internal/admin/overview — booking_state counts", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("returns pending_manual_bookings and failed_bookings counts", async () => {
+    // The overview endpoint runs 16 parallel queries
+    // We need to mock all of them in order
+    const overviewMocks = [
+      [{ billing_status: "active", count: "2" }], // statusCountsRows
+      [{ count: 1 }],  // newSignupsRows
+      [],               // signupAttemptsByStatusRows
+      [{ count: 3 }],  // convsTodayRows
+      [{ count: 2 }],  // bookingsTodayRows
+      [{ count: 1 }],  // failedCalendarSyncsRows
+      [{ count: 0 }],  // noTwilioRows
+      [{ count: 0 }],  // noCalendarRows
+      [{ count: 0 }],  // nearExpiryRows
+      [{ count: 0 }],  // highUsageRows
+      [],               // recentSignupsRows
+      [],               // needsAttentionRows
+      [],               // recentBillingEventsRows
+      [],               // recentConversationsRows
+      [{ count: 4 }],  // pendingManualRows
+      [{ count: 2 }],  // failedBookingsRows
+    ];
+    for (const mock of overviewMocks) {
+      mocks.query.mockResolvedValueOnce(mock);
+    }
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/admin/overview",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.pending_manual_bookings).toBe(4);
+    expect(body.failed_bookings).toBe(2);
+  });
+});
+
+describe("GET /internal/admin/tenants/:id — booking_state in tenant bookings", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("returns booking_state in tenant detail bookings", async () => {
+    const tenantId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    const tenantDetailMocks = [
+      [{ id: tenantId, shop_name: "Test Shop" }], // tenantRows
+      [],  // usersRows
+      [],  // phoneRows
+      [],  // calendarRows
+      [],  // conversationRows
+      [    // bookingRows
+        {
+          id: "b1",
+          customer_phone: "+1111",
+          customer_name: "Alice",
+          service_type: "Oil Change",
+          scheduled_at: "2026-03-15T10:00:00Z",
+          calendar_synced: true,
+          google_event_id: "evt1",
+          booking_state: "CONFIRMED_CALENDAR",
+          created_at: "2026-03-15T09:00:00Z",
+        },
+        {
+          id: "b2",
+          customer_phone: "+2222",
+          customer_name: "Bob",
+          service_type: "Brake Repair",
+          scheduled_at: "2026-03-15T14:00:00Z",
+          calendar_synced: false,
+          google_event_id: null,
+          booking_state: "PENDING_MANUAL_CONFIRMATION",
+          created_at: "2026-03-15T13:00:00Z",
+        },
+      ],
+      [],  // billingEventRows
+      [],  // auditRows
+      [{ conv_used_this_cycle: 5, conv_limit_this_cycle: 50, usage_pct: 10 }], // usageRows
+    ];
+    for (const mock of tenantDetailMocks) {
+      mocks.query.mockResolvedValueOnce(mock);
+    }
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${tenantId}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.bookings).toHaveLength(2);
+    expect(body.bookings[0].booking_state).toBe("CONFIRMED_CALENDAR");
+    expect(body.bookings[1].booking_state).toBe("PENDING_MANUAL_CONFIRMATION");
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -149,6 +149,11 @@ body{background:var(--bg);color:var(--white);font-family:var(--body);line-height
 .badge.pending::before{background:var(--amber);}
 .badge.sync_failed,.badge.failed{background:var(--red-dim);color:var(--red);border:1px solid rgba(220,38,38,.2);}
 .badge.sync_failed::before,.badge.failed::before{background:var(--red);}
+.badge.confirmed_calendar{background:var(--green-dim);color:#15803d;border:1px solid rgba(22,163,74,.2);}
+.badge.confirmed_calendar::before{background:var(--green);}
+.badge.pending_manual_confirmation{background:rgba(217,119,6,.08);color:#b45309;border:1px solid rgba(217,119,6,.2);font-weight:600;}
+.badge.pending_manual_confirmation::before{background:var(--amber);animation:pulse-amber 1.5s infinite;}
+@keyframes pulse-amber{0%,100%{opacity:1}50%{opacity:.4}}
 .badge.open{background:rgba(37,99,235,.06);color:var(--rust);border:1px solid rgba(37,99,235,.2);}
 .badge.open::before{background:var(--rust);}
 .badge.booked{background:var(--green-dim);color:#15803d;border:1px solid rgba(22,163,74,.2);}
@@ -484,6 +489,16 @@ function statusBadge(status) {
   return `<span class="badge ${s}">${label}</span>`;
 }
 
+function bookingStateBadge(state) {
+  const map = {
+    'CONFIRMED_CALENDAR': { cls: 'confirmed_calendar', label: 'Confirmed' },
+    'PENDING_MANUAL_CONFIRMATION': { cls: 'pending_manual_confirmation', label: 'Needs Manual Confirmation' },
+    'FAILED': { cls: 'failed', label: 'Failed' },
+  };
+  const m = map[state] || { cls: 'unknown', label: state || '—' };
+  return `<span class="badge ${m.cls}">${m.label}</span>`;
+}
+
 function relTime(iso) {
   if (!iso) return '—';
   const d = new Date(iso);
@@ -578,6 +593,8 @@ async function loadOverview() {
       <div class="section-label">Alerts</div>
       <div class="stat-grid">
         <div class="stat-card red"><div class="stat-tag">Failed Syncs</div><div class="stat-val ${d.failed_calendar_syncs > 0 ? 'red' : ''}">${d.failed_calendar_syncs}</div><div class="stat-sub">cal sync &gt;1h</div></div>
+        <div class="stat-card red"><div class="stat-tag">Needs Manual Confirm</div><div class="stat-val ${d.pending_manual_bookings > 0 ? 'red' : ''}">${d.pending_manual_bookings}</div><div class="stat-sub">booking action needed</div></div>
+        <div class="stat-card red"><div class="stat-tag">Failed Bookings</div><div class="stat-val ${d.failed_bookings > 0 ? 'red' : ''}">${d.failed_bookings}</div><div class="stat-sub">booking failed</div></div>
         <div class="stat-card amber"><div class="stat-tag">No Twilio</div><div class="stat-val ${d.no_twilio > 0 ? 'red' : ''}">${d.no_twilio}</div><div class="stat-sub">no active phone</div></div>
         <div class="stat-card amber"><div class="stat-tag">No Calendar</div><div class="stat-val ${d.no_calendar > 0 ? 'amber' : ''}">${d.no_calendar}</div><div class="stat-sub">not connected</div></div>
         <div class="stat-card amber"><div class="stat-tag">Near Expiry</div><div class="stat-val ${d.near_expiry > 0 ? 'amber' : ''}">${d.near_expiry}</div><div class="stat-sub">trial ≤3 days</div></div>
@@ -898,13 +915,13 @@ function renderAccountDetail(d) {
           <div class="table-header"><span class="table-title">Recent Bookings</span></div>
           ${d.bookings && d.bookings.length > 0 ? `
           <table class="data-table">
-            <thead><tr><th>Customer</th><th>Name</th><th>Service</th><th>Scheduled</th><th>Cal Synced</th><th>Google Event ID</th><th>Created</th></tr></thead>
+            <thead><tr><th>Customer</th><th>Name</th><th>Service</th><th>Scheduled</th><th>Booking Status</th><th>Google Event ID</th><th>Created</th></tr></thead>
             <tbody>${d.bookings.map(b => `<tr>
               <td class="mono dim">${escHtml(b.customer_phone)}</td>
               <td>${escHtml(b.customer_name || '—')}</td>
               <td>${escHtml(b.service_type || '—')}</td>
               <td class="mono dim">${fmtDate(b.scheduled_at)}</td>
-              <td>${boolIcon(b.calendar_synced)}</td>
+              <td>${bookingStateBadge(b.booking_state)}</td>
               <td class="mono dim" style="font-size:10px">${escHtml(b.google_event_id || '—')}</td>
               <td class="mono dim">${relTime(b.created_at)}</td>
             </tr>`).join('')}
@@ -1228,7 +1245,7 @@ function loadBookings(filter) {
         <td>${escHtml(b.service_type || '—')}</td>
         <td class="mono dim">${fmtDate(b.scheduled_at)}</td>
         <td class="mono dim">${relTime(b.created_at)}</td>
-        <td>${statusBadge(b.sync_status)}</td>
+        <td>${bookingStateBadge(b.booking_state)}</td>
         <td class="mono dim" style="font-size:10px">${escHtml(b.google_event_id || '—')}</td>
         <td>${b.conversation_id ? `<button class="link-btn" onclick="loadConversationDetail('${b.conversation_id}')">View</button>` : '—'}</td>
       </tr>`).join('') : `<tr><td colspan="9">${renderEmpty('No bookings match')}</td></tr>`;
@@ -1240,7 +1257,7 @@ function loadBookings(filter) {
           <table class="data-table">
             <thead><tr>
               <th>Shop</th><th>Customer Name</th><th>Phone</th><th>Service</th>
-              <th>Scheduled At</th><th>Created</th><th>Sync Status</th><th>Google Event ID</th><th>Conv</th>
+              <th>Scheduled At</th><th>Created</th><th>Booking Status</th><th>Google Event ID</th><th>Conv</th>
             </tr></thead>
             <tbody>${tbody}</tbody>
           </table>

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -1113,14 +1113,20 @@ async function loadDashboardData() {
 
     // ── Map bookings ──
     bookingsData = (data.recent_bookings || []).map(function(b) {
-      var syncStatus = b.calendar_synced ? 'synced' : (b.google_event_id ? 'pending' : 'failed');
+      var stateMap = {
+        'CONFIRMED_CALENDAR': { status: 'synced', label: 'Confirmed', note: '' },
+        'PENDING_MANUAL_CONFIRMATION': { status: 'pending', label: 'Needs Manual Confirmation', note: 'Calendar sync failed — confirm this booking manually.' },
+        'FAILED': { status: 'failed', label: 'Failed', note: 'Booking failed — contact customer to reschedule.' },
+      };
+      var mapped = stateMap[b.booking_state] || { status: b.calendar_synced ? 'synced' : 'failed', label: b.calendar_synced ? 'Confirmed' : 'Failed', note: '' };
       return {
         date: fmtDate(b.scheduled_at || b.created_at),
         phone: fmtPhone(b.customer_phone),
         service: b.service_type || 'Appointment',
         vehicle: b.customer_name || '—',
-        syncStatus: syncStatus,
-        failNote: syncStatus === 'failed' ? 'Not synced to Google Calendar.' : ''
+        syncStatus: mapped.status,
+        syncLabel: mapped.label,
+        failNote: mapped.note
       };
     });
 
@@ -1484,10 +1490,12 @@ function renderBookingsCalendarAlert() {
 
 function renderBookings() {
   const html = bookingsData.map(b => {
-    const syncEl = `<span class="status-pill ${b.syncStatus}">${b.syncStatus.charAt(0).toUpperCase() + b.syncStatus.slice(1)}</span>`;
+    const syncEl = `<span class="status-pill ${b.syncStatus}">${b.syncLabel || b.syncStatus.charAt(0).toUpperCase() + b.syncStatus.slice(1)}</span>`;
     const failNote = b.failNote ? `<div style="font-family:var(--mono);font-size:11px;color:var(--red);margin-top:4px;">${b.failNote}</div>` : '';
     const action = b.syncStatus === 'failed'
       ? `<button class="view-btn red" onclick="showToast('Retrying calendar sync...')">Retry Sync</button>`
+      : b.syncStatus === 'pending'
+      ? `<span style="font-family:var(--mono);font-size:11px;color:var(--amber);font-weight:600;">Action Needed</span>`
       : `<span style="font-family:var(--mono);font-size:11px;color:var(--steel);">—</span>`;
     return `<tr>
       <td class="td-date">${b.date}</td>


### PR DESCRIPTION
## Summary

- **Surfaces `booking_state` in all admin and tenant booking views** so operators can immediately see which bookings are confirmed, need manual confirmation, or failed
- **Adds action-needed counts** (pending manual + failed) to admin overview alerts section
- **Uses `booking_state` as source of truth** in tenant app instead of inferring sync status from `calendar_synced`/`google_event_id`

## Why this matters

After PR #115 correctly gated customer confirmations on calendar sync success, `booking_state` is persisted in the database — but operators had no way to see it. Bookings needing manual confirmation could be silently missed. This change closes the visibility gap for pilot reliability.

## Changes

### Backend (API responses now include `booking_state`)
- `GET /internal/admin/bookings` — adds `booking_state` column
- `GET /internal/admin/overview` — adds `pending_manual_bookings` and `failed_bookings` counts
- `GET /internal/admin/tenants/:id` — bookings include `booking_state`
- `GET /internal/admin/conversations` — includes `booking_state` from linked appointment
- `GET /tenant/dashboard` — recent bookings include `booking_state`

### Frontend (operator-visible status)
- Admin bookings table: shows color-coded badges (Confirmed / Needs Manual Confirmation / Failed)
- Admin overview: new alert cards for pending manual and failed booking counts
- Admin tenant detail: booking_state shown in bookings tab
- Tenant app: booking status derived from `booking_state` with human-readable labels and "Action Needed" indicator

### Tests
- `admin-booking-state.test.ts`: 3 tests covering bookings list, overview counts, and tenant detail

## Test plan

- [x] All 296 tests pass (19 test files, 0 failures)
- [ ] Verify admin bookings page shows booking_state badges correctly
- [ ] Verify admin overview shows pending_manual_bookings and failed_bookings counts
- [ ] Verify tenant app bookings view shows correct status labels
- [ ] Verify PENDING_MANUAL_CONFIRMATION bookings are visually distinct (amber badge with pulse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)