### PR TITLE
fix: calendar reconnect shows 'Needs Reconnect' after 1 hour

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -893,8 +893,8 @@ export async function adminRoute(app: FastifyInstance) {
          ORDER BY provisioned_at DESC LIMIT 1`,
         [id]
       ),
-      query<{ token_expiry: string | null; connected_at: string | null }>(
-        `SELECT token_expiry, connected_at FROM tenant_calendar_tokens
+      query<{ token_expiry: string | null; connected_at: string | null; integration_status: string | null }>(
+        `SELECT token_expiry, connected_at, integration_status FROM tenant_calendar_tokens
          WHERE tenant_id = $1 LIMIT 1`,
         [id]
       ),
@@ -1033,11 +1033,13 @@ export async function adminRoute(app: FastifyInstance) {
       },
       {
         id: "calendar_token_valid",
-        label: "Calendar token not expired",
-        pass: !!calendar?.token_expiry && new Date(calendar.token_expiry) > new Date(),
-        detail: calendar?.token_expiry
-          ? `Expires ${new Date(calendar.token_expiry).toLocaleString()}`
-          : "No token — complete OAuth flow first",
+        label: "Calendar integration active",
+        pass: calendar?.integration_status === "active",
+        detail: !calendar
+          ? "No token — complete OAuth flow first"
+          : calendar.integration_status === "active"
+            ? `Active (access token auto-refreshes)`
+            : `Status: ${calendar.integration_status} — reconnect required`,
         critical: true,
       },
       {

--- a/apps/api/src/routes/internal/appointment-sync-proof.ts
+++ b/apps/api/src/routes/internal/appointment-sync-proof.ts
@@ -1,0 +1,165 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+import { decryptToken } from "../auth/google";
+import { createCalendarEvent } from "../../services/google-calendar";
+import { randomUUID } from "crypto";
+
+const ParamsSchema = z.object({
+  tenantId: z.string().uuid(),
+});
+
+/**
+ * POST /internal/appointment-sync-proof/:tenantId
+ *
+ * Diagnostic endpoint: exercises the FULL appointment → calendar sync path
+ * through createCalendarEvent() and captures before/after state for both
+ * tokens and the appointment row.
+ *
+ * This proves the complete production flow:
+ *   appointment created → createCalendarEvent() → Google Calendar event →
+ *   appointment row updated (google_event_id + calendar_synced)
+ *
+ * Internal only — NOT exposed externally.
+ */
+export async function appointmentSyncProofRoute(app: FastifyInstance) {
+  app.post("/appointment-sync-proof/:tenantId", async (request, reply) => {
+    const parsed = ParamsSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Invalid tenantId" });
+    }
+
+    const { tenantId } = parsed.data;
+
+    // 1. BEFORE token state
+    const tokensBefore = await query<{
+      access_token: string;
+      token_expiry: string;
+      last_refreshed: string | null;
+      calendar_id: string;
+    }>(
+      `SELECT access_token, token_expiry, last_refreshed, calendar_id
+       FROM tenant_calendar_tokens WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    if (tokensBefore.length === 0) {
+      return reply.status(404).send({ error: "No calendar tokens for tenant" });
+    }
+
+    const beforeTokenRow = tokensBefore[0];
+    const beforeAccessToken = decryptToken(beforeTokenRow.access_token);
+    const beforeTokenState = {
+      access_token_prefix: beforeAccessToken.substring(0, 30),
+      access_token_length: beforeAccessToken.length,
+      token_expiry: beforeTokenRow.token_expiry,
+      last_refreshed: beforeTokenRow.last_refreshed,
+      calendar_id: beforeTokenRow.calendar_id,
+    };
+
+    // 2. Insert a test appointment row
+    const appointmentId = randomUUID();
+    const scheduledAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); // tomorrow
+    const customerPhone = "+15550000000";
+    const serviceType = "Diagnostic Verification Test";
+
+    await query(
+      `INSERT INTO appointments (id, tenant_id, customer_phone, customer_name, service_type, scheduled_at, duration_minutes, booking_state)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [appointmentId, tenantId, customerPhone, "Sync Proof Test", serviceType, scheduledAt, 30, "PENDING_MANUAL_CONFIRMATION"]
+    );
+
+    // 2b. Read the appointment BEFORE sync
+    const apptBefore = await query<{
+      id: string;
+      google_event_id: string | null;
+      calendar_synced: boolean;
+      booking_state: string;
+    }>(
+      `SELECT id, google_event_id, calendar_synced, booking_state FROM appointments WHERE id = $1`,
+      [appointmentId]
+    );
+
+    const beforeAppointment = apptBefore[0];
+
+    // 3. Call createCalendarEvent() — the REAL production path
+    const calendarInput = {
+      tenantId,
+      appointmentId,
+      customerPhone,
+      customerName: "Sync Proof Test",
+      serviceType,
+      scheduledAt,
+      durationMinutes: 30,
+      timeZone: "America/Chicago",
+    };
+
+    const calendarResult = await createCalendarEvent(calendarInput);
+
+    // 4. AFTER token state
+    const tokensAfter = await query<{
+      access_token: string;
+      token_expiry: string;
+      last_refreshed: string | null;
+    }>(
+      `SELECT access_token, token_expiry, last_refreshed
+       FROM tenant_calendar_tokens WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    const afterTokenRow = tokensAfter[0];
+    const afterAccessToken = decryptToken(afterTokenRow.access_token);
+    const afterTokenState = {
+      access_token_prefix: afterAccessToken.substring(0, 30),
+      access_token_length: afterAccessToken.length,
+      token_expiry: afterTokenRow.token_expiry,
+      last_refreshed: afterTokenRow.last_refreshed,
+    };
+
+    // 5. AFTER appointment state
+    const apptAfter = await query<{
+      id: string;
+      google_event_id: string | null;
+      calendar_synced: boolean;
+      booking_state: string;
+    }>(
+      `SELECT id, google_event_id, calendar_synced, booking_state FROM appointments WHERE id = $1`,
+      [appointmentId]
+    );
+
+    const afterAppointment = apptAfter[0];
+
+    // 6. Build proof summary
+    const proof = {
+      token_refreshed_or_valid: beforeAccessToken !== afterAccessToken
+        ? "token_was_refreshed"
+        : "existing_token_was_valid",
+      google_event_created: calendarResult.googleEventId !== null,
+      appointment_row_updated: afterAppointment.google_event_id !== null,
+      sync_status: afterAppointment.calendar_synced ? "synced" : "not_synced",
+      google_event_id_written: afterAppointment.google_event_id,
+    };
+
+    request.log.info(
+      { tenantId, appointmentId, proof },
+      "Appointment sync proof completed"
+    );
+
+    const status = calendarResult.success ? 200 : 502;
+    return reply.status(status).send({
+      tenantId,
+      appointmentId,
+      timestamp: new Date().toISOString(),
+      before: {
+        token: beforeTokenState,
+        appointment: beforeAppointment,
+      },
+      calendarResult,
+      after: {
+        token: afterTokenState,
+        appointment: afterAppointment,
+      },
+      proof,
+    });
+  });
+}

--- a/apps/api/src/routes/tenant/dashboard.ts
+++ b/apps/api/src/routes/tenant/dashboard.ts
@@ -38,7 +38,8 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
       ),
       // Google Calendar integration
       query(
-        `SELECT calendar_id, connected_at, last_refreshed, token_expiry
+        `SELECT calendar_id, connected_at, last_refreshed, token_expiry,
+                integration_status, google_account_email
          FROM tenant_calendar_tokens WHERE tenant_id = $1`,
         [tenantId]
       ),
@@ -120,14 +121,21 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
     const calendar = (calendarRows as any[])[0] || null;
     const phone = (phoneRows as any[])[0] || null;
 
-    // Determine calendar integration status
+    // Determine calendar integration status from integration_status column.
+    // Do NOT derive status from token_expiry — access tokens expire every hour,
+    // which is normal and does not mean the user needs to reconnect.
+    // integration_status is set to 'active' on successful OAuth connect/reconnect,
+    // and updated to 'refresh_failed' only when the refresh_token actually fails.
     let calendarStatus: string = "not_connected";
     if (calendar) {
-      const expiry = new Date(calendar.token_expiry);
-      if (expiry < new Date()) {
-        calendarStatus = "token_expired";
-      } else {
+      const status = calendar.integration_status;
+      if (status === "active") {
         calendarStatus = "connected";
+      } else if (status === "refresh_failed") {
+        calendarStatus = "token_expired"; // UI maps this to "Needs Reconnect"
+      } else {
+        // 'pending' or unknown — treat as not connected
+        calendarStatus = "not_connected";
       }
     }
 
@@ -151,6 +159,7 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
           calendar_id: calendar?.calendar_id ?? null,
           connected_at: calendar?.connected_at ?? null,
           token_expiry: calendar?.token_expiry ?? null,
+          google_account_email: calendar?.google_account_email ?? null,
         },
         twilio: {
           phone_number: phone?.phone_number ?? null,

--- a/apps/api/src/services/google-calendar.ts
+++ b/apps/api/src/services/google-calendar.ts
@@ -204,6 +204,21 @@ export async function createCalendarEvent(
 
     if (!res.ok) {
       const body = await res.text().catch(() => "");
+      // If still getting 401 after retry, the refresh_token is likely revoked
+      if (res.status === 401) {
+        try {
+          await query(
+            `UPDATE tenant_calendar_tokens
+             SET integration_status = 'refresh_failed',
+                 last_error = 'Google Calendar API returned 401 after token refresh retry',
+                 updated_at = NOW()
+             WHERE tenant_id = $1`,
+            [input.tenantId]
+          );
+        } catch {
+          // Best-effort
+        }
+      }
       return {
         success: false,
         googleEventId: null,

--- a/apps/api/src/services/google-token-refresh.ts
+++ b/apps/api/src/services/google-token-refresh.ts
@@ -65,6 +65,20 @@ export async function refreshAccessToken(
   }
 
   if (!res.ok) {
+    // Mark integration as failed so dashboard shows correct status.
+    // Google returned an error — refresh_token may be revoked or invalid.
+    try {
+      await query(
+        `UPDATE tenant_calendar_tokens
+         SET integration_status = 'refresh_failed',
+             last_error = $1,
+             updated_at = NOW()
+         WHERE tenant_id = $2`,
+        [`Google token refresh failed: HTTP ${res.status}`, tenantId]
+      );
+    } catch {
+      // Best-effort status update — don't block the caller
+    }
     return null;
   }
 
@@ -78,7 +92,8 @@ export async function refreshAccessToken(
 
   await query(
     `UPDATE tenant_calendar_tokens
-     SET access_token = $1, token_expiry = $2, last_refreshed = NOW()
+     SET access_token = $1, token_expiry = $2, last_refreshed = NOW(),
+         integration_status = 'active', last_error = NULL, updated_at = NOW()
      WHERE tenant_id = $3`,
     [encAccess, tokenExpiry.toISOString(), tenantId]
   );

--- a/apps/api/src/tests/pilot-readiness.test.ts
+++ b/apps/api/src/tests/pilot-readiness.test.ts
@@ -114,6 +114,7 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     const calendar = overrides.calendar !== undefined ? overrides.calendar : {
       token_expiry: new Date(Date.now() + 3600000).toISOString(),
       connected_at: new Date().toISOString(),
+      integration_status: "active",
     };
 
     const prompt = overrides.prompt !== undefined ? overrides.prompt : {
@@ -208,12 +209,13 @@ describe("GET /internal/admin/tenants/:id/pilot-readiness", () => {
     expect(body.blockers.some((b: any) => b.id === "calendar_connected")).toBe(true);
   });
 
-  it("returns 'not_ready' when calendar token expired", async () => {
+  it("returns 'not_ready' when calendar refresh has failed", async () => {
     const app = await buildApp();
     setupMocks({
       calendar: {
         connected_at: new Date().toISOString(),
         token_expiry: new Date(Date.now() - 3600000).toISOString(),
+        integration_status: "refresh_failed",
       },
     });
 


### PR DESCRIPTION
## Summary

- **Root cause**: Dashboard computed calendar status from `token_expiry` (access token's 1-hour expiry). After natural expiry, the UI showed "Needs Reconnect" even though `refresh_token` was valid and auto-refresh worked fine.
- **Fix**: Use `integration_status` DB column instead of `token_expiry` to determine connection state. Mark `integration_status = 'refresh_failed'` only when the refresh token actually fails at Google.
- **Result**: Calendar stays "Connected" after reconnect. Only shows "Needs Reconnect" if the refresh token is actually revoked/invalid.

## Files changed

| File | Change |
|------|--------|
| `dashboard.ts` | Use `integration_status` column instead of `token_expiry` |
| `google-token-refresh.ts` | Reset status to `active` on successful refresh; mark `refresh_failed` on Google error |
| `google-calendar.ts` | Mark `refresh_failed` when 401 persists after force-refresh retry |
| `admin.ts` | Pilot readiness uses `integration_status` instead of `token_expiry` |
| `pilot-readiness.test.ts` | Updated mocks to include `integration_status` |
| `appointment-sync-proof.ts` | Diagnostic endpoint (previously untracked) |

## Test plan

- [x] 369/369 tests pass, 0 failures
- [x] TypeScript typecheck clean
- [ ] Deploy → reconnect Google Calendar → verify status stays "Connected" after 1+ hours
- [ ] Verify `integration_status = 'active'` in DB after reconnect
- [ ] Force-revoke token in Google → verify status changes to "Needs Reconnect"

🤖 Generated with [Claude Code](https://claude.com/claude-code)