### PR TITLE
fix: no-cache headers in apps/web/vercel.json (the real config)

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,7 +2,31 @@
   "trailingSlash": false,
   "headers": [
     {
+      "source": "/app.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    },
+    {
       "source": "/admin.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    },
+    {
+      "source": "/login.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Pragma", "value": "no-cache" },
+        { "key": "Expires", "value": "0" }
+      ]
+    },
+    {
+      "source": "/signup.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },


### PR DESCRIPTION
## Summary
- **Root cause**: Vercel reads `apps/web/vercel.json` (inside the `outputDirectory`), NOT the root `vercel.json`
- The root `vercel.json` was updated in PR #135 but `apps/web/vercel.json` was stale — only had `admin.html` no-cache headers
- Adds explicit no-cache entries for `/app.html`, `/login.html`, `/signup.html` in the file Vercel actually uses

## Evidence
- Vercel deployment URL returns `Cache-Control: no-store` (root config partially works)
- Production domain `autoshopsmsai.com` returns `Cache-Control: public, max-age=0, must-revalidate` (old behavior)
- `apps/web/vercel.json` was missing `/app.html` header entry

## Test plan
- [ ] After Vercel auto-deploy, verify `curl -I https://autoshopsmsai.com/app.html` includes `Cache-Control: no-store, no-cache, must-revalidate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)