### PR TITLE
fix: apply no-cache headers to all HTML files

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -141,8 +141,8 @@ async function bootstrap() {
     prefix: "/",
     decorateReply: false,
     setHeaders: (res, filePath) => {
-      // Prevent caching of admin pages so operators always see fresh content
-      if (typeof filePath === "string" && filePath.replace(/\\/g, "/").includes("admin")) {
+      // Prevent caching of all HTML pages so users always see fresh content
+      if (typeof filePath === "string" && filePath.endsWith(".html")) {
         res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
         res.setHeader("Pragma", "no-cache");
         res.setHeader("Expires", "0");


### PR DESCRIPTION
## Summary
- Broadens `Cache-Control: no-store, no-cache, must-revalidate` headers from admin-only to **all `.html` files**
- Prevents browsers from serving stale `app.html` after deploys
- One-line change in `apps/api/src/index.ts` — no UI or deployment changes

## Root cause
Only `admin.html` had no-cache headers. `app.html` (the tenant dashboard) could remain cached in browsers, causing users to see outdated UI after production deploys.

## Test plan
- [ ] Verify `/health` returns new commit hash after deploy
- [ ] Verify `curl -I https://autoshopsmsai.com/app.html` includes `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] Verify `admin.html` still has the same no-cache behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)