### PR TITLE
feat: Twilio webhook URL verification in pilot-readiness

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -3,6 +3,8 @@ import * as bcrypt from "bcryptjs";
 import { z } from "zod";
 import { query } from "../../db/client";
 import { adminGuard } from "../../middleware/admin-guard";
+import { fetchTwilioNumberConfig, verifyWebhookUrls } from "../../services/twilio-verify";
+import { getConfig } from "../../db/app-config";
 
 /**
  * Internal Admin API
@@ -884,8 +886,8 @@ export async function adminRoute(app: FastifyInstance) {
          FROM tenants WHERE id = $1`,
         [id]
       ),
-      query<{ phone_number: string; forward_to: string | null; status: string }>(
-        `SELECT phone_number, forward_to, status FROM tenant_phone_numbers
+      query<{ phone_number: string; forward_to: string | null; status: string; twilio_sid: string }>(
+        `SELECT phone_number, forward_to, status, twilio_sid FROM tenant_phone_numbers
          WHERE tenant_id = $1 AND status = 'active'
          ORDER BY provisioned_at DESC LIMIT 1`,
         [id]
@@ -916,14 +918,64 @@ export async function adminRoute(app: FastifyInstance) {
     const blockedBillingStatuses = ["trial_expired", "canceled", "past_due_blocked"];
     const billingOk = !blockedBillingStatuses.includes(tenant.billing_status);
 
+    // ── Twilio webhook verification (live API check) ──────────────────────
+    // If we have a phone with a twilio_sid, verify Twilio's actual webhook config
+    let twilioWebhookResult: {
+      sms: { pass: boolean; expected: string; actual: string | null } | null;
+      voice: { pass: boolean; expected: string; actual: string | null } | null;
+      error: string | null;
+    } = { sms: null, voice: null, error: null };
+
+    if (phone?.twilio_sid) {
+      const expectedOrigin = process.env.PUBLIC_ORIGIN || process.env.API_BASE_URL || null;
+      if (!expectedOrigin) {
+        twilioWebhookResult.error = "PUBLIC_ORIGIN not configured — cannot verify webhook URLs";
+      } else {
+        const twilioResult = await fetchTwilioNumberConfig(phone.twilio_sid);
+        if (twilioResult.success && twilioResult.config) {
+          const verification = verifyWebhookUrls(twilioResult.config, expectedOrigin);
+          twilioWebhookResult.sms = verification.sms_webhook;
+          twilioWebhookResult.voice = verification.voice_webhook;
+        } else {
+          twilioWebhookResult.error = twilioResult.error || "Failed to fetch Twilio config";
+        }
+      }
+    }
+
     // Build readiness checks — ordered by the live path:
-    // Twilio number → voice/sms webhook → forward_to → missed-call trigger → AI reply → calendar
+    // Twilio number → webhooks configured → forward_to → missed-call trigger → AI reply → calendar
     const checks = [
       {
         id: "twilio_number",
         label: "Twilio number assigned",
         pass: !!phone,
         detail: phone ? phone.phone_number : "No active phone number provisioned",
+        critical: true,
+      },
+      {
+        id: "twilio_sms_webhook",
+        label: "Twilio SMS webhook URL correct",
+        pass: twilioWebhookResult.sms?.pass ?? false,
+        detail: !phone
+          ? "No phone number — skipped"
+          : twilioWebhookResult.error
+            ? `Cannot verify: ${twilioWebhookResult.error}`
+            : twilioWebhookResult.sms?.pass
+              ? `Configured: ${twilioWebhookResult.sms.actual}`
+              : `MISMATCH — Expected: ${twilioWebhookResult.sms?.expected} | Actual: ${twilioWebhookResult.sms?.actual || "(empty)"}. Fix in Twilio Console > Phone Numbers > ${phone.phone_number} > Messaging > A MESSAGE COMES IN`,
+        critical: true,
+      },
+      {
+        id: "twilio_voice_webhook",
+        label: "Twilio Voice webhook URL correct",
+        pass: twilioWebhookResult.voice?.pass ?? false,
+        detail: !phone
+          ? "No phone number — skipped"
+          : twilioWebhookResult.error
+            ? `Cannot verify: ${twilioWebhookResult.error}`
+            : twilioWebhookResult.voice?.pass
+              ? `Configured: ${twilioWebhookResult.voice.actual}`
+              : `MISMATCH — Expected: ${twilioWebhookResult.voice?.expected} | Actual: ${twilioWebhookResult.voice?.actual || "(empty)"}. Fix in Twilio Console > Phone Numbers > ${phone.phone_number} > Voice > A CALL COMES IN`,
         critical: true,
       },
       {

--- a/apps/api/src/services/twilio-verify.ts
+++ b/apps/api/src/services/twilio-verify.ts
@@ -1,0 +1,101 @@
+import { getConfig } from "../db/app-config";
+
+export interface TwilioWebhookConfig {
+  sms_url: string | null;
+  sms_method: string | null;
+  voice_url: string | null;
+  voice_method: string | null;
+  status_callback: string | null;
+  status_callback_method: string | null;
+  friendly_name: string | null;
+}
+
+export interface TwilioVerifyResult {
+  success: boolean;
+  config: TwilioWebhookConfig | null;
+  error: string | null;
+}
+
+/**
+ * Fetches the webhook configuration for a Twilio phone number by its SID.
+ * Calls Twilio REST API: GET /IncomingPhoneNumbers/{SID}.json
+ */
+export async function fetchTwilioNumberConfig(
+  twilioSid: string,
+  fetchFn: typeof fetch = fetch
+): Promise<TwilioVerifyResult> {
+  const accountSid = await getConfig("TWILIO_ACCOUNT_SID");
+  const authToken = await getConfig("TWILIO_AUTH_TOKEN");
+
+  if (!accountSid || !authToken) {
+    return { success: false, config: null, error: "Twilio credentials not configured" };
+  }
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/IncomingPhoneNumbers/${twilioSid}.json`;
+  const auth = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+
+  try {
+    const res = await fetchFn(url, {
+      method: "GET",
+      headers: { Authorization: `Basic ${auth}` },
+    });
+
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { message?: string };
+      return {
+        success: false,
+        config: null,
+        error: `Twilio API ${res.status}: ${data.message || "unknown error"}`,
+      };
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    return {
+      success: true,
+      config: {
+        sms_url: (data.sms_url as string) || null,
+        sms_method: (data.sms_method as string) || null,
+        voice_url: (data.voice_url as string) || null,
+        voice_method: (data.voice_method as string) || null,
+        status_callback: (data.status_callback as string) || null,
+        status_callback_method: (data.status_callback_method as string) || null,
+        friendly_name: (data.friendly_name as string) || null,
+      },
+      error: null,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      config: null,
+      error: `Twilio request failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+/**
+ * Checks webhook URLs against expected values.
+ * Returns per-check results with expected vs actual.
+ */
+export function verifyWebhookUrls(
+  config: TwilioWebhookConfig,
+  expectedOrigin: string
+): {
+  sms_webhook: { pass: boolean; expected: string; actual: string | null };
+  voice_webhook: { pass: boolean; expected: string; actual: string | null };
+} {
+  const expectedSms = `${expectedOrigin}/webhooks/twilio/sms`;
+  const expectedVoice = `${expectedOrigin}/webhooks/twilio/voice`;
+
+  return {
+    sms_webhook: {
+      pass: config.sms_url === expectedSms,
+      expected: expectedSms,
+      actual: config.sms_url,
+    },
+    voice_webhook: {
+      pass: config.voice_url === expectedVoice,
+      expected: expectedVoice,
+      actual: config.voice_url,
+    },
+  };
+}

--- a/apps/api/src/tests/pilot-readiness.test.ts
+++ b/apps/api/src/tests/pilot-readiness.test.ts
@@ -5,6 +5,7 @@ import Fastify from "fastify";
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
+  fetchTwilioNumberConfig: vi.fn(),
 }));
 
 vi.mock("../db/client", () => ({
@@ -16,11 +17,43 @@ vi.mock("../middleware/admin-guard", () => ({
   adminGuard: async () => {},
 }));
 
+vi.mock("../services/twilio-verify", () => ({
+  fetchTwilioNumberConfig: mocks.fetchTwilioNumberConfig,
+  verifyWebhookUrls: (
+    config: { sms_url: string | null; voice_url: string | null },
+    expectedOrigin: string
+  ) => {
+    const expectedSms = `${expectedOrigin}/webhooks/twilio/sms`;
+    const expectedVoice = `${expectedOrigin}/webhooks/twilio/voice`;
+    return {
+      sms_webhook: {
+        pass: config.sms_url === expectedSms,
+        expected: expectedSms,
+        actual: config.sms_url,
+      },
+      voice_webhook: {
+        pass: config.voice_url === expectedVoice,
+        expected: expectedVoice,
+        actual: config.voice_url,
+      },
+    };
+  },
+}));
+
+vi.mock("../db/app-config", () => ({
+  getConfig: async (key: string) => {
+    if (key === "TWILIO_ACCOUNT_SID") return "ACtest123";
+    if (key === "TWILIO_AUTH_TOKEN") return "authtest123";
+    return null;
+  },
+}));
+
 import { adminRoute } from "../routes/internal/admin";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const TEST_ORIGIN = "https://api.autoshop.example.com";
 
 async function buildApp() {
   const app = Fastify({ logger: false });
@@ -32,6 +65,22 @@ async function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.PUBLIC_ORIGIN = TEST_ORIGIN;
+
+  // Default: Twilio returns correct webhook URLs
+  mocks.fetchTwilioNumberConfig.mockResolvedValue({
+    success: true,
+    config: {
+      sms_url: `${TEST_ORIGIN}/webhooks/twilio/sms`,
+      sms_method: "POST",
+      voice_url: `${TEST_ORIGIN}/webhooks/twilio/voice`,
+      voice_method: "POST",
+      status_callback: null,
+      status_callback_method: null,
+      friendly_name: "AutoShop Test",
+    },
+    error: null,
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -59,6 +108,7 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
       phone_number: "+13257523890",
       forward_to: "+15125559999",
       status: "active",
+      twilio_sid: "PNf77089f763ad788a2ea7bf65e71c181a",
     };
 
     const calendar = overrides.calendar !== undefined ? overrides.calendar : {
@@ -91,7 +141,7 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it("returns 'ready' when all checks pass", async () => {
+  it("returns 'ready' when all checks pass including Twilio webhooks", async () => {
     const app = await buildApp();
     setupMocks();
 
@@ -106,6 +156,8 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     expect(body.blockers).toHaveLength(0);
     expect(body.warnings).toHaveLength(0);
     expect(body.checks.every((c: any) => c.pass)).toBe(true);
+    // Verify Twilio API was called
+    expect(mocks.fetchTwilioNumberConfig).toHaveBeenCalledWith("PNf77089f763ad788a2ea7bf65e71c181a");
   });
 
   it("returns 'not_ready' when no phone number", async () => {
@@ -121,12 +173,15 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     expect(body.verdict).toBe("not_ready");
     expect(body.blockers.some((b: any) => b.id === "twilio_number")).toBe(true);
     expect(body.blockers.some((b: any) => b.id === "forward_to")).toBe(true);
+    // Webhook checks should also fail (no phone = no SID to check)
+    expect(body.blockers.some((b: any) => b.id === "twilio_sms_webhook")).toBe(true);
+    expect(body.blockers.some((b: any) => b.id === "twilio_voice_webhook")).toBe(true);
   });
 
   it("returns 'not_ready' when forward_to is missing", async () => {
     const app = await buildApp();
     setupMocks({
-      phone: { phone_number: "+13257523890", forward_to: null, status: "active" },
+      phone: { phone_number: "+13257523890", forward_to: null, status: "active", twilio_sid: "PNtest" },
     });
 
     const res = await app.inject({
@@ -223,15 +278,15 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
   it("returns 'ready_with_warnings' when only non-critical checks fail", async () => {
     const app = await buildApp();
     setupMocks({
-      prompt: null, // AI prompt missing (non-critical)
+      prompt: null,
       tenant: {
         shop_name: "Joe's Auto",
         owner_phone: "+15125551234",
         billing_status: "trial",
         trial_ends_at: new Date(Date.now() + 7 * 86400000).toISOString(),
         missed_call_sms_template: "Template text",
-        business_hours: null, // missing (non-critical)
-        services_description: null, // missing (non-critical)
+        business_hours: null,
+        services_description: null,
       },
     });
 
@@ -257,11 +312,11 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     });
 
     const body = res.json();
-    expect(body.checks).toHaveLength(9);
+    expect(body.checks).toHaveLength(11);
     expect(body.summary).toMatch(/\d+\/\d+ critical checks passed/);
   });
 
-  it("returns all 9 checks in live-path order", async () => {
+  it("returns all 11 checks in live-path order", async () => {
     const app = await buildApp();
     setupMocks();
 
@@ -274,6 +329,8 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     const ids = body.checks.map((c: any) => c.id);
     expect(ids).toEqual([
       "twilio_number",
+      "twilio_sms_webhook",
+      "twilio_voice_webhook",
       "forward_to",
       "sms_template",
       "ai_prompt",
@@ -283,5 +340,111 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
       "calendar_token_valid",
       "billing_active",
     ]);
+  });
+
+  // ── Twilio webhook verification tests ──────────────────────────────────
+
+  it("returns 'not_ready' when Twilio SMS webhook URL is wrong", async () => {
+    const app = await buildApp();
+    setupMocks();
+    mocks.fetchTwilioNumberConfig.mockResolvedValue({
+      success: true,
+      config: {
+        sms_url: "https://old-domain.example.com/webhooks/twilio/sms",
+        sms_method: "POST",
+        voice_url: `${TEST_ORIGIN}/webhooks/twilio/voice`,
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "AutoShop Test",
+      },
+      error: null,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    const smsCheck = body.checks.find((c: any) => c.id === "twilio_sms_webhook");
+    expect(smsCheck.pass).toBe(false);
+    expect(smsCheck.detail).toContain("MISMATCH");
+    expect(smsCheck.detail).toContain("old-domain.example.com");
+    expect(smsCheck.detail).toContain("Twilio Console");
+  });
+
+  it("returns 'not_ready' when Twilio Voice webhook URL is wrong", async () => {
+    const app = await buildApp();
+    setupMocks();
+    mocks.fetchTwilioNumberConfig.mockResolvedValue({
+      success: true,
+      config: {
+        sms_url: `${TEST_ORIGIN}/webhooks/twilio/sms`,
+        sms_method: "POST",
+        voice_url: "https://wrong.example.com/webhooks/twilio/voice",
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "AutoShop Test",
+      },
+      error: null,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    const voiceCheck = body.checks.find((c: any) => c.id === "twilio_voice_webhook");
+    expect(voiceCheck.pass).toBe(false);
+    expect(voiceCheck.detail).toContain("MISMATCH");
+    expect(voiceCheck.detail).toContain("wrong.example.com");
+  });
+
+  it("shows error detail when Twilio API call fails", async () => {
+    const app = await buildApp();
+    setupMocks();
+    mocks.fetchTwilioNumberConfig.mockResolvedValue({
+      success: false,
+      config: null,
+      error: "Twilio API 401: Authentication failed",
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    const smsCheck = body.checks.find((c: any) => c.id === "twilio_sms_webhook");
+    expect(smsCheck.pass).toBe(false);
+    expect(smsCheck.detail).toContain("Cannot verify");
+    expect(smsCheck.detail).toContain("Authentication failed");
+  });
+
+  it("shows error when PUBLIC_ORIGIN is not set", async () => {
+    const app = await buildApp();
+    setupMocks();
+    delete process.env.PUBLIC_ORIGIN;
+    delete process.env.API_BASE_URL;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/internal/admin/tenants/${TENANT_ID}/pilot-readiness`,
+    });
+
+    const body = res.json();
+    expect(body.verdict).toBe("not_ready");
+    const smsCheck = body.checks.find((c: any) => c.id === "twilio_sms_webhook");
+    expect(smsCheck.pass).toBe(false);
+    expect(smsCheck.detail).toContain("PUBLIC_ORIGIN not configured");
+
+    // Restore for other tests
+    process.env.PUBLIC_ORIGIN = TEST_ORIGIN;
   });
 });

--- a/apps/api/src/tests/twilio-verify.test.ts
+++ b/apps/api/src/tests/twilio-verify.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/app-config", () => ({
+  getConfig: vi.fn(),
+}));
+
+import { fetchTwilioNumberConfig, verifyWebhookUrls } from "../services/twilio-verify";
+import { getConfig } from "../db/app-config";
+
+const mockGetConfig = vi.mocked(getConfig);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockImplementation(async (key: string) => {
+    if (key === "TWILIO_ACCOUNT_SID") return "AC1234567890";
+    if (key === "TWILIO_AUTH_TOKEN") return "authtoken123";
+    return null;
+  });
+});
+
+describe("fetchTwilioNumberConfig", () => {
+  it("returns config when Twilio API responds successfully", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sms_url: "https://api.example.com/webhooks/twilio/sms",
+        sms_method: "POST",
+        voice_url: "https://api.example.com/webhooks/twilio/voice",
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "Test Number",
+      }),
+    });
+
+    const result = await fetchTwilioNumberConfig("PNtest123", mockFetch);
+
+    expect(result.success).toBe(true);
+    expect(result.config?.sms_url).toBe("https://api.example.com/webhooks/twilio/sms");
+    expect(result.config?.voice_url).toBe("https://api.example.com/webhooks/twilio/voice");
+    expect(result.error).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.twilio.com/2010-04-01/Accounts/AC1234567890/IncomingPhoneNumbers/PNtest123.json",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("returns error when Twilio credentials missing", async () => {
+    mockGetConfig.mockResolvedValue(null);
+
+    const result = await fetchTwilioNumberConfig("PNtest123");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Twilio credentials not configured");
+  });
+
+  it("returns error when Twilio API returns non-OK", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: "Number not found" }),
+    });
+
+    const result = await fetchTwilioNumberConfig("PNinvalid", mockFetch);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("404");
+    expect(result.error).toContain("Number not found");
+  });
+
+  it("returns error when fetch throws", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const result = await fetchTwilioNumberConfig("PNtest123", mockFetch);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Network error");
+  });
+});
+
+describe("verifyWebhookUrls", () => {
+  const origin = "https://api.autoshop.example.com";
+
+  it("returns pass when URLs match expected origin", () => {
+    const result = verifyWebhookUrls(
+      {
+        sms_url: `${origin}/webhooks/twilio/sms`,
+        sms_method: "POST",
+        voice_url: `${origin}/webhooks/twilio/voice`,
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "Test",
+      },
+      origin
+    );
+
+    expect(result.sms_webhook.pass).toBe(true);
+    expect(result.voice_webhook.pass).toBe(true);
+  });
+
+  it("returns fail when SMS URL points to wrong domain", () => {
+    const result = verifyWebhookUrls(
+      {
+        sms_url: "https://old.example.com/webhooks/twilio/sms",
+        sms_method: "POST",
+        voice_url: `${origin}/webhooks/twilio/voice`,
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "Test",
+      },
+      origin
+    );
+
+    expect(result.sms_webhook.pass).toBe(false);
+    expect(result.sms_webhook.expected).toBe(`${origin}/webhooks/twilio/sms`);
+    expect(result.sms_webhook.actual).toBe("https://old.example.com/webhooks/twilio/sms");
+    expect(result.voice_webhook.pass).toBe(true);
+  });
+
+  it("returns fail when voice URL is empty", () => {
+    const result = verifyWebhookUrls(
+      {
+        sms_url: `${origin}/webhooks/twilio/sms`,
+        sms_method: "POST",
+        voice_url: null,
+        voice_method: null,
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "Test",
+      },
+      origin
+    );
+
+    expect(result.sms_webhook.pass).toBe(true);
+    expect(result.voice_webhook.pass).toBe(false);
+    expect(result.voice_webhook.actual).toBeNull();
+  });
+
+  it("returns fail when both URLs are wrong", () => {
+    const result = verifyWebhookUrls(
+      {
+        sms_url: "https://wrong.com/sms",
+        sms_method: "POST",
+        voice_url: "https://wrong.com/voice",
+        voice_method: "POST",
+        status_callback: null,
+        status_callback_method: null,
+        friendly_name: "Test",
+      },
+      origin
+    );
+
+    expect(result.sms_webhook.pass).toBe(false);
+    expect(result.voice_webhook.pass).toBe(false);
+  });
+});

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -1095,7 +1095,7 @@ async function loadPilotReadiness(tenantId) {
       </div>
 
       <div style="font-weight:700;font-size:14px;margin-bottom:12px;color:var(--white)">
-        Live Path: Twilio &rarr; Voice/SMS &rarr; Forward &rarr; Missed-call &rarr; AI Reply &rarr; Calendar
+        Live Path: Twilio Number &rarr; Webhook URLs &rarr; Forward &rarr; Missed-call SMS &rarr; AI Reply &rarr; Calendar
       </div>
 
       <div style="display:flex;flex-direction:column;gap:8px">


### PR DESCRIPTION
## Summary
- **New critical check**: Pilot readiness now calls Twilio REST API to verify the phone number's actual SMS and Voice webhook URLs match the expected `PUBLIC_ORIGIN`
- **Surfaces mismatches as blockers** with exact Twilio Console path and expected URL for fix
- **Closes the #1 silent-failure gap** between "tenant marked READY" and a real external pilot test succeeding

## What changed
- `apps/api/src/services/twilio-verify.ts` — New service: fetches phone number config from Twilio API, compares webhook URLs
- `apps/api/src/routes/internal/admin.ts` — 2 new critical checks added to pilot-readiness: `twilio_sms_webhook`, `twilio_voice_webhook`
- `apps/web/admin.html` — Updated live-path label in readiness UI
- `apps/api/src/tests/pilot-readiness.test.ts` — 15 tests (was 11), covers webhook pass/fail/error/missing-origin
- `apps/api/src/tests/twilio-verify.test.ts` — 8 new unit tests for the verification service

## Why this is highest leverage
Previously, a tenant could pass all readiness checks (internal DB looks fine) but Twilio's webhooks could point to a wrong domain — the human would call/text, nothing would happen, with no way to diagnose from the admin dashboard. Now the readiness check catches this before any live test attempt.

## Test plan
- [x] All 339 tests pass (21 test files, 0 failures)
- [x] Webhook URL mismatch correctly surfaces as critical blocker
- [x] Twilio API failure gracefully degrades to "Cannot verify" message
- [x] Missing PUBLIC_ORIGIN detected and reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)