### PR TITLE
fix: no-cache headers for all HTML files in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "trailingSlash": false,
   "headers": [
     {
-      "source": "/admin.html",
+      "source": "/(.*)\\.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },


### PR DESCRIPTION
## Summary
- **Root cause found**: `autoshopsmsai.com` is served by **Vercel CDN**, not Render directly
- `app.html` was served as a static file by Vercel with default caching — the Fastify `index.ts` headers never applied because requests never reached Render
- Only `admin.html` had explicit no-cache headers in `vercel.json`
- Changes header source from `/admin.html` to `/(.*)\.html` so **all HTML files** get `Cache-Control: no-store, no-cache, must-revalidate`

## Architecture (discovered)
```
Browser → Vercel CDN (autoshopsmsai.com)
  ├── *.html files → served directly by Vercel (static)
  ├── /admin.html → rewritten to Render backend
  ├── /health → rewritten to Render backend
  └── /auth, /billing, /webhooks, /internal → rewritten to Render backend
```

## Test plan
- [ ] After Vercel redeploy, `curl -I https://autoshopsmsai.com/app.html` must include `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] `admin.html` must retain same no-cache behavior
- [ ] `login.html` and `signup.html` should also get no-cache headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)