### PR TITLE
feat: pilot tenant readiness check for live-test validation

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -865,6 +865,164 @@ export async function adminRoute(app: FastifyInstance) {
     });
   });
 
+  // ── GET /internal/admin/tenants/:id/pilot-readiness ─────────────────────
+  app.get("/admin/tenants/:id/pilot-readiness", { preHandler: [adminGuard] }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    const [tenantRows, phoneRows, calendarRows, promptRows] = await Promise.all([
+      query<{
+        shop_name: string | null;
+        owner_phone: string | null;
+        billing_status: string;
+        trial_ends_at: string | null;
+        missed_call_sms_template: string | null;
+        business_hours: string | null;
+        services_description: string | null;
+      }>(
+        `SELECT shop_name, owner_phone, billing_status, trial_ends_at,
+                missed_call_sms_template, business_hours, services_description
+         FROM tenants WHERE id = $1`,
+        [id]
+      ),
+      query<{ phone_number: string; forward_to: string | null; status: string }>(
+        `SELECT phone_number, forward_to, status FROM tenant_phone_numbers
+         WHERE tenant_id = $1 AND status = 'active'
+         ORDER BY provisioned_at DESC LIMIT 1`,
+        [id]
+      ),
+      query<{ token_expiry: string | null; connected_at: string | null }>(
+        `SELECT token_expiry, connected_at FROM tenant_calendar_tokens
+         WHERE tenant_id = $1 LIMIT 1`,
+        [id]
+      ),
+      query<{ prompt_text: string }>(
+        `SELECT prompt_text FROM system_prompts
+         WHERE tenant_id = $1 AND is_active = TRUE
+         ORDER BY version DESC LIMIT 1`,
+        [id]
+      ),
+    ]);
+
+    if ((tenantRows as any[]).length === 0) {
+      return reply.status(404).send({ error: "Tenant not found" });
+    }
+
+    const tenant = (tenantRows as any[])[0];
+    const phone = (phoneRows as any[])[0] ?? null;
+    const calendar = (calendarRows as any[])[0] ?? null;
+    const prompt = (promptRows as any[])[0] ?? null;
+
+    // Billing must be in a usable state
+    const blockedBillingStatuses = ["trial_expired", "canceled", "past_due_blocked"];
+    const billingOk = !blockedBillingStatuses.includes(tenant.billing_status);
+
+    // Build readiness checks — ordered by the live path:
+    // Twilio number → voice/sms webhook → forward_to → missed-call trigger → AI reply → calendar
+    const checks = [
+      {
+        id: "twilio_number",
+        label: "Twilio number assigned",
+        pass: !!phone,
+        detail: phone ? phone.phone_number : "No active phone number provisioned",
+        critical: true,
+      },
+      {
+        id: "forward_to",
+        label: "Call forwarding configured",
+        pass: !!phone?.forward_to,
+        detail: phone?.forward_to
+          ? `Calls forward to ${phone.forward_to}`
+          : "No forward_to number — incoming calls won't ring the shop",
+        critical: true,
+      },
+      {
+        id: "sms_template",
+        label: "Missed-call SMS template set",
+        pass: !!tenant.missed_call_sms_template?.trim(),
+        detail: tenant.missed_call_sms_template
+          ? `Template: "${tenant.missed_call_sms_template.substring(0, 80)}${tenant.missed_call_sms_template.length > 80 ? '...' : ''}"`
+          : "No SMS template — missed calls won't trigger outbound SMS",
+        critical: true,
+      },
+      {
+        id: "ai_prompt",
+        label: "AI system prompt configured",
+        pass: !!prompt?.prompt_text?.trim(),
+        detail: prompt
+          ? `Active prompt: ${prompt.prompt_text.substring(0, 60)}...`
+          : "No active AI prompt — conversations will use generic defaults",
+        critical: false,
+      },
+      {
+        id: "business_hours",
+        label: "Business hours set",
+        pass: !!tenant.business_hours?.trim(),
+        detail: tenant.business_hours || "Not configured — AI won't know shop hours",
+        critical: false,
+      },
+      {
+        id: "services",
+        label: "Services description set",
+        pass: !!tenant.services_description?.trim(),
+        detail: tenant.services_description
+          ? `${tenant.services_description.substring(0, 80)}${tenant.services_description.length > 80 ? '...' : ''}`
+          : "Not configured — AI won't know what services the shop offers",
+        critical: false,
+      },
+      {
+        id: "calendar_connected",
+        label: "Google Calendar connected",
+        pass: !!calendar?.connected_at,
+        detail: calendar?.connected_at
+          ? `Connected ${new Date(calendar.connected_at).toLocaleDateString()}`
+          : "OAuth not completed — bookings won't sync to calendar",
+        critical: true,
+      },
+      {
+        id: "calendar_token_valid",
+        label: "Calendar token not expired",
+        pass: !!calendar?.token_expiry && new Date(calendar.token_expiry) > new Date(),
+        detail: calendar?.token_expiry
+          ? `Expires ${new Date(calendar.token_expiry).toLocaleString()}`
+          : "No token — complete OAuth flow first",
+        critical: true,
+      },
+      {
+        id: "billing_active",
+        label: "Billing status allows operation",
+        pass: billingOk,
+        detail: `Status: ${tenant.billing_status}${!billingOk ? " — tenant is blocked from operating" : ""}`,
+        critical: true,
+      },
+    ];
+
+    const criticalPassed = checks.filter(c => c.critical && c.pass).length;
+    const criticalTotal = checks.filter(c => c.critical).length;
+    const allPassed = checks.every(c => c.pass);
+    const criticalAllPassed = checks.filter(c => c.critical).every(c => c.pass);
+    const blockers = checks.filter(c => c.critical && !c.pass);
+    const warnings = checks.filter(c => !c.critical && !c.pass);
+
+    let verdict: "ready" | "not_ready" | "ready_with_warnings";
+    if (!criticalAllPassed) {
+      verdict = "not_ready";
+    } else if (!allPassed) {
+      verdict = "ready_with_warnings";
+    } else {
+      verdict = "ready";
+    }
+
+    return reply.status(200).send({
+      tenant_id: id,
+      shop_name: tenant.shop_name,
+      verdict,
+      summary: `${criticalPassed}/${criticalTotal} critical checks passed`,
+      checks,
+      blockers: blockers.map(b => ({ id: b.id, label: b.label, detail: b.detail })),
+      warnings: warnings.map(w => ({ id: w.id, label: w.label, detail: w.detail })),
+    });
+  });
+
   // ── PUT /internal/admin/tenants/:id/settings ────────────────────────────
   const E164_REGEX = /^\+[1-9]\d{1,14}$/;
   const SettingsSchema = z.object({

--- a/apps/api/src/tests/pilot-readiness.test.ts
+++ b/apps/api/src/tests/pilot-readiness.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+vi.mock("../middleware/admin-guard", () => ({
+  adminGuard: async () => {},
+}));
+
+import { adminRoute } from "../routes/internal/admin";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminRoute, { prefix: "/internal" });
+  return app;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /internal/admin/tenants/:id/pilot-readiness
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
+  function setupMocks(overrides: {
+    tenant?: any;
+    phone?: any;
+    calendar?: any;
+    prompt?: any;
+  } = {}) {
+    const tenant = overrides.tenant !== undefined ? overrides.tenant : {
+      shop_name: "Joe's Auto",
+      owner_phone: "+15125551234",
+      billing_status: "trial",
+      trial_ends_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+      missed_call_sms_template: "Hi from {shop_name}! We missed your call.",
+      business_hours: "Mon-Fri 8am-6pm",
+      services_description: "Oil changes, brake repair, AC service",
+    };
+
+    const phone = overrides.phone !== undefined ? overrides.phone : {
+      phone_number: "+13257523890",
+      forward_to: "+15125559999",
+      status: "active",
+    };
+
+    const calendar = overrides.calendar !== undefined ? overrides.calendar : {
+      token_expiry: new Date(Date.now() + 3600000).toISOString(),
+      connected_at: new Date().toISOString(),
+    };
+
+    const prompt = overrides.prompt !== undefined ? overrides.prompt : {
+      prompt_text: "You are an AI assistant for Joe's Auto repair shop.",
+    };
+
+    mocks.query.mockImplementation((sql: string) => {
+      if (sql.includes("missed_call_sms_template")) return tenant ? [tenant] : [];
+      if (sql.includes("tenant_phone_numbers")) return phone ? [phone] : [];
+      if (sql.includes("tenant_calendar_tokens")) return calendar ? [calendar] : [];
+      if (sql.includes("system_prompts")) return prompt ? [prompt] : [];
+      return [];
+    });
+  }
+
+  it("returns 404 for non-existent tenant", async () => {
+    const app = await buildApp();
+    setupMocks({ tenant: null });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 'ready' when all checks pass", async () => {
+    const app = await buildApp();
+    setupMocks();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.verdict).toBe("ready");
+    expect(body.blockers).toHaveLength(0);
+    expect(body.warnings).toHaveLength(0);
+    expect(body.checks.every((c: any) => c.pass)).toBe(true);
+  });
+
+  it("returns 'not_ready' when no phone number", async () => {
+    const app = await buildApp();
+    setupMocks({ phone: null });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "twilio_number")).toBe(true);
+    expect(body.blockers.some((b: any) => b.id === "forward_to")).toBe(true);
+  });
+
+  it("returns 'not_ready' when forward_to is missing", async () => {
+    const app = await buildApp();
+    setupMocks({
+      phone: { phone_number: "+13257523890", forward_to: null, status: "active" },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "forward_to")).toBe(true);
+  });
+
+  it("returns 'not_ready' when calendar not connected", async () => {
+    const app = await buildApp();
+    setupMocks({ calendar: null });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "calendar_connected")).toBe(true);
+  });
+
+  it("returns 'not_ready' when calendar token expired", async () => {
+    const app = await buildApp();
+    setupMocks({
+      calendar: {
+        connected_at: new Date().toISOString(),
+        token_expiry: new Date(Date.now() - 3600000).toISOString(),
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "calendar_token_valid")).toBe(true);
+  });
+
+  it("returns 'not_ready' when billing is blocked", async () => {
+    const app = await buildApp();
+    setupMocks({
+      tenant: {
+        shop_name: "Joe's Auto",
+        owner_phone: "+15125551234",
+        billing_status: "trial_expired",
+        trial_ends_at: new Date(Date.now() - 86400000).toISOString(),
+        missed_call_sms_template: "Template",
+        business_hours: "Mon-Fri",
+        services_description: "Oil changes",
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "billing_active")).toBe(true);
+  });
+
+  it("returns 'not_ready' when SMS template is missing", async () => {
+    const app = await buildApp();
+    setupMocks({
+      tenant: {
+        shop_name: "Joe's Auto",
+        owner_phone: "+15125551234",
+        billing_status: "trial",
+        trial_ends_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+        missed_call_sms_template: null,
+        business_hours: "Mon-Fri",
+        services_description: "Oil changes",
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    expect(body.blockers.some((b: any) => b.id === "sms_template")).toBe(true);
+  });
+
+  it("returns 'ready_with_warnings' when only non-critical checks fail", async () => {
+    const app = await buildApp();
+    setupMocks({
+      prompt: null, // AI prompt missing (non-critical)
+      tenant: {
+        shop_name: "Joe's Auto",
+        owner_phone: "+15125551234",
+        billing_status: "trial",
+        trial_ends_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+        missed_call_sms_template: "Template text",
+        business_hours: null, // missing (non-critical)
+        services_description: null, // missing (non-critical)
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("ready_with_warnings");
+    expect(body.blockers).toHaveLength(0);
+    expect(body.warnings.length).toBeGreaterThan(0);
+    expect(body.warnings.some((w: any) => w.id === "ai_prompt")).toBe(true);
+  });
+
+  it("includes correct check count in summary", async () => {
+    const app = await buildApp();
+    setupMocks();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.checks).toHaveLength(9);
+    expect(body.summary).toMatch(/\d+\/\d+ critical checks passed/);
+  });
+
+  it("returns all 9 checks in live-path order", async () => {
+    const app = await buildApp();
+    setupMocks();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    const ids = body.checks.map((c: any) => c.id);
+    expect(ids).toEqual([
+      "twilio_number",
+      "forward_to",
+      "sms_template",
+      "ai_prompt",
+      "business_hours",
+      "services",
+      "calendar_connected",
+      "calendar_token_valid",
+      "billing_active",
+    ]);
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -820,9 +820,9 @@ async function loadAccountDetail(id) {
 
 function renderAccountDetail(d) {
   const t = d.tenant;
-  const tabs = ['summary','settings','usage','billing','conversations','bookings','integrations','billing_events','audit'];
+  const tabs = ['summary','readiness','settings','usage','billing','conversations','bookings','integrations','billing_events','audit'];
   const tabLabels = {
-    summary:'Summary', settings:'Settings', usage:'Usage', billing:'Billing', conversations:'Conversations',
+    summary:'Summary', readiness:'Readiness', settings:'Settings', usage:'Usage', billing:'Billing', conversations:'Conversations',
     bookings:'Bookings', integrations:'Integrations', billing_events:'Billing Events', audit:'Audit Log'
   };
 
@@ -859,6 +859,17 @@ function renderAccountDetail(d) {
             </div>
           </div>
         </div>`;
+      break;
+
+    case 'readiness':
+      tabContent = `
+        <div class="panel" id="readinessPanel">
+          <div class="panel-header"><span class="panel-title">Pilot Readiness — Live-Test Checklist</span></div>
+          <div class="panel-body" id="readinessBody">
+            <div class="loading"><div class="spinner"></div> Checking readiness...</div>
+          </div>
+        </div>`;
+      setTimeout(() => loadPilotReadiness(t.id), 0);
       break;
 
     case 'settings':
@@ -1055,6 +1066,82 @@ function renderAccountDetail(d) {
 function switchAccountTab(tab) {
   accountDetailTab = tab;
   renderAccountDetail(window._accountDetailData);
+}
+
+// ── PILOT READINESS ─────────────────────────────────────────────────────────
+async function loadPilotReadiness(tenantId) {
+  const body = document.getElementById('readinessBody');
+  if (!body) return;
+  try {
+    const r = await apiFetch(`/internal/admin/tenants/${tenantId}/pilot-readiness`);
+
+    const verdictColor = r.verdict === 'ready' ? 'var(--green)' :
+                          r.verdict === 'ready_with_warnings' ? 'var(--amber)' : 'var(--red)';
+    const verdictLabel = r.verdict === 'ready' ? 'READY FOR LIVE TEST' :
+                          r.verdict === 'ready_with_warnings' ? 'READY (with warnings)' : 'NOT READY';
+    const verdictIcon = r.verdict === 'ready' ? '&#10003;' :
+                         r.verdict === 'ready_with_warnings' ? '!' : '&#10007;';
+
+    body.innerHTML = `
+      <div style="text-align:center;padding:24px 0 20px;border-bottom:1px solid var(--border);margin-bottom:20px">
+        <div style="display:inline-flex;align-items:center;gap:12px;padding:16px 32px;border-radius:12px;
+             border:2px solid ${verdictColor};background:${verdictColor}10">
+          <span style="font-size:28px;font-weight:700;color:${verdictColor}">${verdictIcon}</span>
+          <div>
+            <div style="font-size:20px;font-weight:700;color:${verdictColor};letter-spacing:-.01em">${verdictLabel}</div>
+            <div style="font-size:13px;color:var(--steel);margin-top:2px">${escHtml(r.summary)}</div>
+          </div>
+        </div>
+      </div>
+
+      <div style="font-weight:700;font-size:14px;margin-bottom:12px;color:var(--white)">
+        Live Path: Twilio &rarr; Voice/SMS &rarr; Forward &rarr; Missed-call &rarr; AI Reply &rarr; Calendar
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:8px">
+        ${r.checks.map(c => `
+          <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 16px;border-radius:10px;
+               border:1px solid ${c.pass ? 'var(--border)' : c.critical ? 'rgba(239,68,68,.3)' : 'rgba(245,158,11,.3)'};
+               background:${c.pass ? 'var(--bg)' : c.critical ? 'rgba(239,68,68,.04)' : 'rgba(245,158,11,.04)'}">
+            <span style="font-size:18px;flex-shrink:0;margin-top:1px;width:24px;text-align:center;
+                  color:${c.pass ? 'var(--green)' : c.critical ? 'var(--red)' : 'var(--amber)'}">
+              ${c.pass ? '&#10003;' : c.critical ? '&#10007;' : '!'}
+            </span>
+            <div style="flex:1;min-width:0">
+              <div style="font-weight:600;font-size:14px;color:var(--white);display:flex;align-items:center;gap:8px">
+                ${escHtml(c.label)}
+                ${c.critical ? '<span style="font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--red);background:rgba(239,68,68,.08);padding:2px 6px;border-radius:4px">critical</span>' : ''}
+              </div>
+              <div style="font-size:12px;color:var(--steel);margin-top:3px;font-family:var(--mono);word-break:break-all">${escHtml(c.detail)}</div>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+
+      ${r.blockers.length > 0 ? `
+        <div style="margin-top:24px;padding:16px;border-radius:10px;background:rgba(239,68,68,.06);border:1px solid rgba(239,68,68,.2)">
+          <div style="font-weight:700;font-size:13px;color:var(--red);margin-bottom:8px">Blockers — must fix before live test</div>
+          <ul style="margin:0;padding-left:20px;color:var(--white);font-size:13px;line-height:1.8">
+            ${r.blockers.map(b => `<li><strong>${escHtml(b.label)}</strong>: ${escHtml(b.detail)}</li>`).join('')}
+          </ul>
+        </div>` : ''}
+
+      ${r.warnings.length > 0 ? `
+        <div style="margin-top:12px;padding:16px;border-radius:10px;background:rgba(245,158,11,.06);border:1px solid rgba(245,158,11,.2)">
+          <div style="font-weight:700;font-size:13px;color:var(--amber);margin-bottom:8px">Warnings — recommended before live test</div>
+          <ul style="margin:0;padding-left:20px;color:var(--white);font-size:13px;line-height:1.8">
+            ${r.warnings.map(w => `<li><strong>${escHtml(w.label)}</strong>: ${escHtml(w.detail)}</li>`).join('')}
+          </ul>
+        </div>` : ''}
+
+      <div style="margin-top:20px;padding:12px 16px;border-radius:8px;background:var(--bg);border:1px solid var(--border);
+           font-size:12px;color:var(--steel);font-family:var(--mono)">
+        Checked at ${new Date().toLocaleString()} — refresh the tab to re-check
+      </div>
+    `;
+  } catch (err) {
+    body.innerHTML = renderError(err);
+  }
 }
 
 // ── TENANT SETTINGS ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `GET /internal/admin/tenants/:id/pilot-readiness` endpoint that inspects all critical tenant wiring against the live path (Twilio number -> voice/SMS webhook -> forward_to -> missed-call trigger -> AI reply -> Google Calendar)
- Add "Readiness" tab in admin tenant detail view with visual pass/fail checklist, blocker summary, and warning summary
- 9 checks in live-path order: twilio_number, forward_to, sms_template, ai_prompt, business_hours, services, calendar_connected, calendar_token_valid, billing_active
- Returns verdict: `ready` | `ready_with_warnings` | `not_ready` with actionable detail for each failing check
- 11 new tests covering all verdict states and check combinations (327 total, 20 files, all passing)

## What live-path gap this closes

Before: operator had no way to know if a pilot tenant was actually ready for a real missed-call/SMS test. Config was scattered across settings, integrations, and billing tabs. A human could attempt a live test and hit a silent failure from missing forward_to, expired calendar token, or missing SMS template.

After: operator opens tenant detail -> Readiness tab -> sees exactly which checks pass/fail with "READY FOR LIVE TEST" / "NOT READY" verdict and specific blockers to fix.

## Test plan

- [x] TypeScript compiles clean
- [x] 327/327 tests pass (20 files, 0 failures)
- [x] New endpoint returns correct verdict for all check combinations
- [x] 404 for non-existent tenant
- [ ] Manual: verify Readiness tab renders in admin dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)