### PR TITLE
fix: remove max-width constraint for full-width admin layout

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -112,7 +112,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
 .status-sub{font-size:11px;color:var(--text-tertiary);margin-top:1px}
 
 /* ── MAIN ── */
-.main{flex:1;padding:24px 32px 60px;overflow-x:hidden;min-width:0;max-width:1280px}
+.main{flex:1;padding:24px 32px 60px;overflow-x:hidden;min-width:0}
 .page-header{display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:24px;gap:12px;flex-wrap:wrap}
 .page-title{font-size:22px;font-weight:700;color:var(--text);letter-spacing:-.02em;line-height:1.2}
 .page-subtitle{font-size:13px;color:var(--text-tertiary);margin-top:4px}


### PR DESCRIPTION
## Summary
- Removed `max-width:1280px` from `.main` container in `apps/web/app.html`
- All admin views (Dashboard, Conversations, Appointments, Customers, Analytics, Billing, Settings) now fill the full available content area next to the sidebar
- No other CSS or HTML changes needed — this was the single root cause

## Root Cause
`.main{...max-width:1280px}` on line 115 capped the content area at 1280px regardless of screen size, making all views appear narrow and boxed on larger displays.

## Test plan
- [ ] Verify Dashboard fills full width on desktop
- [ ] Verify Conversations, Appointments, Customers, Analytics, Billing, Settings all fill full width
- [ ] Verify sidebar remains intact
- [ ] Verify responsive behavior on tablet/mobile is unchanged (media queries untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)