### PR TITLE
feat: pilot execution trace for missed-call and inbound SMS

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -5,6 +5,7 @@ import { query } from "../../db/client";
 import { adminGuard } from "../../middleware/admin-guard";
 import { fetchTwilioNumberConfig, verifyWebhookUrls } from "../../services/twilio-verify";
 import { getConfig } from "../../db/app-config";
+import { getRecentTraces, getTraceById } from "../../services/pipeline-trace";
 
 /**
  * Internal Admin API
@@ -1172,5 +1173,20 @@ export async function adminRoute(app: FastifyInstance) {
     }
 
     return reply.status(200).send({ success: true });
+  });
+
+  // ── GET /internal/admin/traces ────────────────────────────────────────────
+  // Returns recent pipeline execution traces for pilot live-test visibility.
+  app.get("/admin/traces", { preHandler: [adminGuard] }, async (_req, reply) => {
+    const traces = await getRecentTraces(100);
+    return reply.send(traces);
+  });
+
+  // ── GET /internal/admin/traces/:id ────────────────────────────────────────
+  app.get("/admin/traces/:id", { preHandler: [adminGuard] }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const trace = await getTraceById(id);
+    if (!trace) return reply.status(404).send({ error: "Trace not found" });
+    return reply.send(trace);
   });
 }

--- a/apps/api/src/routes/internal/missed-call-sms.ts
+++ b/apps/api/src/routes/internal/missed-call-sms.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { handleMissedCallSms } from "../../services/missed-call-sms";
+import { resumeTrace } from "../../services/pipeline-trace";
 
 const BodySchema = z.object({
   tenantId: z.string().uuid(),
@@ -8,6 +9,7 @@ const BodySchema = z.object({
   ourPhone: z.string().min(1),
   callSid: z.string().min(1),
   callStatus: z.string().min(1),
+  traceId: z.string().uuid().nullable().optional(),
 });
 
 /**
@@ -31,7 +33,34 @@ export async function missedCallSmsRoute(app: FastifyInstance) {
       });
     }
 
-    const result = await handleMissedCallSms(parsed.data);
+    const { traceId, ...missedCallInput } = parsed.data;
+    const trace = traceId ? await resumeTrace(traceId).catch(() => null) : null;
+
+    if (trace) {
+      await trace.step("worker_picked_up", "ok", "missed-call-sms handler started");
+    }
+
+    const result = await handleMissedCallSms(missedCallInput);
+
+    // ── Record trace steps from result ──────────────────────────────────
+    if (trace) {
+      try {
+        if (result.conversationId) {
+          await trace.step("conversation_created", "ok", `conv: ${result.conversationId.slice(0, 8)}`);
+        }
+        if (result.smsSent) {
+          await trace.step("sms_sent", "ok", `Initial SMS sent (sid: ${result.twilioSid?.slice(0, 10) ?? "n/a"})`);
+        } else {
+          await trace.step("sms_sent", "fail", result.error ?? "SMS not sent");
+        }
+
+        if (result.success) {
+          await trace.complete();
+        } else {
+          await trace.fail(result.error ?? "Unknown error");
+        }
+      } catch { /* non-fatal */ }
+    }
 
     request.log.info(
       {

--- a/apps/api/src/routes/internal/process-sms.ts
+++ b/apps/api/src/routes/internal/process-sms.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { processSms } from "../../services/process-sms";
+import { resumeTrace } from "../../services/pipeline-trace";
 
 const BodySchema = z.object({
   tenantId: z.string().uuid(),
@@ -9,6 +10,7 @@ const BodySchema = z.object({
   body: z.string().min(1),
   messageSid: z.string().min(1),
   atSoftLimit: z.boolean().default(false),
+  traceId: z.string().uuid().nullable().optional(),
 });
 
 /**
@@ -34,7 +36,48 @@ export async function processSmsRoute(app: FastifyInstance) {
       });
     }
 
-    const result = await processSms(parsed.data);
+    const { traceId, ...smsInput } = parsed.data;
+    const trace = traceId ? await resumeTrace(traceId).catch(() => null) : null;
+
+    if (trace) {
+      await trace.step("worker_picked_up", "ok", "process-sms handler started");
+    }
+
+    const result = await processSms(smsInput);
+
+    // ── Record trace steps from result ──────────────────────────────────
+    if (trace) {
+      try {
+        if (result.conversationId) {
+          await trace.step("conversation_resolved", "ok", `conv: ${result.conversationId.slice(0, 8)}`);
+        }
+        if (result.aiResponse) {
+          await trace.step("ai_replied", "ok", `${result.aiResponse.length} chars`);
+        } else if (result.error?.includes("OpenAI")) {
+          await trace.step("ai_replied", "fail", result.error);
+        }
+        if (result.isBooked) {
+          await trace.step("booking_detected", "ok", `appointment: ${result.appointmentId?.slice(0, 8) ?? "n/a"}`);
+        }
+        if (result.calendarSynced) {
+          await trace.step("calendar_synced", "ok", "Google Calendar event created");
+        } else if (result.isBooked) {
+          await trace.step("calendar_synced", result.bookingState === "FAILED" ? "fail" : "skip",
+            result.error?.includes("Calendar") ? result.error : "Calendar sync not completed");
+        }
+        if (result.smsSent) {
+          await trace.step("sms_sent", "ok", `Reply SMS sent to customer`);
+        } else if (result.error?.includes("SMS")) {
+          await trace.step("sms_sent", "fail", result.error);
+        }
+
+        if (result.success) {
+          await trace.complete();
+        } else {
+          await trace.fail(result.error ?? "Unknown error");
+        }
+      } catch { /* non-fatal */ }
+    }
 
     request.log.info(
       {

--- a/apps/api/src/routes/webhooks/twilio-sms.ts
+++ b/apps/api/src/routes/webhooks/twilio-sms.ts
@@ -7,6 +7,7 @@ import {
   checkIdempotency,
   markIdempotency,
 } from "../../queues/redis";
+import { startTrace } from "../../services/pipeline-trace";
 
 // Twilio sends form-encoded body
 const TwilioSmsBody = z.object({
@@ -31,6 +32,20 @@ export async function twilioSmsRoute(app: FastifyInstance) {
 
       const { MessageSid, From, To, Body } = parsed.data;
 
+      // ── 0. Start execution trace ──────────────────────────────────────────
+      let traceId: string | null = null;
+      try {
+        const trace = await startTrace({
+          triggerType: "inbound_sms",
+          triggerId: MessageSid,
+          customerPhone: From,
+        });
+        traceId = trace.id;
+        await trace.step("webhook_received", "ok", `POST /webhooks/twilio/sms from ${From}`);
+      } catch {
+        // Non-fatal: tracing must never break the pipeline
+      }
+
       // ── 1. Idempotency (Twilio retries if no 200 within 15s) ──────────────
       const alreadyProcessed = await checkIdempotency(`twilio:${MessageSid}`);
       if (alreadyProcessed) {
@@ -43,8 +58,23 @@ export async function twilioSmsRoute(app: FastifyInstance) {
       const tenant = await getTenantByPhoneNumber(To);
       if (!tenant) {
         request.log.warn({ to: To }, "No tenant found for phone number");
+        if (traceId) {
+          const { resumeTrace } = await import("../../services/pipeline-trace");
+          const t = await resumeTrace(traceId);
+          await t.step("tenant_resolved", "fail", `No tenant for ${To}`);
+          await t.fail(`No tenant found for phone number ${To}`);
+        }
         // Return 200 to Twilio (avoid retry storms), but don't process
         return reply.status(200).type("text/xml").send("<Response/>");
+      }
+
+      if (traceId) {
+        try {
+          const { resumeTrace } = await import("../../services/pipeline-trace");
+          const t = await resumeTrace(traceId);
+          await t.setTenant(tenant.id);
+          await t.step("tenant_resolved", "ok", `${tenant.shop_name ?? "unknown"} (${tenant.id.slice(0, 8)})`);
+        } catch { /* non-fatal */ }
       }
 
       // ── 3. Enforcement check ───────────────────────────────────────────────
@@ -54,6 +84,14 @@ export async function twilioSmsRoute(app: FastifyInstance) {
           { tenantId: tenant.id, blockReason },
           "Tenant blocked — queuing block-response job"
         );
+        if (traceId) {
+          try {
+            const { resumeTrace } = await import("../../services/pipeline-trace");
+            const t = await resumeTrace(traceId);
+            await t.step("billing_check", "fail", `Blocked: ${blockReason}`);
+            await t.fail(`Tenant blocked: ${blockReason}`);
+          } catch { /* non-fatal */ }
+        }
         // TODO: enqueue a job to send a "service unavailable" SMS reply
         // This keeps the response fast and moves SMS sending to worker
         return reply.status(200).type("text/xml").send("<Response/>");
@@ -77,6 +115,7 @@ export async function twilioSmsRoute(app: FastifyInstance) {
             body: Body,
             messageSid: MessageSid,
             atSoftLimit,
+            traceId,
           },
           {
             jobId: `sms-${MessageSid}`, // BullMQ dedup key
@@ -87,11 +126,27 @@ export async function twilioSmsRoute(app: FastifyInstance) {
           { tenantId: tenant.id, from: From, messageSid: MessageSid },
           "SMS job enqueued"
         );
+
+        if (traceId) {
+          try {
+            const { resumeTrace } = await import("../../services/pipeline-trace");
+            const t = await resumeTrace(traceId);
+            await t.step("job_enqueued", "ok", "sms-inbound / process-sms");
+          } catch { /* non-fatal */ }
+        }
       } catch (err) {
         request.log.error(
           { err, tenantId: tenant.id, messageSid: MessageSid },
           "Failed to enqueue SMS job — Redis may be down"
         );
+        if (traceId) {
+          try {
+            const { resumeTrace } = await import("../../services/pipeline-trace");
+            const t = await resumeTrace(traceId);
+            await t.step("job_enqueued", "fail", `Redis error: ${(err as Error).message}`);
+            await t.fail(`Failed to enqueue job: ${(err as Error).message}`);
+          } catch { /* non-fatal */ }
+        }
       }
 
       // Must respond with TwiML — empty = no immediate reply (worker sends reply)

--- a/apps/api/src/routes/webhooks/twilio-voice-status.ts
+++ b/apps/api/src/routes/webhooks/twilio-voice-status.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { validateTwilioSignature } from "../../middleware/twilio-validate";
 import { getTenantByPhoneNumber } from "../../db/tenants";
 import { smsInboundQueue, checkIdempotency, markIdempotency } from "../../queues/redis";
+import { startTrace, resumeTrace } from "../../services/pipeline-trace";
 
 const TwilioVoiceStatusBody = z.object({
   CallSid: z.string(),
@@ -42,6 +43,20 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
         return reply.status(200).type("text/xml").send("<Response/>");
       }
 
+      // ── Start execution trace ──────────────────────────────────────────
+      let traceId: string | null = null;
+      try {
+        const trace = await startTrace({
+          triggerType: "missed_call",
+          triggerId: CallSid,
+          customerPhone: From,
+        });
+        traceId = trace.id;
+        await trace.step("webhook_received", "ok", `POST /webhooks/twilio/voice-status — ${CallStatus}`);
+      } catch {
+        // Non-fatal
+      }
+
       // Idempotency
       const key = `voice:${CallSid}`;
       if (await checkIdempotency(key)) {
@@ -52,7 +67,22 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
       const tenant = await getTenantByPhoneNumber(To);
       if (!tenant) {
         request.log.warn({ to: To }, "No tenant found for voice status webhook");
+        if (traceId) {
+          try {
+            const t = await resumeTrace(traceId);
+            await t.step("tenant_resolved", "fail", `No tenant for ${To}`);
+            await t.fail(`No tenant found for phone number ${To}`);
+          } catch { /* non-fatal */ }
+        }
         return reply.status(200).type("text/xml").send("<Response/>");
+      }
+
+      if (traceId) {
+        try {
+          const t = await resumeTrace(traceId);
+          await t.setTenant(tenant.id);
+          await t.step("tenant_resolved", "ok", `${tenant.shop_name ?? "unknown"} (${tenant.id.slice(0, 8)})`);
+        } catch { /* non-fatal */ }
       }
 
       // Enqueue missed-call SMS trigger
@@ -68,6 +98,7 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
             callSid: CallSid,
             callStatus: CallStatus,
             triggerType: "missed_call",
+            traceId,
           },
           {
             jobId: `missed-call-${CallSid}`,
@@ -79,11 +110,25 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
           { tenantId: tenant.id, callSid: CallSid, callStatus: CallStatus },
           "Missed call job enqueued"
         );
+
+        if (traceId) {
+          try {
+            const t = await resumeTrace(traceId);
+            await t.step("job_enqueued", "ok", "sms-inbound / missed-call-trigger");
+          } catch { /* non-fatal */ }
+        }
       } catch (err) {
         request.log.error(
           { err, tenantId: tenant.id, callSid: CallSid },
           "Failed to enqueue missed-call job — Redis may be down"
         );
+        if (traceId) {
+          try {
+            const t = await resumeTrace(traceId);
+            await t.step("job_enqueued", "fail", `Redis error: ${(err as Error).message}`);
+            await t.fail(`Failed to enqueue job: ${(err as Error).message}`);
+          } catch { /* non-fatal */ }
+        }
       }
 
       return reply.status(200).type("text/xml").send("<Response/>");

--- a/apps/api/src/services/pipeline-trace.ts
+++ b/apps/api/src/services/pipeline-trace.ts
@@ -1,0 +1,196 @@
+/**
+ * Pipeline Execution Trace Service
+ *
+ * Records step-by-step execution traces for missed-call and inbound-SMS
+ * pipeline runs. Each trace captures every step the pipeline touched,
+ * whether it succeeded or failed, and how long it took.
+ *
+ * This gives operators immediate visibility into "where exactly did it
+ * fail?" after a real pilot test attempt.
+ *
+ * Usage pattern:
+ *   const trace = await startTrace({ ... });
+ *   await trace.step("tenant_resolved", "ok", "Bob's Auto (abc-123)");
+ *   await trace.step("job_enqueued", "ok", "sms-inbound / process-sms");
+ *   await trace.complete();        // or trace.fail("reason")
+ */
+
+import { query } from "../db/client";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type TriggerType = "missed_call" | "inbound_sms";
+export type StepStatus = "ok" | "fail" | "skip";
+export type TraceStatus = "running" | "completed" | "failed";
+
+export interface TraceStep {
+  step: string;
+  status: StepStatus;
+  detail: string | null;
+  at: string;        // ISO timestamp
+  ms: number | null;  // duration if measured
+}
+
+export interface PipelineTrace {
+  id: string;
+  tenant_id: string | null;
+  trigger_type: TriggerType;
+  trigger_id: string | null;
+  customer_phone: string | null;
+  status: TraceStatus;
+  steps: TraceStep[];
+  started_at: string;
+  completed_at: string | null;
+  error_summary: string | null;
+}
+
+export interface StartTraceInput {
+  triggerType: TriggerType;
+  triggerId: string | null;
+  customerPhone: string | null;
+  tenantId?: string | null;
+}
+
+export interface TraceHandle {
+  id: string;
+  /** Record a pipeline step. Non-fatal: silently ignores DB errors. */
+  step: (name: string, status: StepStatus, detail?: string | null, durationMs?: number | null) => Promise<void>;
+  /** Set tenant_id after resolution (may not be known at trace start). */
+  setTenant: (tenantId: string) => Promise<void>;
+  /** Mark trace as completed (all steps done). */
+  complete: () => Promise<void>;
+  /** Mark trace as failed with an error summary. */
+  fail: (error: string) => Promise<void>;
+}
+
+// ── Core functions ───────────────────────────────────────────────────────────
+
+/**
+ * Start a new pipeline execution trace.
+ * Returns a handle with step(), complete(), and fail() methods.
+ */
+export async function startTrace(input: StartTraceInput): Promise<TraceHandle> {
+  const rows = await query<{ id: string }>(
+    `INSERT INTO pipeline_traces (trigger_type, trigger_id, customer_phone, tenant_id, status)
+     VALUES ($1, $2, $3, $4, 'running')
+     RETURNING id`,
+    [input.triggerType, input.triggerId, input.customerPhone, input.tenantId ?? null]
+  );
+
+  const traceId = rows[0].id;
+
+  return buildHandle(traceId);
+}
+
+/**
+ * Resume an existing trace by ID (used when worker picks up a job
+ * that was started at the webhook layer).
+ */
+export async function resumeTrace(traceId: string): Promise<TraceHandle> {
+  return buildHandle(traceId);
+}
+
+/**
+ * Find trace by trigger_id (CallSid or MessageSid).
+ * Returns the trace ID if found, null otherwise.
+ */
+export async function findTraceByTriggerId(triggerId: string): Promise<string | null> {
+  const rows = await query<{ id: string }>(
+    `SELECT id FROM pipeline_traces WHERE trigger_id = $1 ORDER BY started_at DESC LIMIT 1`,
+    [triggerId]
+  );
+  return rows.length > 0 ? rows[0].id : null;
+}
+
+/**
+ * Fetch recent traces for the admin UI.
+ */
+export async function getRecentTraces(limit = 50): Promise<PipelineTrace[]> {
+  return query<PipelineTrace>(
+    `SELECT id, tenant_id, trigger_type, trigger_id, customer_phone,
+            status, steps, started_at, completed_at, error_summary
+     FROM pipeline_traces
+     ORDER BY started_at DESC
+     LIMIT $1`,
+    [limit]
+  );
+}
+
+/**
+ * Fetch a single trace by ID.
+ */
+export async function getTraceById(id: string): Promise<PipelineTrace | null> {
+  const rows = await query<PipelineTrace>(
+    `SELECT id, tenant_id, trigger_type, trigger_id, customer_phone,
+            status, steps, started_at, completed_at, error_summary
+     FROM pipeline_traces
+     WHERE id = $1`,
+    [id]
+  );
+  return rows.length > 0 ? rows[0] : null;
+}
+
+// ── Internal ─────────────────────────────────────────────────────────────────
+
+function buildHandle(traceId: string): TraceHandle {
+  return {
+    id: traceId,
+
+    async step(name: string, status: StepStatus, detail?: string | null, durationMs?: number | null) {
+      const stepObj: TraceStep = {
+        step: name,
+        status,
+        detail: detail ?? null,
+        at: new Date().toISOString(),
+        ms: durationMs ?? null,
+      };
+      try {
+        await query(
+          `UPDATE pipeline_traces
+           SET steps = steps || $1::jsonb
+           WHERE id = $2`,
+          [JSON.stringify([stepObj]), traceId]
+        );
+      } catch {
+        // Non-fatal: tracing must never break the pipeline
+      }
+    },
+
+    async setTenant(tenantId: string) {
+      try {
+        await query(
+          `UPDATE pipeline_traces SET tenant_id = $1 WHERE id = $2`,
+          [tenantId, traceId]
+        );
+      } catch {
+        // Non-fatal
+      }
+    },
+
+    async complete() {
+      try {
+        await query(
+          `UPDATE pipeline_traces
+           SET status = 'completed', completed_at = now()
+           WHERE id = $1`,
+          [traceId]
+        );
+      } catch {
+        // Non-fatal
+      }
+    },
+
+    async fail(error: string) {
+      try {
+        await query(
+          `UPDATE pipeline_traces
+           SET status = 'failed', completed_at = now(), error_summary = $1
+           WHERE id = $2`,
+          [error, traceId]
+        );
+      } catch {
+        // Non-fatal
+      }
+    },
+  };
+}

--- a/apps/api/src/tests/missed-call-sms.test.ts
+++ b/apps/api/src/tests/missed-call-sms.test.ts
@@ -12,6 +12,16 @@ vi.mock("../db/client", () => ({
   query: mocks.query,
 }));
 
+vi.mock("../services/pipeline-trace", () => ({
+  resumeTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 import { missedCallSmsRoute } from "../routes/internal/missed-call-sms";
 import {
   handleMissedCallSms,

--- a/apps/api/src/tests/pipeline-trace.test.ts
+++ b/apps/api/src/tests/pipeline-trace.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: (...args: unknown[]) => mockQuery(...args),
+  withTenant: vi.fn(),
+}));
+
+import {
+  startTrace,
+  resumeTrace,
+  findTraceByTriggerId,
+  getRecentTraces,
+  getTraceById,
+} from "../services/pipeline-trace";
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+const TRACE_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockResolvedValue([]);
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("pipeline-trace", () => {
+  describe("startTrace", () => {
+    it("inserts a new trace and returns a handle", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      expect(handle.id).toBe(TRACE_ID);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(mockQuery.mock.calls[0][0]).toContain("INSERT INTO pipeline_traces");
+      expect(mockQuery.mock.calls[0][1]).toEqual([
+        "inbound_sms",
+        "SM123",
+        "+15551234567",
+        null,
+      ]);
+    });
+
+    it("accepts optional tenantId", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+
+      await startTrace({
+        triggerType: "missed_call",
+        triggerId: "CA456",
+        customerPhone: "+15559999999",
+        tenantId: "tenant-1",
+      });
+
+      expect(mockQuery.mock.calls[0][1]).toEqual([
+        "missed_call",
+        "CA456",
+        "+15559999999",
+        "tenant-1",
+      ]);
+    });
+  });
+
+  describe("TraceHandle.step", () => {
+    it("appends a step via JSONB concat", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.step("webhook_received", "ok", "POST /webhooks/twilio/sms");
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      const stepCall = mockQuery.mock.calls[1];
+      expect(stepCall[0]).toContain("steps || $1::jsonb");
+      const stepData = JSON.parse(stepCall[1][0]);
+      expect(stepData).toHaveLength(1);
+      expect(stepData[0].step).toBe("webhook_received");
+      expect(stepData[0].status).toBe("ok");
+      expect(stepData[0].detail).toBe("POST /webhooks/twilio/sms");
+      expect(stepData[0].at).toBeDefined();
+    });
+
+    it("records duration if provided", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.step("ai_replied", "ok", "200 chars", 350);
+
+      const stepData = JSON.parse(mockQuery.mock.calls[1][1][0]);
+      expect(stepData[0].ms).toBe(350);
+    });
+
+    it("silently ignores db errors (non-fatal)", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockRejectedValueOnce(new Error("db down"));
+      // Should not throw
+      await handle.step("tenant_resolved", "fail", "no tenant");
+    });
+  });
+
+  describe("TraceHandle.setTenant", () => {
+    it("updates tenant_id on the trace", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.setTenant("tenant-abc");
+
+      expect(mockQuery.mock.calls[1][0]).toContain("SET tenant_id");
+      expect(mockQuery.mock.calls[1][1]).toEqual(["tenant-abc", TRACE_ID]);
+    });
+  });
+
+  describe("TraceHandle.complete", () => {
+    it("sets status to completed with timestamp", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.complete();
+
+      expect(mockQuery.mock.calls[1][0]).toContain("status = 'completed'");
+      expect(mockQuery.mock.calls[1][0]).toContain("completed_at = now()");
+    });
+  });
+
+  describe("TraceHandle.fail", () => {
+    it("sets status to failed with error summary", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const handle = await startTrace({
+        triggerType: "inbound_sms",
+        triggerId: "SM123",
+        customerPhone: "+15551234567",
+      });
+
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.fail("No tenant found");
+
+      expect(mockQuery.mock.calls[1][0]).toContain("status = 'failed'");
+      expect(mockQuery.mock.calls[1][1]).toEqual(["No tenant found", TRACE_ID]);
+    });
+  });
+
+  describe("resumeTrace", () => {
+    it("returns a handle for an existing trace ID", async () => {
+      const handle = await resumeTrace(TRACE_ID);
+      expect(handle.id).toBe(TRACE_ID);
+    });
+
+    it("can add steps to a resumed trace", async () => {
+      const handle = await resumeTrace(TRACE_ID);
+      mockQuery.mockResolvedValueOnce([]);
+      await handle.step("worker_picked_up", "ok", "started");
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("findTraceByTriggerId", () => {
+    it("returns trace id when found", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: TRACE_ID }]);
+      const result = await findTraceByTriggerId("SM123");
+      expect(result).toBe(TRACE_ID);
+      expect(mockQuery.mock.calls[0][1]).toEqual(["SM123"]);
+    });
+
+    it("returns null when not found", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+      const result = await findTraceByTriggerId("SM999");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getRecentTraces", () => {
+    it("queries with default limit of 50", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+      await getRecentTraces();
+      expect(mockQuery.mock.calls[0][1]).toEqual([50]);
+    });
+
+    it("queries with custom limit", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+      await getRecentTraces(10);
+      expect(mockQuery.mock.calls[0][1]).toEqual([10]);
+    });
+
+    it("returns trace records", async () => {
+      const mockTrace = {
+        id: TRACE_ID,
+        tenant_id: "t1",
+        trigger_type: "inbound_sms",
+        trigger_id: "SM123",
+        customer_phone: "+15551234567",
+        status: "completed",
+        steps: [],
+        started_at: "2026-03-16T12:00:00Z",
+        completed_at: "2026-03-16T12:00:02Z",
+        error_summary: null,
+      };
+      mockQuery.mockResolvedValueOnce([mockTrace]);
+      const result = await getRecentTraces();
+      expect(result).toEqual([mockTrace]);
+    });
+  });
+
+  describe("getTraceById", () => {
+    it("returns trace when found", async () => {
+      const mockTrace = { id: TRACE_ID, status: "completed" };
+      mockQuery.mockResolvedValueOnce([mockTrace]);
+      const result = await getTraceById(TRACE_ID);
+      expect(result).toEqual(mockTrace);
+    });
+
+    it("returns null when not found", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+      const result = await getTraceById("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -17,6 +17,16 @@ vi.mock("../routes/auth/google", () => ({
   decryptToken: vi.fn((t: string) => t),
 }));
 
+vi.mock("../services/pipeline-trace", () => ({
+  resumeTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 import { processSms, ProcessSmsInput } from "../services/process-sms";
 import { processSmsRoute } from "../routes/internal/process-sms";
 

--- a/apps/api/src/tests/sms-inbound.test.ts
+++ b/apps/api/src/tests/sms-inbound.test.ts
@@ -29,6 +29,23 @@ vi.mock("../db/tenants", () => ({
   getBlockReason: mocks.getBlockReason,
 }));
 
+vi.mock("../services/pipeline-trace", () => ({
+  startTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+  resumeTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 import { twilioSmsRoute } from "../routes/webhooks/twilio-sms";
 
 // ── Constants ──────────────────────────────────────────────────────────────────

--- a/apps/api/src/tests/voice-status.test.ts
+++ b/apps/api/src/tests/voice-status.test.ts
@@ -27,6 +27,23 @@ vi.mock("../db/tenants", () => ({
   getBlockReason: vi.fn(() => null),
 }));
 
+vi.mock("../services/pipeline-trace", () => ({
+  startTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+  resumeTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 import { twilioVoiceStatusRoute } from "../routes/webhooks/twilio-voice-status";
 
 // ── Constants ─────────────────────────────────────────────────────────────────

--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -344,6 +344,10 @@ body{background:var(--bg);color:var(--white);font-family:var(--body);line-height
       <div class="sidebar-item" data-section="signup" onclick="navigate('signup')">
         <span class="sidebar-icon">⊕</span> Signup Funnel
       </div>
+      <div class="sidebar-label">Pilot</div>
+      <div class="sidebar-item" data-section="traces" onclick="navigate('traces')">
+        <span class="sidebar-icon">▸</span> Execution Traces
+      </div>
       <div class="sidebar-label">Logs</div>
       <div class="sidebar-item" data-section="audit" onclick="navigate('audit')">
         <span class="sidebar-icon">≡</span> Audit Log
@@ -493,6 +497,7 @@ function navigate(section, params) {
     case 'errors':        loadErrors(); break;
     case 'signup':        loadSignupFunnel(); break;
     case 'audit':         loadAudit(); break;
+    case 'traces':        loadTraces(); break;
     case 'project-ops':   loadProjectOps(); break;
     default: main.innerHTML = '<div class="empty-state">Unknown section</div>';
   }
@@ -1729,6 +1734,129 @@ async function loadSignupFunnel() {
   } catch (err) {
     document.getElementById('mainContent').innerHTML = renderError(err);
   }
+}
+
+// ── SECTION: EXECUTION TRACES ────────────────────────────────────────────────
+function loadTraces() {
+  apiFetch('/internal/admin/traces').then(traces => {
+    const main = document.getElementById('mainContent');
+    if (!traces || traces.length === 0) {
+      main.innerHTML = `
+        <div class="page-header">
+          <div><div class="page-title">Execution Traces</div>
+          <div class="page-subtitle">Pipeline execution traces for pilot live-test visibility</div></div>
+        </div>
+        <div class="empty-state">No traces yet. Traces appear when Twilio webhooks fire (missed call or inbound SMS).</div>`;
+      return;
+    }
+
+    const rows = traces.map(t => {
+      const steps = (typeof t.steps === 'string' ? JSON.parse(t.steps) : t.steps) || [];
+      const stepCount = steps.length;
+      const failedSteps = steps.filter(s => s.status === 'fail');
+      const lastStep = steps.length > 0 ? steps[steps.length - 1] : null;
+      const statusCls = t.status === 'completed' ? 'active' : t.status === 'failed' ? 'past_due_blocked' : 'trialing';
+      const statusLabel = t.status === 'completed' ? 'OK' : t.status === 'failed' ? 'FAILED' : 'RUNNING';
+      const triggerLabel = t.trigger_type === 'missed_call' ? 'Missed Call' : 'Inbound SMS';
+      const triggerCls = t.trigger_type === 'missed_call' ? 'amber' : 'rust';
+
+      const durationMs = t.completed_at && t.started_at
+        ? new Date(t.completed_at).getTime() - new Date(t.started_at).getTime()
+        : null;
+      const durationStr = durationMs !== null ? (durationMs < 1000 ? durationMs + 'ms' : (durationMs/1000).toFixed(1) + 's') : '...';
+
+      return `<tr class="clickable-row" onclick="showTraceDetail('${t.id}')">
+        <td><span class="badge ${statusCls}">${statusLabel}</span></td>
+        <td><span class="badge ${triggerCls}" style="font-size:11px">${triggerLabel}</span></td>
+        <td class="mono">${escHtml(t.customer_phone)}</td>
+        <td>${stepCount} steps${failedSteps.length > 0 ? ' <span style="color:var(--red)">(' + failedSteps.length + ' failed)</span>' : ''}</td>
+        <td>${lastStep ? escHtml(lastStep.step) : '—'}</td>
+        <td class="mono dim">${durationStr}</td>
+        <td>${relTime(t.started_at)}</td>
+        <td class="mono dim" style="font-size:11px">${t.trigger_id ? escHtml(t.trigger_id.slice(0, 16)) + '...' : '—'}</td>
+      </tr>`;
+    }).join('');
+
+    const completedCount = traces.filter(t => t.status === 'completed').length;
+    const failedCount = traces.filter(t => t.status === 'failed').length;
+    const runningCount = traces.filter(t => t.status === 'running').length;
+
+    main.innerHTML = `
+      <div class="page-header">
+        <div><div class="page-title">Execution Traces</div>
+        <div class="page-subtitle">Pipeline execution traces for pilot live-test visibility</div></div>
+        <button class="btn-sm" onclick="loadTraces()">Refresh</button>
+      </div>
+      <div class="stat-grid">
+        <div class="stat-card green"><div class="stat-tag">Completed</div><div class="stat-val">${completedCount}</div></div>
+        <div class="stat-card red"><div class="stat-tag">Failed</div><div class="stat-val ${failedCount > 0 ? 'red' : ''}">${failedCount}</div></div>
+        <div class="stat-card amber"><div class="stat-tag">Running</div><div class="stat-val">${runningCount}</div></div>
+        <div class="stat-card steel"><div class="stat-tag">Total Traces</div><div class="stat-val">${traces.length}</div></div>
+      </div>
+      <div class="section-label">Recent Traces</div>
+      <table class="data-table">
+        <thead><tr>
+          <th>Status</th><th>Trigger</th><th>Phone</th><th>Steps</th><th>Last Step</th><th>Duration</th><th>When</th><th>Trigger ID</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }).catch(err => {
+    document.getElementById('mainContent').innerHTML =
+      '<div class="empty-state" style="color:var(--red)">Failed to load traces: ' + escHtml(err.message) + '</div>';
+  });
+}
+
+function showTraceDetail(traceId) {
+  apiFetch('/internal/admin/traces/' + traceId).then(t => {
+    const steps = (typeof t.steps === 'string' ? JSON.parse(t.steps) : t.steps) || [];
+    const statusCls = t.status === 'completed' ? 'active' : t.status === 'failed' ? 'past_due_blocked' : 'trialing';
+    const statusLabel = t.status === 'completed' ? 'COMPLETED' : t.status === 'failed' ? 'FAILED' : 'RUNNING';
+
+    const stepRows = steps.map((s, i) => {
+      const sCls = s.status === 'ok' ? 'bool-ok' : s.status === 'fail' ? 'bool-fail' : 'bool-neutral';
+      const icon = s.status === 'ok' ? '✓' : s.status === 'fail' ? '✗' : '—';
+      const msStr = s.ms !== null && s.ms !== undefined ? s.ms + 'ms' : '';
+      const timeStr = s.at ? new Date(s.at).toLocaleTimeString() : '';
+      return `<tr>
+        <td style="text-align:center"><span class="${sCls}" style="font-size:16px">${icon}</span></td>
+        <td class="mono" style="font-weight:600">${escHtml(s.step)}</td>
+        <td>${escHtml(s.detail)}</td>
+        <td class="mono dim">${msStr}</td>
+        <td class="mono dim" style="font-size:11px">${timeStr}</td>
+      </tr>`;
+    }).join('');
+
+    const main = document.getElementById('mainContent');
+    main.innerHTML = `
+      <div class="page-header">
+        <div>
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px">
+            <button class="btn-sm" onclick="navigate('traces')">&larr; Back</button>
+            <div class="page-title">Trace Detail</div>
+          </div>
+          <div class="page-subtitle">${t.trigger_type === 'missed_call' ? 'Missed Call' : 'Inbound SMS'} — ${escHtml(t.customer_phone)}</div>
+        </div>
+        <span class="badge ${statusCls}" style="font-size:14px;padding:6px 16px">${statusLabel}</span>
+      </div>
+
+      <div class="stat-grid" style="grid-template-columns:repeat(auto-fill,minmax(160px,1fr))">
+        <div class="stat-card"><div class="stat-tag">Trigger ID</div><div style="font-family:var(--mono);font-size:12px;word-break:break-all">${escHtml(t.trigger_id)}</div></div>
+        <div class="stat-card"><div class="stat-tag">Tenant ID</div><div style="font-family:var(--mono);font-size:12px">${t.tenant_id ? escHtml(t.tenant_id.slice(0, 8)) + '...' : 'Not resolved'}</div></div>
+        <div class="stat-card"><div class="stat-tag">Started</div><div style="font-size:13px">${fmtDate(t.started_at)}</div></div>
+        <div class="stat-card"><div class="stat-tag">Completed</div><div style="font-size:13px">${t.completed_at ? fmtDate(t.completed_at) : 'In progress...'}</div></div>
+      </div>
+
+      ${t.error_summary ? '<div style="background:var(--red-dim);border:1px solid var(--red);border-radius:8px;padding:16px;margin-bottom:24px"><strong style="color:var(--red)">Error:</strong> <span style="font-family:var(--mono);font-size:13px">' + escHtml(t.error_summary) + '</span></div>' : ''}
+
+      <div class="section-label">Pipeline Steps (${steps.length})</div>
+      <table class="data-table">
+        <thead><tr><th style="width:40px"></th><th>Step</th><th>Detail</th><th>Duration</th><th>Time</th></tr></thead>
+        <tbody>${stepRows.length > 0 ? stepRows : '<tr><td colspan="5" class="empty-state">No steps recorded</td></tr>'}</tbody>
+      </table>`;
+  }).catch(err => {
+    document.getElementById('mainContent').innerHTML =
+      '<div class="empty-state" style="color:var(--red)">Failed to load trace: ' + escHtml(err.message) + '</div>';
+  });
 }
 
 // ── SECTION 10: AUDIT LOG ─────────────────────────────────────────────────────

--- a/db/migrations/018_pipeline_traces.sql
+++ b/db/migrations/018_pipeline_traces.sql
@@ -1,0 +1,25 @@
+-- Pipeline execution traces for pilot live-test visibility.
+-- Each trace records the step-by-step execution of a missed-call or inbound-SMS pipeline run.
+-- Steps are stored as a JSONB array for simplicity (no second table needed).
+
+CREATE TABLE IF NOT EXISTS pipeline_traces (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     UUID,
+  trigger_type  TEXT NOT NULL,           -- 'missed_call' | 'inbound_sms'
+  trigger_id    TEXT,                    -- CallSid or MessageSid
+  customer_phone TEXT,
+  status        TEXT NOT NULL DEFAULT 'running',  -- 'running' | 'completed' | 'failed'
+  steps         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  started_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at  TIMESTAMPTZ,
+  error_summary TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for admin queries: recent traces per tenant
+CREATE INDEX IF NOT EXISTS idx_pipeline_traces_tenant_started
+  ON pipeline_traces (tenant_id, started_at DESC);
+
+-- Index for lookup by trigger_id (CallSid / MessageSid)
+CREATE INDEX IF NOT EXISTS idx_pipeline_traces_trigger
+  ON pipeline_traces (trigger_id);


### PR DESCRIPTION
## Summary

- Adds step-by-step pipeline execution tracing so operators can immediately see where a real pilot test attempt succeeded or failed
- Traces the full live path: webhook received → tenant resolved → job enqueued → worker picked up → AI replied → booking detected → calendar synced → SMS sent
- New admin UI tab "Execution Traces" with list view (status, trigger type, steps, duration) and detail view (each step with pass/fail/skip status)

## What changed

- **Migration 018**: `pipeline_traces` table with JSONB steps array, indexed by tenant + trigger_id
- **pipeline-trace service**: `startTrace()`, `resumeTrace()`, `step()`, `complete()`, `fail()` — all non-fatal (never breaks pipeline)
- **Twilio SMS webhook**: starts trace at webhook entry, records tenant resolution and job enqueue
- **Voice-status webhook**: starts trace for missed-call flow
- **Internal process-sms route**: continues trace through AI reply, booking detection, calendar sync, SMS send
- **Internal missed-call-sms route**: continues trace through conversation creation and initial SMS
- **Admin API**: `GET /internal/admin/traces` (list) and `GET /internal/admin/traces/:id` (detail)
- **Admin UI**: new "Execution Traces" tab under Pilot sidebar section

## Test plan

- [x] 17 new pipeline-trace service tests (startTrace, step, setTenant, complete, fail, resumeTrace, findByTriggerId, getRecentTraces, getTraceById)
- [x] All existing tests updated with pipeline-trace mocks (sms-inbound, voice-status, process-sms, missed-call-sms)
- [x] Full suite: 356/356 passed (22 test files)
- [x] TypeScript: clean compilation
- [ ] Manual: run real missed call or SMS test and verify trace appears in admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)