### PR TITLE
feat: operator action workflow for action-needed bookings

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,48 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: booking-action-workflow — 2026-03-15
+
+**Branch:** ai/booking-action-workflow
+**Status:** COMPLETE — Operator action workflow for action-needed bookings
+
+### Selected Task
+Turn action-needed bookings (PENDING_MANUAL_CONFIRMATION, FAILED) into an actionable operator workflow in the admin dashboard.
+
+### Why This Is Highest Leverage
+Visibility alone is not enough. Operators can see action-needed bookings but cannot close them from the dashboard. This means:
+- Action-needed bookings pile up with no closure mechanism
+- Operators revert to ad-hoc phone/memory workflows
+- The dashboard is a passive monitor, not an operational tool
+
+This task closes the final gap in the booking path: booking detected → booking resolved.
+
+### State Transitions Implemented
+- `PENDING_MANUAL_CONFIRMATION` → `CONFIRMED_MANUAL` (operator marks as manually confirmed)
+- `FAILED` → `RESOLVED` (operator marks failed booking as resolved)
+- Invalid transitions are rejected with 409
+
+### Changes
+- `apps/api/src/services/appointments.ts` — Extended BookingState type with CONFIRMED_MANUAL, RESOLVED
+- `apps/api/src/routes/internal/admin.ts` — Added GET /admin/bookings/action-needed, PATCH /admin/bookings/:id/state with transition validation and audit logging
+- `apps/web/admin.html` — Added Action Needed sidebar nav with badge count, dedicated action-needed page with operator action buttons, action buttons in main bookings list, updated badge labels for truthful distinction
+- `apps/web/app.html` — Updated tenant dashboard state map with new states
+- `apps/api/src/tests/admin-booking-state.test.ts` — Added 8 new tests: action-needed endpoint, allowed transitions, rejected invalid transitions, 404, invalid state
+
+### Verification
+```
+VERIFICATION
+EXIT_CODE=0
+TEST_FILES=19
+TESTS_TOTAL=304
+TESTS_FAILED=0
+DURATION=4.72s
+```
+- All 304 tests pass (19 test files)
+- 8 new tests for booking state transitions
+
+---
+
 ## TASK: live-env-hardening — 2026-03-15
 
 **Branch:** ai/live-env-hardening

--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -357,6 +357,7 @@ export async function adminRoute(app: FastifyInstance) {
               WHEN $1 = 'synced'    THEN a.calendar_synced
               WHEN $1 = 'today'     THEN a.scheduled_at::date = CURRENT_DATE
               WHEN $1 = 'upcoming'  THEN a.scheduled_at > NOW()
+              WHEN $1 = 'action_needed' THEN a.booking_state IN ('PENDING_MANUAL_CONFIRMATION', 'FAILED')
               ELSE true END
        )
        AND ($2::uuid IS NULL OR a.tenant_id = $2)
@@ -366,6 +367,105 @@ export async function adminRoute(app: FastifyInstance) {
     );
 
     return reply.status(200).send({ count: (bookings as any[]).length, bookings, page });
+  });
+
+  // ── GET /internal/admin/bookings/action-needed ─────────────────────────────
+  app.get("/admin/bookings/action-needed", { preHandler: [adminGuard] }, async (_req, reply) => {
+    const bookings = await query(
+      `SELECT a.id, a.tenant_id, t.shop_name, a.customer_phone, a.customer_name,
+         a.service_type, a.scheduled_at, a.calendar_synced, a.google_event_id, a.created_at,
+         a.conversation_id, a.booking_state
+       FROM appointments a
+       JOIN tenants t ON t.id = a.tenant_id
+       WHERE t.is_test = FALSE
+         AND a.booking_state IN ('PENDING_MANUAL_CONFIRMATION', 'FAILED')
+       ORDER BY a.created_at DESC
+       LIMIT 100`
+    );
+
+    return reply.status(200).send({ count: (bookings as any[]).length, bookings });
+  });
+
+  // ── PATCH /internal/admin/bookings/:id/state ──────────────────────────────
+  const BookingStateTransitionSchema = z.object({
+    booking_state: z.enum(["CONFIRMED_MANUAL", "RESOLVED"]),
+  });
+
+  const ALLOWED_TRANSITIONS: Record<string, string[]> = {
+    PENDING_MANUAL_CONFIRMATION: ["CONFIRMED_MANUAL"],
+    FAILED: ["RESOLVED"],
+  };
+
+  app.patch("/admin/bookings/:id/state", { preHandler: [adminGuard] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const parsed = BookingStateTransitionSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`),
+      });
+    }
+
+    const newState = parsed.data.booking_state;
+
+    // Fetch current booking state
+    const rows = await query<{ booking_state: string }>(
+      `SELECT booking_state FROM appointments WHERE id = $1`,
+      [id]
+    );
+
+    if ((rows as any[]).length === 0) {
+      return reply.status(404).send({ error: "Booking not found" });
+    }
+
+    const currentState = (rows as any[])[0].booking_state;
+    const allowed = ALLOWED_TRANSITIONS[currentState];
+
+    if (!allowed || !allowed.includes(newState)) {
+      return reply.status(409).send({
+        error: "Invalid state transition",
+        current_state: currentState,
+        requested_state: newState,
+        allowed_transitions: allowed || [],
+      });
+    }
+
+    // Perform the transition
+    await query(
+      `UPDATE appointments SET booking_state = $1 WHERE id = $2`,
+      [newState, id]
+    );
+
+    // Audit log entry if audit_log table exists
+    try {
+      const tenantRows = await query<{ tenant_id: string }>(
+        `SELECT tenant_id FROM appointments WHERE id = $1`,
+        [id]
+      );
+      const tenantId = (tenantRows as any[])[0]?.tenant_id;
+      if (tenantId) {
+        await query(
+          `INSERT INTO audit_log (tenant_id, event_type, actor, metadata)
+           VALUES ($1, $2, $3, $4)`,
+          [
+            tenantId,
+            "booking_state_change",
+            "admin",
+            JSON.stringify({ booking_id: id, from: currentState, to: newState }),
+          ]
+        );
+      }
+    } catch (_) {
+      // Non-critical — don't fail the transition if audit logging fails
+    }
+
+    return reply.status(200).send({
+      success: true,
+      booking_id: id,
+      previous_state: currentState,
+      booking_state: newState,
+    });
   });
 
   // ── GET /internal/admin/billing ─────────────────────────────────────────────

--- a/apps/api/src/services/appointments.ts
+++ b/apps/api/src/services/appointments.ts
@@ -9,7 +9,7 @@
 
 import { query } from "../db/client";
 
-export type BookingState = "CONFIRMED_CALENDAR" | "PENDING_MANUAL_CONFIRMATION" | "FAILED";
+export type BookingState = "CONFIRMED_CALENDAR" | "PENDING_MANUAL_CONFIRMATION" | "FAILED" | "CONFIRMED_MANUAL" | "RESOLVED";
 
 export interface CreateAppointmentInput {
   tenantId: string;

--- a/apps/api/src/tests/admin-booking-state.test.ts
+++ b/apps/api/src/tests/admin-booking-state.test.ts
@@ -222,3 +222,152 @@ describe("GET /internal/admin/tenants/:id — booking_state in tenant bookings",
     expect(body.bookings[1].booking_state).toBe("PENDING_MANUAL_CONFIRMATION");
   });
 });
+
+// ── Action-needed endpoint tests ─────────────────────────────────────────────
+
+describe("GET /internal/admin/bookings/action-needed", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("returns only PENDING_MANUAL_CONFIRMATION and FAILED bookings", async () => {
+    const fakeBookings = [
+      { id: "b1", tenant_id: "t1", shop_name: "Shop A", booking_state: "PENDING_MANUAL_CONFIRMATION" },
+      { id: "b2", tenant_id: "t1", shop_name: "Shop A", booking_state: "FAILED" },
+    ];
+    mocks.query.mockResolvedValueOnce(fakeBookings);
+
+    const app = buildApp();
+    const res = await app.inject({ method: "GET", url: "/internal/admin/bookings/action-needed" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.count).toBe(2);
+    expect(body.bookings[0].booking_state).toBe("PENDING_MANUAL_CONFIRMATION");
+    expect(body.bookings[1].booking_state).toBe("FAILED");
+  });
+});
+
+// ── State transition tests ───────────────────────────────────────────────────
+
+describe("PATCH /internal/admin/bookings/:id/state — booking state transitions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("allows PENDING_MANUAL_CONFIRMATION → CONFIRMED_MANUAL", async () => {
+    // SELECT booking_state
+    mocks.query.mockResolvedValueOnce([{ booking_state: "PENDING_MANUAL_CONFIRMATION" }]);
+    // UPDATE
+    mocks.query.mockResolvedValueOnce([]);
+    // SELECT tenant_id for audit
+    mocks.query.mockResolvedValueOnce([{ tenant_id: "t1" }]);
+    // INSERT audit_log
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b1/state",
+      payload: { booking_state: "CONFIRMED_MANUAL" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.previous_state).toBe("PENDING_MANUAL_CONFIRMATION");
+    expect(body.booking_state).toBe("CONFIRMED_MANUAL");
+  });
+
+  it("allows FAILED → RESOLVED", async () => {
+    mocks.query.mockResolvedValueOnce([{ booking_state: "FAILED" }]);
+    mocks.query.mockResolvedValueOnce([]);
+    mocks.query.mockResolvedValueOnce([{ tenant_id: "t1" }]);
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b2/state",
+      payload: { booking_state: "RESOLVED" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.previous_state).toBe("FAILED");
+    expect(body.booking_state).toBe("RESOLVED");
+  });
+
+  it("rejects invalid transition: CONFIRMED_CALENDAR → RESOLVED", async () => {
+    mocks.query.mockResolvedValueOnce([{ booking_state: "CONFIRMED_CALENDAR" }]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b3/state",
+      payload: { booking_state: "RESOLVED" },
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.error).toBe("Invalid state transition");
+    expect(body.current_state).toBe("CONFIRMED_CALENDAR");
+  });
+
+  it("rejects invalid transition: PENDING_MANUAL_CONFIRMATION → RESOLVED", async () => {
+    mocks.query.mockResolvedValueOnce([{ booking_state: "PENDING_MANUAL_CONFIRMATION" }]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b4/state",
+      payload: { booking_state: "RESOLVED" },
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.error).toBe("Invalid state transition");
+  });
+
+  it("rejects invalid transition: FAILED → CONFIRMED_MANUAL", async () => {
+    mocks.query.mockResolvedValueOnce([{ booking_state: "FAILED" }]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b5/state",
+      payload: { booking_state: "CONFIRMED_MANUAL" },
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.error).toBe("Invalid state transition");
+  });
+
+  it("returns 404 for non-existent booking", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/nonexistent/state",
+      payload: { booking_state: "CONFIRMED_MANUAL" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects invalid booking_state value", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/internal/admin/bookings/b1/state",
+      payload: { booking_state: "INVALID_STATE" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -154,6 +154,17 @@ body{background:var(--bg);color:var(--white);font-family:var(--body);line-height
 .badge.pending_manual_confirmation{background:rgba(217,119,6,.08);color:#b45309;border:1px solid rgba(217,119,6,.2);font-weight:600;}
 .badge.pending_manual_confirmation::before{background:var(--amber);animation:pulse-amber 1.5s infinite;}
 @keyframes pulse-amber{0%,100%{opacity:1}50%{opacity:.4}}
+.badge.confirmed_manual{background:rgba(22,163,74,.08);color:#15803d;border:1px solid rgba(22,163,74,.2);}
+.badge.confirmed_manual::before{background:var(--green);}
+.badge.resolved{background:rgba(107,114,128,.08);color:var(--steel);border:1px solid rgba(107,114,128,.15);}
+.badge.resolved::before{background:var(--steel);}
+.action-btn{font-family:var(--body);font-size:12px;font-weight:600;padding:6px 14px;border:1px solid var(--border);background:var(--bg-panel);cursor:pointer;border-radius:6px;transition:all .15s;white-space:nowrap;}
+.action-btn:hover{border-color:var(--border-mid);box-shadow:0 1px 3px rgba(0,0,0,.06);}
+.action-btn.confirm{color:#15803d;border-color:rgba(22,163,74,.3);background:rgba(22,163,74,.06);}
+.action-btn.confirm:hover{background:rgba(22,163,74,.12);}
+.action-btn.resolve{color:var(--rust);border-color:rgba(59,130,246,.3);background:rgba(59,130,246,.06);}
+.action-btn.resolve:hover{background:rgba(59,130,246,.12);}
+.action-btn:disabled{opacity:.5;cursor:not-allowed;}
 .badge.open{background:rgba(37,99,235,.06);color:var(--rust);border:1px solid rgba(37,99,235,.2);}
 .badge.open::before{background:var(--rust);}
 .badge.booked{background:var(--green-dim);color:#15803d;border:1px solid rgba(22,163,74,.2);}
@@ -312,6 +323,10 @@ body{background:var(--bg);color:var(--white);font-family:var(--body);line-height
       </div>
       <div class="sidebar-item" data-section="bookings" onclick="navigate('bookings')">
         <span class="sidebar-icon">◷</span> Bookings
+      </div>
+      <div class="sidebar-item" data-section="action-needed" onclick="navigate('action-needed')">
+        <span class="sidebar-icon">⚑</span> Action Needed
+        <span class="sidebar-badge" id="actionNeededBadge" style="display:none">0</span>
       </div>
       <div class="sidebar-label">Finance</div>
       <div class="sidebar-item" data-section="billing" onclick="navigate('billing')">
@@ -472,6 +487,7 @@ function navigate(section, params) {
     case 'account-detail': loadAccountDetail(params.id); break;
     case 'conversations': loadConversations(); break;
     case 'bookings':      loadBookings(); break;
+    case 'action-needed': loadActionNeeded(); break;
     case 'billing':       loadBilling(); break;
     case 'integrations':  loadIntegrations(); break;
     case 'errors':        loadErrors(); break;
@@ -491,9 +507,11 @@ function statusBadge(status) {
 
 function bookingStateBadge(state) {
   const map = {
-    'CONFIRMED_CALENDAR': { cls: 'confirmed_calendar', label: 'Confirmed' },
+    'CONFIRMED_CALENDAR': { cls: 'confirmed_calendar', label: 'Confirmed (Calendar)' },
+    'CONFIRMED_MANUAL': { cls: 'confirmed_manual', label: 'Confirmed (Manual)' },
     'PENDING_MANUAL_CONFIRMATION': { cls: 'pending_manual_confirmation', label: 'Needs Manual Confirmation' },
     'FAILED': { cls: 'failed', label: 'Failed' },
+    'RESOLVED': { cls: 'resolved', label: 'Resolved' },
   };
   const m = map[state] || { cls: 'unknown', label: state || '—' };
   return `<span class="badge ${m.cls}">${m.label}</span>`;
@@ -563,6 +581,16 @@ async function loadOverview() {
       document.getElementById('errorBadge').style.display = '';
     }
 
+    // Update action-needed badge
+    const actionCount = (d.pending_manual_bookings || 0) + (d.failed_bookings || 0);
+    const actionBadge = document.getElementById('actionNeededBadge');
+    if (actionCount > 0) {
+      actionBadge.textContent = actionCount;
+      actionBadge.style.display = '';
+    } else {
+      actionBadge.style.display = 'none';
+    }
+
     document.getElementById('mainContent').innerHTML = `
       <div class="page-header">
         <div>
@@ -593,8 +621,8 @@ async function loadOverview() {
       <div class="section-label">Alerts</div>
       <div class="stat-grid">
         <div class="stat-card red"><div class="stat-tag">Failed Syncs</div><div class="stat-val ${d.failed_calendar_syncs > 0 ? 'red' : ''}">${d.failed_calendar_syncs}</div><div class="stat-sub">cal sync &gt;1h</div></div>
-        <div class="stat-card red"><div class="stat-tag">Needs Manual Confirm</div><div class="stat-val ${d.pending_manual_bookings > 0 ? 'red' : ''}">${d.pending_manual_bookings}</div><div class="stat-sub">booking action needed</div></div>
-        <div class="stat-card red"><div class="stat-tag">Failed Bookings</div><div class="stat-val ${d.failed_bookings > 0 ? 'red' : ''}">${d.failed_bookings}</div><div class="stat-sub">booking failed</div></div>
+        <div class="stat-card red" style="cursor:pointer" onclick="navigate('action-needed')"><div class="stat-tag">Needs Manual Confirm</div><div class="stat-val ${d.pending_manual_bookings > 0 ? 'red' : ''}">${d.pending_manual_bookings}</div><div class="stat-sub">click to resolve</div></div>
+        <div class="stat-card red" style="cursor:pointer" onclick="navigate('action-needed')"><div class="stat-tag">Failed Bookings</div><div class="stat-val ${d.failed_bookings > 0 ? 'red' : ''}">${d.failed_bookings}</div><div class="stat-sub">click to resolve</div></div>
         <div class="stat-card amber"><div class="stat-tag">No Twilio</div><div class="stat-val ${d.no_twilio > 0 ? 'red' : ''}">${d.no_twilio}</div><div class="stat-sub">no active phone</div></div>
         <div class="stat-card amber"><div class="stat-tag">No Calendar</div><div class="stat-val ${d.no_calendar > 0 ? 'amber' : ''}">${d.no_calendar}</div><div class="stat-sub">not connected</div></div>
         <div class="stat-card amber"><div class="stat-tag">Near Expiry</div><div class="stat-val ${d.near_expiry > 0 ? 'amber' : ''}">${d.near_expiry}</div><div class="stat-sub">trial ≤3 days</div></div>
@@ -1215,13 +1243,111 @@ document.getElementById('convModal').addEventListener('click', e => {
 });
 
 // ── SECTION 5: BOOKINGS ──────────────────────────────────────────────────────
+// ── SECTION 4b: ACTION NEEDED ─────────────────────────────────────────────
+async function updateBookingState(bookingId, newState, btnEl) {
+  if (btnEl) { btnEl.disabled = true; btnEl.textContent = 'Updating…'; }
+  try {
+    const token = localStorage.getItem('autoshop_jwt') || '';
+    const resp = await fetch(API + '/internal/admin/bookings/' + bookingId + '/state', {
+      method: 'PATCH',
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ booking_state: newState }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: resp.statusText }));
+      throw new Error(err.error || resp.statusText);
+    }
+    // Reload action-needed view
+    loadActionNeeded();
+  } catch (err) {
+    if (btnEl) { btnEl.disabled = false; btnEl.textContent = 'Retry'; }
+    alert('Failed to update booking: ' + err.message);
+  }
+}
+
+async function loadActionNeeded() {
+  const main = document.getElementById('mainContent');
+  main.innerHTML = '<div class="loading"><div class="spinner"></div> Loading…</div>';
+
+  try {
+    const d = await apiFetch('/internal/admin/bookings/action-needed');
+
+    const pending = d.bookings.filter(b => b.booking_state === 'PENDING_MANUAL_CONFIRMATION');
+    const failed = d.bookings.filter(b => b.booking_state === 'FAILED');
+
+    function renderActionRow(b) {
+      const actionBtn = b.booking_state === 'PENDING_MANUAL_CONFIRMATION'
+        ? `<button class="action-btn confirm" onclick="updateBookingState('${b.id}','CONFIRMED_MANUAL',this)">Mark Manually Confirmed</button>`
+        : `<button class="action-btn resolve" onclick="updateBookingState('${b.id}','RESOLVED',this)">Mark Resolved</button>`;
+
+      return `<tr>
+        <td style="font-weight:600">${escHtml(b.shop_name)}</td>
+        <td>${escHtml(b.customer_name || '—')}</td>
+        <td class="mono dim">${escHtml(b.customer_phone)}</td>
+        <td>${escHtml(b.service_type || '—')}</td>
+        <td class="mono dim">${fmtDate(b.scheduled_at)}</td>
+        <td>${bookingStateBadge(b.booking_state)}</td>
+        <td class="mono dim">${relTime(b.created_at)}</td>
+        <td>${actionBtn}</td>
+        <td>${b.conversation_id ? '<button class="link-btn" onclick="loadConversationDetail(\'' + b.conversation_id + '\')">View</button>' : '—'}</td>
+      </tr>`;
+    }
+
+    const tableHead = '<thead><tr><th>Shop</th><th>Customer</th><th>Phone</th><th>Service</th><th>Scheduled</th><th>Status</th><th>Created</th><th>Action</th><th>Conv</th></tr></thead>';
+
+    const pendingSection = `
+      <div class="section-label">Needs Manual Confirmation <span class="mono dim">(${pending.length})</span></div>
+      <div class="table-wrap">
+        ${pending.length > 0 ? `
+        <table class="data-table">
+          ${tableHead}
+          <tbody>${pending.map(renderActionRow).join('')}</tbody>
+        </table>` : renderEmpty('No bookings pending manual confirmation')}
+      </div>`;
+
+    const failedSection = `
+      <div class="section-label" style="margin-top:32px">Failed Bookings <span class="mono dim">(${failed.length})</span></div>
+      <div class="table-wrap">
+        ${failed.length > 0 ? `
+        <table class="data-table">
+          ${tableHead}
+          <tbody>${failed.map(renderActionRow).join('')}</tbody>
+        </table>` : renderEmpty('No failed bookings')}
+      </div>`;
+
+    // Update sidebar badge
+    const totalAction = d.count;
+    const actionBadge = document.getElementById('actionNeededBadge');
+    if (totalAction > 0) {
+      actionBadge.textContent = totalAction;
+      actionBadge.style.display = '';
+    } else {
+      actionBadge.style.display = 'none';
+    }
+
+    main.innerHTML = `
+      <div class="page-header">
+        <div>
+          <div class="page-title">Action Needed</div>
+          <div class="page-subtitle">Bookings requiring operator action — ${d.count} total</div>
+        </div>
+        <button class="btn-sm" onclick="navigate('action-needed')">&#8635; Refresh</button>
+      </div>
+      ${pendingSection}
+      ${failedSection}`;
+  } catch (err) {
+    main.innerHTML = renderError(err);
+  }
+}
+
+// ── SECTION 5: BOOKINGS ──────────────────────────────────────────────────────
 function loadBookings(filter) {
   if (filter !== undefined) _bookFilter = filter;
   const params = { page: _bookPage };
   if (_bookFilter) params.filter = _bookFilter;
 
   const filters = [
-    {label:'All',val:null},{label:'Today',val:'today'},{label:'Upcoming',val:'upcoming'},
+    {label:'All',val:null},{label:'Action Needed',val:'action_needed'},{label:'Today',val:'today'},{label:'Upcoming',val:'upcoming'},
     {label:'Sync Failed',val:'failed'},{label:'Pending',val:'pending'},{label:'Synced',val:'synced'}
   ];
 
@@ -1238,7 +1364,14 @@ function loadBookings(filter) {
 
   apiFetch('/internal/admin/bookings', params)
     .then(d => {
-      const tbody = d.bookings.length > 0 ? d.bookings.map(b => `<tr>
+      const tbody = d.bookings.length > 0 ? d.bookings.map(b => {
+        let actionCell = '—';
+        if (b.booking_state === 'PENDING_MANUAL_CONFIRMATION') {
+          actionCell = `<button class="action-btn confirm" onclick="updateBookingState('${b.id}','CONFIRMED_MANUAL',this)">Confirm</button>`;
+        } else if (b.booking_state === 'FAILED') {
+          actionCell = `<button class="action-btn resolve" onclick="updateBookingState('${b.id}','RESOLVED',this); setTimeout(()=>loadBookings(),500)">Resolve</button>`;
+        }
+        return `<tr>
         <td style="font-weight:600">${escHtml(b.shop_name)}</td>
         <td>${escHtml(b.customer_name || '—')}</td>
         <td class="mono dim">${escHtml(b.customer_phone)}</td>
@@ -1246,9 +1379,11 @@ function loadBookings(filter) {
         <td class="mono dim">${fmtDate(b.scheduled_at)}</td>
         <td class="mono dim">${relTime(b.created_at)}</td>
         <td>${bookingStateBadge(b.booking_state)}</td>
+        <td>${actionCell}</td>
         <td class="mono dim" style="font-size:10px">${escHtml(b.google_event_id || '—')}</td>
         <td>${b.conversation_id ? `<button class="link-btn" onclick="loadConversationDetail('${b.conversation_id}')">View</button>` : '—'}</td>
-      </tr>`).join('') : `<tr><td colspan="9">${renderEmpty('No bookings match')}</td></tr>`;
+      </tr>`;
+      }).join('') : `<tr><td colspan="10">${renderEmpty('No bookings match')}</td></tr>`;
 
       document.getElementById('mainContent').innerHTML = header + `
         <div class="table-wrap">
@@ -1257,7 +1392,7 @@ function loadBookings(filter) {
           <table class="data-table">
             <thead><tr>
               <th>Shop</th><th>Customer Name</th><th>Phone</th><th>Service</th>
-              <th>Scheduled At</th><th>Created</th><th>Booking Status</th><th>Google Event ID</th><th>Conv</th>
+              <th>Scheduled At</th><th>Created</th><th>Booking Status</th><th>Action</th><th>Google Event ID</th><th>Conv</th>
             </tr></thead>
             <tbody>${tbody}</tbody>
           </table>

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -1114,9 +1114,11 @@ async function loadDashboardData() {
     // ── Map bookings ──
     bookingsData = (data.recent_bookings || []).map(function(b) {
       var stateMap = {
-        'CONFIRMED_CALENDAR': { status: 'synced', label: 'Confirmed', note: '' },
+        'CONFIRMED_CALENDAR': { status: 'synced', label: 'Confirmed (Calendar)', note: '' },
+        'CONFIRMED_MANUAL': { status: 'synced', label: 'Confirmed (Manual)', note: '' },
         'PENDING_MANUAL_CONFIRMATION': { status: 'pending', label: 'Needs Manual Confirmation', note: 'Calendar sync failed — confirm this booking manually.' },
         'FAILED': { status: 'failed', label: 'Failed', note: 'Booking failed — contact customer to reschedule.' },
+        'RESOLVED': { status: 'synced', label: 'Resolved', note: '' },
       };
       var mapped = stateMap[b.booking_state] || { status: b.calendar_synced ? 'synced' : 'failed', label: b.calendar_synced ? 'Confirmed' : 'Failed', note: '' };
       return {


### PR DESCRIPTION
## Summary
- Adds operator action workflow so action-needed bookings (PENDING_MANUAL_CONFIRMATION, FAILED) can be resolved directly from the admin dashboard
- New state transitions: PENDING_MANUAL_CONFIRMATION → CONFIRMED_MANUAL, FAILED → RESOLVED
- Dedicated Action Needed page with operator action buttons + badge count in sidebar
- Action buttons also appear inline in the main bookings list
- Backend validates transitions (rejects invalid ones with 409), logs to audit_log
- Truthful labels distinguish Confirmed (Calendar) vs Confirmed (Manual) vs Resolved

## Why
Operators could see action-needed bookings but had no way to close them. Without closure, bookings pile up and operators revert to ad-hoc workflows. This turns the dashboard from a passive monitor into an operational tool.

## Changes
- `apps/api/src/services/appointments.ts` — Extended BookingState type
- `apps/api/src/routes/internal/admin.ts` — GET /admin/bookings/action-needed + PATCH /admin/bookings/:id/state
- `apps/web/admin.html` — Action Needed nav, page, action buttons, updated badge map
- `apps/web/app.html` — Tenant dashboard updated for new states
- `apps/api/src/tests/admin-booking-state.test.ts` — 8 new tests

## Test plan
- [x] All 304 tests pass (19 test files, 0 failures)
- [x] 8 new tests: allowed transitions, rejected invalid transitions, 404, invalid state, action-needed listing
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)