### PR TITLE
fix: booking state consistency after operator manual-closure

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -118,7 +118,7 @@ export async function adminRoute(app: FastifyInstance) {
       query(`SELECT status, COUNT(*)::int as count FROM signup_attempts WHERE created_at > NOW() - INTERVAL '7 days' GROUP BY status`),
       query(`SELECT COUNT(*)::int FROM conversations c JOIN tenants t ON t.id = c.tenant_id AND t.is_test = FALSE WHERE c.opened_at >= CURRENT_DATE`),
       query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.created_at >= CURRENT_DATE`),
-      query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.calendar_synced = false AND a.created_at < NOW() - INTERVAL '1 hour'`),
+      query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.calendar_synced = false AND a.created_at < NOW() - INTERVAL '1 hour' AND a.booking_state NOT IN ('CONFIRMED_MANUAL', 'RESOLVED')`),
       query(`SELECT COUNT(*)::int FROM tenants t WHERE t.is_test = FALSE AND NOT EXISTS (SELECT 1 FROM tenant_phone_numbers tpn WHERE tpn.tenant_id = t.id AND tpn.status = 'active')`),
       query(`SELECT COUNT(*)::int FROM tenants t WHERE t.is_test = FALSE AND NOT EXISTS (SELECT 1 FROM tenant_calendar_tokens tct WHERE tct.tenant_id = t.id)`),
       query(`SELECT COUNT(*)::int FROM tenants WHERE is_test = FALSE AND billing_status = 'trial' AND trial_ends_at > NOW() AND trial_ends_at <= NOW() + INTERVAL '3 days'`),
@@ -345,16 +345,18 @@ export async function adminRoute(app: FastifyInstance) {
       `SELECT a.id, a.tenant_id, t.shop_name, a.customer_phone, a.customer_name,
          a.service_type, a.scheduled_at, a.calendar_synced, a.google_event_id, a.created_at,
          a.conversation_id, a.booking_state,
-         CASE WHEN NOT a.calendar_synced AND a.google_event_id IS NULL THEN 'sync_failed'
+         CASE WHEN a.booking_state = 'CONFIRMED_MANUAL' THEN 'confirmed_manual'
+              WHEN a.booking_state = 'RESOLVED' THEN 'resolved'
+              WHEN NOT a.calendar_synced AND a.google_event_id IS NULL THEN 'sync_failed'
               WHEN NOT a.calendar_synced THEN 'pending'
               ELSE 'synced' END as sync_status
        FROM appointments a
        JOIN tenants t ON t.id = a.tenant_id
        WHERE t.is_test = FALSE
          AND ($1::text IS NULL OR
-         CASE WHEN $1 = 'failed'    THEN NOT a.calendar_synced AND a.created_at < NOW() - INTERVAL '1 hour'
-              WHEN $1 = 'pending'   THEN NOT a.calendar_synced AND a.created_at >= NOW() - INTERVAL '1 hour'
-              WHEN $1 = 'synced'    THEN a.calendar_synced
+         CASE WHEN $1 = 'failed'    THEN a.booking_state = 'FAILED'
+              WHEN $1 = 'pending'   THEN a.booking_state = 'PENDING_MANUAL_CONFIRMATION'
+              WHEN $1 = 'synced'    THEN a.booking_state IN ('CONFIRMED_CALENDAR', 'CONFIRMED_MANUAL', 'RESOLVED')
               WHEN $1 = 'today'     THEN a.scheduled_at::date = CURRENT_DATE
               WHEN $1 = 'upcoming'  THEN a.scheduled_at > NOW()
               WHEN $1 = 'action_needed' THEN a.booking_state IN ('PENDING_MANUAL_CONFIRMATION', 'FAILED')

--- a/apps/api/src/tests/admin-booking-state.test.ts
+++ b/apps/api/src/tests/admin-booking-state.test.ts
@@ -371,3 +371,104 @@ describe("PATCH /internal/admin/bookings/:id/state — booking state transitions
     expect(res.statusCode).toBe(400);
   });
 });
+
+// ── Filter correctness after operator actions ────────────────────────────────
+
+describe("GET /internal/admin/bookings — filter uses booking_state", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("'failed' filter queries booking_state = FAILED, not calendar_synced", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/bookings?filter=failed" });
+
+    const sql = mocks.query.mock.calls[0][0] as string;
+    expect(sql).toContain("booking_state = 'FAILED'");
+    expect(sql).not.toMatch(/WHEN \$1 = 'failed'.*calendar_synced/);
+  });
+
+  it("'pending' filter queries booking_state = PENDING_MANUAL_CONFIRMATION", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/bookings?filter=pending" });
+
+    const sql = mocks.query.mock.calls[0][0] as string;
+    expect(sql).toContain("booking_state = 'PENDING_MANUAL_CONFIRMATION'");
+  });
+
+  it("'synced' filter includes CONFIRMED_CALENDAR, CONFIRMED_MANUAL, and RESOLVED", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/bookings?filter=synced" });
+
+    const sql = mocks.query.mock.calls[0][0] as string;
+    expect(sql).toContain("CONFIRMED_CALENDAR");
+    expect(sql).toContain("CONFIRMED_MANUAL");
+    expect(sql).toContain("RESOLVED");
+  });
+
+  it("'action_needed' filter matches only PENDING_MANUAL_CONFIRMATION and FAILED", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/bookings?filter=action_needed" });
+
+    const sql = mocks.query.mock.calls[0][0] as string;
+    // Extract just the action_needed filter line from the SQL
+    const actionNeededLine = sql.split("\n").find((l: string) => l.includes("action_needed"));
+    expect(actionNeededLine).toBeDefined();
+    expect(actionNeededLine).toContain("PENDING_MANUAL_CONFIRMATION");
+    expect(actionNeededLine).toContain("FAILED");
+    expect(actionNeededLine).not.toContain("CONFIRMED_MANUAL");
+    expect(actionNeededLine).not.toContain("RESOLVED");
+  });
+});
+
+describe("GET /internal/admin/overview — failed_calendar_syncs excludes resolved states", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("failed_calendar_syncs query excludes CONFIRMED_MANUAL and RESOLVED", async () => {
+    // Mock all 16 overview queries
+    const overviewMocks = [
+      [{ billing_status: "active", count: "1" }],
+      [{ count: 0 }], [{ count: 0 }], [{ count: 0 }], [{ count: 0 }],
+      [{ count: 0 }], [{ count: 0 }], [{ count: 0 }], [{ count: 0 }],
+      [{ count: 0 }], [], [], [], [],
+      [{ count: 0 }], [{ count: 0 }],
+    ];
+    for (const mock of overviewMocks) {
+      mocks.query.mockResolvedValueOnce(mock);
+    }
+
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/overview" });
+
+    // The failed_calendar_syncs query is the 6th query (index 5)
+    const failedSyncSql = mocks.query.mock.calls[5][0] as string;
+    expect(failedSyncSql).toContain("calendar_synced = false");
+    expect(failedSyncSql).toContain("NOT IN ('CONFIRMED_MANUAL', 'RESOLVED')");
+  });
+});
+
+describe("GET /internal/admin/bookings — sync_status respects booking_state", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.ADMIN_EMAILS = "admin@test.com";
+  });
+
+  it("sync_status SQL checks booking_state before calendar_synced", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({ method: "GET", url: "/internal/admin/bookings" });
+
+    const sql = mocks.query.mock.calls[0][0] as string;
+    // CONFIRMED_MANUAL and RESOLVED cases should appear before the calendar_synced fallback
+    expect(sql).toContain("WHEN a.booking_state = 'CONFIRMED_MANUAL' THEN 'confirmed_manual'");
+    expect(sql).toContain("WHEN a.booking_state = 'RESOLVED' THEN 'resolved'");
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -1257,8 +1257,12 @@ async function updateBookingState(bookingId, newState, btnEl) {
       const err = await resp.json().catch(() => ({ error: resp.statusText }));
       throw new Error(err.error || resp.statusText);
     }
-    // Reload action-needed view
-    loadActionNeeded();
+    // Reload the current view to reflect updated state
+    if (currentSection === 'bookings') {
+      loadBookings();
+    } else {
+      loadActionNeeded();
+    }
   } catch (err) {
     if (btnEl) { btnEl.disabled = false; btnEl.textContent = 'Retry'; }
     alert('Failed to update booking: ' + err.message);
@@ -1369,7 +1373,7 @@ function loadBookings(filter) {
         if (b.booking_state === 'PENDING_MANUAL_CONFIRMATION') {
           actionCell = `<button class="action-btn confirm" onclick="updateBookingState('${b.id}','CONFIRMED_MANUAL',this)">Confirm</button>`;
         } else if (b.booking_state === 'FAILED') {
-          actionCell = `<button class="action-btn resolve" onclick="updateBookingState('${b.id}','RESOLVED',this); setTimeout(()=>loadBookings(),500)">Resolve</button>`;
+          actionCell = `<button class="action-btn resolve" onclick="updateBookingState('${b.id}','RESOLVED',this)">Resolve</button>`;
         }
         return `<tr>
         <td style="font-weight:600">${escHtml(b.shop_name)}</td>

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -1118,7 +1118,7 @@ async function loadDashboardData() {
         'CONFIRMED_MANUAL': { status: 'synced', label: 'Confirmed (Manual)', note: '' },
         'PENDING_MANUAL_CONFIRMATION': { status: 'pending', label: 'Needs Manual Confirmation', note: 'Calendar sync failed — confirm this booking manually.' },
         'FAILED': { status: 'failed', label: 'Failed', note: 'Booking failed — contact customer to reschedule.' },
-        'RESOLVED': { status: 'synced', label: 'Resolved', note: '' },
+        'RESOLVED': { status: 'resolved', label: 'Resolved', note: '' },
       };
       var mapped = stateMap[b.booking_state] || { status: b.calendar_synced ? 'synced' : 'failed', label: b.calendar_synced ? 'Confirmed' : 'Failed', note: '' };
       return {


### PR DESCRIPTION
## Summary

- **Filter leak fixed**: Admin bookings `failed`, `pending`, `synced` filters used legacy `calendar_synced` column — resolved/manual-confirmed bookings leaked into wrong filter categories. Now uses `booking_state` directly.
- **Failed sync count fixed**: Overview `failed_calendar_syncs` count included operator-resolved bookings. Now excludes `CONFIRMED_MANUAL` and `RESOLVED` states.
- **Stale sync_status fixed**: Computed `sync_status` column showed `CONFIRMED_MANUAL` bookings as `sync_failed`. Now checks `booking_state` first.
- **Post-action refresh fixed**: `updateBookingState()` always navigated to action-needed view even when called from bookings list. Plus race condition from `setTimeout` on resolve button. Now refreshes the current view correctly.
- **Tenant RESOLVED styling fixed**: `RESOLVED` mapped to `synced` status class (green) in tenant dashboard. Now uses `resolved` class (gray/steel).

## Test plan

- [x] Filter SQL correctness — `failed` uses `booking_state = 'FAILED'`, `pending` uses `booking_state = 'PENDING_MANUAL_CONFIRMATION'`, `synced` includes all confirmed+resolved states
- [x] `action_needed` filter still matches only `PENDING_MANUAL_CONFIRMATION` and `FAILED`
- [x] `failed_calendar_syncs` count excludes `CONFIRMED_MANUAL` and `RESOLVED`
- [x] `sync_status` CASE checks `booking_state` before `calendar_synced` fallback
- [x] All 310 tests pass (17 in admin-booking-state.test.ts including 5 new)
- [x] Lint: 0 errors, build: tsc clean, Docker build: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)