### PR TITLE
feat: admin phone wiring for pilot tenant live-path

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -821,14 +821,15 @@ export async function adminRoute(app: FastifyInstance) {
   app.get("/admin/tenants/:id/settings", { preHandler: [adminGuard] }, async (request, reply) => {
     const { id } = request.params as { id: string };
 
-    const [tenantRows, promptRows] = await Promise.all([
+    const [tenantRows, promptRows, phoneRows] = await Promise.all([
       query<{
         shop_name: string | null;
+        owner_phone: string | null;
         missed_call_sms_template: string | null;
         business_hours: string | null;
         services_description: string | null;
       }>(
-        `SELECT shop_name, missed_call_sms_template, business_hours, services_description
+        `SELECT shop_name, owner_phone, missed_call_sms_template, business_hours, services_description
          FROM tenants WHERE id = $1`,
         [id]
       ),
@@ -838,6 +839,12 @@ export async function adminRoute(app: FastifyInstance) {
          ORDER BY version DESC LIMIT 1`,
         [id]
       ),
+      query<{ phone_number: string; forward_to: string | null; status: string }>(
+        `SELECT phone_number, forward_to, status FROM tenant_phone_numbers
+         WHERE tenant_id = $1 AND status = 'active'
+         ORDER BY provisioned_at DESC LIMIT 1`,
+        [id]
+      ),
     ]);
 
     if ((tenantRows as any[]).length === 0) {
@@ -845,8 +852,12 @@ export async function adminRoute(app: FastifyInstance) {
     }
 
     const tenant = (tenantRows as any[])[0];
+    const phone = (phoneRows as any[])[0] ?? null;
     return reply.status(200).send({
       shop_name: tenant.shop_name,
+      owner_phone: tenant.owner_phone,
+      twilio_number: phone?.phone_number ?? null,
+      forward_to: phone?.forward_to ?? null,
       missed_call_sms_template: tenant.missed_call_sms_template,
       ai_system_prompt: (promptRows as any[])[0]?.prompt_text ?? null,
       business_hours: tenant.business_hours,
@@ -855,8 +866,11 @@ export async function adminRoute(app: FastifyInstance) {
   });
 
   // ── PUT /internal/admin/tenants/:id/settings ────────────────────────────
+  const E164_REGEX = /^\+[1-9]\d{1,14}$/;
   const SettingsSchema = z.object({
     shop_name: z.string().min(1).max(200).optional(),
+    owner_phone: z.string().regex(E164_REGEX, "Must be E.164 format (e.g. +15125551234)").nullable().optional(),
+    forward_to: z.string().regex(E164_REGEX, "Must be E.164 format (e.g. +15125551234)").nullable().optional(),
     missed_call_sms_template: z.string().max(500).nullable().optional(),
     ai_system_prompt: z.string().max(2000).nullable().optional(),
     business_hours: z.string().max(500).nullable().optional(),
@@ -891,6 +905,10 @@ export async function adminRoute(app: FastifyInstance) {
       tenantUpdates.push(`shop_name = $${paramIdx++}`);
       tenantValues.push(data.shop_name);
     }
+    if (data.owner_phone !== undefined) {
+      tenantUpdates.push(`owner_phone = $${paramIdx++}`);
+      tenantValues.push(data.owner_phone);
+    }
     if (data.missed_call_sms_template !== undefined) {
       tenantUpdates.push(`missed_call_sms_template = $${paramIdx++}`);
       tenantValues.push(data.missed_call_sms_template);
@@ -909,6 +927,15 @@ export async function adminRoute(app: FastifyInstance) {
       await query(
         `UPDATE tenants SET ${tenantUpdates.join(", ")} WHERE id = $${paramIdx}`,
         [...tenantValues, id]
+      );
+    }
+
+    // Update forward_to in tenant_phone_numbers table
+    if (data.forward_to !== undefined) {
+      await query(
+        `UPDATE tenant_phone_numbers SET forward_to = $1
+         WHERE tenant_id = $2 AND status = 'active'`,
+        [data.forward_to, id]
       );
     }
 

--- a/apps/api/src/tests/tenant-settings.test.ts
+++ b/apps/api/src/tests/tenant-settings.test.ts
@@ -79,15 +79,17 @@ describe("buildMissedCallSms with template", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("GET /internal/admin/tenants/:id/settings", () => {
-  it("returns tenant settings with system prompt", async () => {
+  it("returns tenant settings with system prompt and phone wiring", async () => {
     mocks.query
       .mockResolvedValueOnce([{
         shop_name: "Joe's Auto",
+        owner_phone: "+15125551234",
         missed_call_sms_template: "Hey {shop_name} missed you!",
         business_hours: "Mon-Fri 8-6",
         services_description: "Oil changes, brakes",
       }])
-      .mockResolvedValueOnce([{ prompt_text: "You are Joe's assistant." }]);
+      .mockResolvedValueOnce([{ prompt_text: "You are Joe's assistant." }])
+      .mockResolvedValueOnce([{ phone_number: "+13257523890", forward_to: "+15125559999", status: "active" }]);
 
     const app = await buildApp();
     const res = await app.inject({
@@ -98,20 +100,25 @@ describe("GET /internal/admin/tenants/:id/settings", () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);
     expect(body.shop_name).toBe("Joe's Auto");
+    expect(body.owner_phone).toBe("+15125551234");
+    expect(body.twilio_number).toBe("+13257523890");
+    expect(body.forward_to).toBe("+15125559999");
     expect(body.missed_call_sms_template).toBe("Hey {shop_name} missed you!");
     expect(body.ai_system_prompt).toBe("You are Joe's assistant.");
     expect(body.business_hours).toBe("Mon-Fri 8-6");
     expect(body.services_description).toBe("Oil changes, brakes");
   });
 
-  it("returns nulls when no settings configured", async () => {
+  it("returns nulls when no settings or phone configured", async () => {
     mocks.query
       .mockResolvedValueOnce([{
         shop_name: "Default Shop",
+        owner_phone: null,
         missed_call_sms_template: null,
         business_hours: null,
         services_description: null,
       }])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
 
     const app = await buildApp();
@@ -122,6 +129,9 @@ describe("GET /internal/admin/tenants/:id/settings", () => {
 
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);
+    expect(body.owner_phone).toBeNull();
+    expect(body.twilio_number).toBeNull();
+    expect(body.forward_to).toBeNull();
     expect(body.missed_call_sms_template).toBeNull();
     expect(body.ai_system_prompt).toBeNull();
     expect(body.business_hours).toBeNull();
@@ -130,6 +140,7 @@ describe("GET /internal/admin/tenants/:id/settings", () => {
 
   it("returns 404 for unknown tenant", async () => {
     mocks.query
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
 
@@ -263,5 +274,106 @@ describe("PUT /internal/admin/tenants/:id/settings", () => {
     const updateCall = mocks.query.mock.calls[1];
     expect(updateCall[0]).toContain("missed_call_sms_template");
     expect(updateCall[1]).toContain(null);
+  });
+
+  it("updates forward_to in tenant_phone_numbers", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // exists check
+    mocks.query.mockResolvedValueOnce([]); // forward_to UPDATE
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { forward_to: "+15125559999" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // forward_to update should target tenant_phone_numbers
+    const fwdCall = mocks.query.mock.calls[1];
+    expect(fwdCall[0]).toContain("tenant_phone_numbers");
+    expect(fwdCall[0]).toContain("forward_to");
+    expect(fwdCall[1]).toContain("+15125559999");
+  });
+
+  it("updates owner_phone in tenants table", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // exists check
+    mocks.query.mockResolvedValueOnce([]); // tenant UPDATE
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { owner_phone: "+15125551234" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mocks.query.mock.calls[1];
+    expect(updateCall[0]).toContain("owner_phone");
+    expect(updateCall[1]).toContain("+15125551234");
+  });
+
+  it("updates forward_to and owner_phone together with other fields", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // exists check
+    mocks.query.mockResolvedValueOnce([]); // tenant UPDATE (shop_name + owner_phone)
+    mocks.query.mockResolvedValueOnce([]); // forward_to UPDATE
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: {
+        shop_name: "New Shop",
+        owner_phone: "+15125551234",
+        forward_to: "+15125559999",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // tenant update should include shop_name and owner_phone
+    const tenantCall = mocks.query.mock.calls[1];
+    expect(tenantCall[0]).toContain("shop_name");
+    expect(tenantCall[0]).toContain("owner_phone");
+    // forward_to update should be separate (tenant_phone_numbers)
+    const fwdCall = mocks.query.mock.calls[2];
+    expect(fwdCall[0]).toContain("tenant_phone_numbers");
+  });
+
+  it("rejects invalid E.164 forward_to", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { forward_to: "5125551234" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects invalid E.164 owner_phone", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { owner_phone: "notaphone" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("allows clearing forward_to with null", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // exists check
+    mocks.query.mockResolvedValueOnce([]); // forward_to UPDATE
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/internal/admin/tenants/${TENANT_ID}/settings`,
+      payload: { forward_to: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const fwdCall = mocks.query.mock.calls[1];
+    expect(fwdCall[0]).toContain("tenant_phone_numbers");
+    expect(fwdCall[1][0]).toBeNull();
   });
 });

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -968,6 +968,7 @@ function renderAccountDetail(d) {
             <div class="panel-body">
               ${ph ? `<div class="kv-grid">
                 <div class="kv-item"><div class="kv-label">Phone Number</div><div class="kv-val mono">${escHtml(ph.phone_number)}</div></div>
+                <div class="kv-item"><div class="kv-label">Forwards To</div><div class="kv-val mono">${escHtml(ph.forward_to || '— not set')}</div></div>
                 <div class="kv-item"><div class="kv-label">Status</div><div class="kv-val">${statusBadge(ph.status)}</div></div>
                 <div class="kv-item"><div class="kv-label">Twilio SID</div><div class="kv-val mono dim" style="font-size:11px">${escHtml(ph.twilio_sid || '—')}</div></div>
                 <div class="kv-item"><div class="kv-label">Provisioned</div><div class="kv-val mono dim">${fmtDate(ph.provisioned_at)}</div></div>
@@ -1064,6 +1065,27 @@ async function loadTenantSettings(tenantId) {
     const s = await apiFetch(`/internal/admin/tenants/${tenantId}/settings`);
     body.innerHTML = `
       <div style="display:flex;flex-direction:column;gap:20px;max-width:640px">
+        <div style="border:1px solid var(--border);border-radius:10px;padding:16px;background:rgba(255,255,255,0.02)">
+          <div style="font-weight:700;font-size:14px;margin-bottom:12px">Phone Wiring</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+            <div>
+              <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Twilio Number</label>
+              <input type="text" value="${escHtml(s.twilio_number || 'Not assigned')}" disabled
+                style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--mono);font-size:13px;background:rgba(255,255,255,0.03);color:var(--steel)" />
+            </div>
+            <div>
+              <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Forward Calls To</label>
+              <input type="tel" id="set_forward_to" value="${escHtml(s.forward_to || '')}" placeholder="+15125551234"
+                style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--mono);font-size:13px;background:var(--bg);color:var(--white)" />
+            </div>
+            <div>
+              <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Owner Phone (alerts)</label>
+              <input type="tel" id="set_owner_phone" value="${escHtml(s.owner_phone || '')}" placeholder="+15125551234"
+                style="width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:var(--mono);font-size:13px;background:var(--bg);color:var(--white)" />
+            </div>
+          </div>
+          <div style="font-size:11px;color:var(--steel);margin-top:8px">Forward Calls To: where unanswered calls ring before triggering missed-call SMS. Owner Phone: receives alert SMS on calendar sync failures.</div>
+        </div>
         <div>
           <label style="font-weight:600;font-size:13px;display:block;margin-bottom:6px">Shop Name</label>
           <input type="text" id="set_shop_name" value="${escHtml(s.shop_name || '')}"
@@ -1106,8 +1128,12 @@ async function saveTenantSettings(tenantId) {
   const status = document.getElementById('settingsSaveStatus');
   if (status) status.textContent = 'Saving...';
   try {
+    const fwdVal = document.getElementById('set_forward_to').value.trim();
+    const ownerVal = document.getElementById('set_owner_phone').value.trim();
     const payload = {
       shop_name: document.getElementById('set_shop_name').value || undefined,
+      forward_to: fwdVal || null,
+      owner_phone: ownerVal || null,
       missed_call_sms_template: document.getElementById('set_missed_call_sms').value || null,
       ai_system_prompt: document.getElementById('set_ai_prompt').value || null,
       business_hours: document.getElementById('set_business_hours').value || null,


### PR DESCRIPTION
## Summary

- **Closes the last pilot wiring gap**: `forward_to` (call forwarding number) and `owner_phone` (alert SMS recipient) can now be managed via the admin dashboard instead of raw SQL
- **API**: Extended `GET/PUT /admin/tenants/:id/settings` to include phone wiring fields with E.164 validation
- **UI**: Added Phone Wiring section to Settings tab (Twilio number read-only, forward_to and owner_phone editable) and forward_to display in Integrations tab

## Why highest-leverage

The entire webhook → tenant lookup → AI → booking → calendar pipeline is fully wired and dynamic. The only remaining pilot gap was that phone routing (`forward_to`) and alert destination (`owner_phone`) required manual DB edits. This PR makes the Texas pilot shop fully manageable through the admin interface.

## Live-path gap closed

Before: Changing where calls forward or where alerts go required `UPDATE tenant_phone_numbers SET forward_to = '...'` SQL.
After: Admin opens Settings tab → edits Forward Calls To / Owner Phone → saves. Validated E.164 format, updates immediately.

## Test plan

- [x] 316/316 tests pass (19 test files)
- [x] 7 new tests for phone wiring (forward_to update, owner_phone update, combined update, E.164 validation, null clearing)
- [x] Docker build succeeds
- [x] Lint: 0 errors (69 pre-existing warnings)
- [ ] Manual: open admin → tenant → Settings → verify Phone Wiring section renders
- [ ] Manual: update forward_to, verify voice webhook uses new number

🤖 Generated with [Claude Code](https://claude.com/claude-code)