### PR TITLE
feat: add force-refresh diagnostic endpoint

### DIFF
--- a/apps/api/src/routes/internal/calendar-tokens.ts
+++ b/apps/api/src/routes/internal/calendar-tokens.ts
@@ -20,6 +20,95 @@ const ParamsSchema = z.object({
  * NOT exposed externally (nginx does not proxy /internal/).
  */
 export async function calendarTokensRoute(app: FastifyInstance) {
+  /**
+   * POST /internal/calendar-tokens/:tenantId/force-refresh
+   *
+   * Diagnostic endpoint: forces a Google OAuth token refresh regardless of
+   * expiry, and returns before/after state for verification.
+   * Internal only — NOT exposed externally.
+   */
+  app.post("/calendar-tokens/:tenantId/force-refresh", async (request, reply) => {
+    const parsed = ParamsSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Invalid tenantId" });
+    }
+
+    const { tenantId } = parsed.data;
+
+    // 1. Read BEFORE state
+    const before = await query<{
+      access_token: string;
+      refresh_token: string;
+      token_expiry: string;
+      calendar_id: string;
+      last_refreshed: string | null;
+    }>(
+      `SELECT access_token, refresh_token, token_expiry, calendar_id, last_refreshed
+       FROM tenant_calendar_tokens WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    if (before.length === 0) {
+      return reply.status(404).send({ error: "No calendar tokens for tenant" });
+    }
+
+    const beforeRow = before[0];
+    const beforeAccessToken = decryptToken(beforeRow.access_token);
+    const beforeState = {
+      token_expiry: beforeRow.token_expiry,
+      access_token_prefix: beforeAccessToken.substring(0, 30),
+      access_token_length: beforeAccessToken.length,
+      last_refreshed: beforeRow.last_refreshed,
+    };
+
+    // 2. Force refresh (bypass expiry check)
+    let refreshResult: { accessToken: string; tokenExpiry: string } | null = null;
+    let refreshError: string | null = null;
+    try {
+      refreshResult = await refreshAccessToken(tenantId, beforeRow.refresh_token);
+    } catch (err) {
+      refreshError = (err as Error).message;
+    }
+
+    if (!refreshResult) {
+      return reply.status(502).send({
+        error: refreshError ?? "Refresh returned null",
+        before: beforeState,
+      });
+    }
+
+    // 3. Read AFTER state from DB
+    const after = await query<{
+      access_token: string;
+      token_expiry: string;
+      last_refreshed: string | null;
+    }>(
+      `SELECT access_token, token_expiry, last_refreshed
+       FROM tenant_calendar_tokens WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    const afterRow = after[0];
+    const afterAccessToken = decryptToken(afterRow.access_token);
+
+    const afterState = {
+      token_expiry: afterRow.token_expiry,
+      access_token_prefix: afterAccessToken.substring(0, 30),
+      access_token_length: afterAccessToken.length,
+      last_refreshed: afterRow.last_refreshed,
+    };
+
+    request.log.info({ tenantId }, "Force-refresh completed for diagnostic verification");
+
+    return reply.send({
+      tenantId,
+      token_changed: beforeAccessToken !== afterAccessToken,
+      expiry_moved_forward: new Date(afterRow.token_expiry) > new Date(beforeRow.token_expiry),
+      before: beforeState,
+      after: afterState,
+    });
+  });
+
   app.get("/calendar-tokens/:tenantId", async (request, reply) => {
     const parsed = ParamsSchema.safeParse(request.params);
     if (!parsed.success) {


### PR DESCRIPTION
## Summary
- Adds `POST /internal/calendar-tokens/:tenantId/force-refresh` diagnostic endpoint
- Forces real Google OAuth token refresh bypassing expiry check
- Returns before/after state for production verification
- Internal only — not exposed externally

## Purpose
One-time diagnostic to prove token refresh works in production with real Google OAuth tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)