### PR TITLE
fix: Customer Details panel fallback placeholders

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -634,6 +634,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
 .conv-detail-appt-tag.completed{background:#F1F5F9;color:#64748B}
 .conv-detail-notes{width:100%;padding:10px 12px;background:var(--bg);border:1px solid var(--border);border-radius:8px;font-size:13px;color:var(--text);font-family:var(--body);resize:none;outline:none;transition:border-color .15s}
 .conv-detail-notes:focus{border-color:var(--rust);box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+.conv-detail-placeholder{font-size:12px;color:var(--text-tertiary);font-style:italic}
 .conv-detail-value{font-size:13px;color:var(--text);font-weight:500}
 .conv-empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--text-tertiary);font-size:14px;gap:8px}
 
@@ -2429,7 +2430,7 @@ function selectConversation(el, id) {
     body.innerHTML = '<div class="conv-empty-state"><span style="font-size:13px;">Thread data not available — <a style="color:var(--rust);cursor:pointer;" onclick="openModal(\'' + id + '\')">open in modal</a></span></div>';
   }
 
-  // Detail panel — enhanced with contact, vehicle, appointments, notes
+  // Detail panel — always show all sections with fallback placeholders
   var detail = document.getElementById('convDetailBody');
   if (detail) {
     var vehicleModel = conv.vehicleModel || conv.vehicle || '';
@@ -2437,33 +2438,60 @@ function selectConversation(el, id) {
     var mileage = conv.mileage || '';
     var email = conv.email || '';
     var location = conv.location || '';
+    var hasVehicle = vehicleModel || vin || mileage;
+
+    // Find appointments matching this conversation's phone
+    var convAppts = bookingsData.filter(function(b) { return b.phone === conv.phone; });
 
     var html = '';
 
-    // Contact Information
+    // ── Contact Information (always shown) ──
+    var phoneSvg = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg>';
+    var mailSvg = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>';
+    var pinSvg = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>';
+
     html += '<div class="conv-detail-section">' +
       '<div class="conv-detail-label">Contact Information</div>' +
-      '<div class="conv-detail-row"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg><span>' + conv.phone + '</span></div>' +
-      (email ? '<div class="conv-detail-row"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg><span>' + email + '</span></div>' : '') +
-      (location ? '<div class="conv-detail-row"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg><span>' + location + '</span></div>' : '') +
+      '<div class="conv-detail-row">' + phoneSvg + '<span>' + conv.phone + '</span></div>' +
+      '<div class="conv-detail-row">' + mailSvg + (email ? '<span>' + email + '</span>' : '<span class="conv-detail-placeholder">No email available</span>') + '</div>' +
+      '<div class="conv-detail-row">' + pinSvg + (location ? '<span>' + location + '</span>' : '<span class="conv-detail-placeholder">No location available</span>') + '</div>' +
     '</div>';
 
-    // Vehicle Information
-    if (vehicleModel || vin || mileage) {
-      html += '<div class="conv-detail-section bordered">' +
-        '<div class="conv-detail-label">Vehicle Information</div>' +
-        '<div class="conv-detail-vehicle"><div class="conv-detail-vehicle-row">' +
-          '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="' + 'var(--rust)' + '" stroke-width="2"><path d="M14 16H9m10 0h3v-3.15a1 1 0 00-.84-.99L16 11l-2.7-3.6a1 1 0 00-.8-.4H5.24a1 1 0 00-.9.55l-2.18 4.37a1 1 0 00-.16.53V16h3"/><circle cx="6.5" cy="16.5" r="2.5"/><circle cx="16.5" cy="16.5" r="2.5"/></svg>' +
-          '<div>' +
-            (vehicleModel ? '<div class="conv-detail-vehicle-name">' + vehicleModel + '</div>' : '') +
-            (vin ? '<div class="conv-detail-vehicle-sub">VIN: ' + vin + '</div>' : '') +
-            (mileage ? '<div class="conv-detail-vehicle-sub">' + mileage + '</div>' : '') +
-          '</div>' +
-        '</div></div>' +
-      '</div>';
+    // ── Vehicle Information (always shown) ──
+    var carSvg = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--rust)" stroke-width="2"><path d="M14 16H9m10 0h3v-3.15a1 1 0 00-.84-.99L16 11l-2.7-3.6a1 1 0 00-.8-.4H5.24a1 1 0 00-.9.55l-2.18 4.37a1 1 0 00-.16.53V16h3"/><circle cx="6.5" cy="16.5" r="2.5"/><circle cx="16.5" cy="16.5" r="2.5"/></svg>';
+    html += '<div class="conv-detail-section bordered">' +
+      '<div class="conv-detail-label">Vehicle Information</div>';
+    if (hasVehicle) {
+      html += '<div class="conv-detail-vehicle"><div class="conv-detail-vehicle-row">' + carSvg + '<div>' +
+        (vehicleModel ? '<div class="conv-detail-vehicle-name">' + vehicleModel + '</div>' : '') +
+        (vin ? '<div class="conv-detail-vehicle-sub">VIN: ' + vin + '</div>' : '') +
+        (mileage ? '<div class="conv-detail-vehicle-sub">' + mileage + '</div>' : '') +
+      '</div></div></div>';
+    } else {
+      html += '<div class="conv-detail-vehicle"><div class="conv-detail-vehicle-row">' + carSvg +
+        '<div><span class="conv-detail-placeholder">No vehicle data available</span></div>' +
+      '</div></div>';
     }
+    html += '</div>';
 
-    // Status and conversation info
+    // ── Recent Appointments (always shown) ──
+    html += '<div class="conv-detail-section bordered">' +
+      '<div class="conv-detail-label">Recent Appointments</div>';
+    if (convAppts.length > 0) {
+      convAppts.slice(0, 3).forEach(function(a) {
+        var tagCls = a.syncStatus === 'synced' ? 'upcoming' : 'completed';
+        html += '<div class="conv-detail-appt">' +
+          '<div class="conv-detail-appt-name">' + a.service + '</div>' +
+          '<div class="conv-detail-appt-date">' + a.date + '</div>' +
+          '<span class="conv-detail-appt-tag ' + tagCls + '">' + a.syncLabel + '</span>' +
+        '</div>';
+      });
+    } else {
+      html += '<span class="conv-detail-placeholder">No appointment history</span>';
+    }
+    html += '</div>';
+
+    // ── Conversation Info ──
     html += '<div class="conv-detail-section bordered">' +
       '<div class="conv-detail-label">Conversation Info</div>' +
       '<div style="margin-bottom:8px;"><div style="font-size:11px;color:var(--text-tertiary);margin-bottom:2px;">Status</div><div>' + convStatusBadge(conv.status) + '</div></div>' +
@@ -2472,7 +2500,7 @@ function selectConversation(el, id) {
       '<div><div style="font-size:11px;color:var(--text-tertiary);margin-bottom:2px;">Duration</div><div class="conv-detail-value">' + (conv.duration || '—') + '</div></div>' +
     '</div>';
 
-    // Actions
+    // ── Actions ──
     html += '<div class="conv-detail-section bordered">' +
       '<div class="conv-detail-label">Actions</div>' +
       '<div style="display:flex;gap:6px;flex-wrap:wrap;">' +
@@ -2481,7 +2509,7 @@ function selectConversation(el, id) {
       '</div>' +
     '</div>';
 
-    // Notes
+    // ── Notes (always shown) ──
     html += '<div class="conv-detail-section bordered" style="border-bottom:none;">' +
       '<div class="conv-detail-label">Notes</div>' +
       '<textarea class="conv-detail-notes" rows="4" placeholder="Add notes about this customer..." id="convNotes_' + id + '"></textarea>' +


### PR DESCRIPTION
## Summary
- All four Customer Details sections (Contact, Vehicle, Appointments, Notes) now always render regardless of data availability
- Missing email/location show italic placeholder text instead of being hidden
- Vehicle section shows "No vehicle data available" when no vehicle fields exist
- Recent Appointments section cross-references bookingsData by phone, shows "No appointment history" when empty
- Notes textarea always visible

## Test plan
- [ ] Select a conversation with no email/location — verify placeholders appear
- [ ] Select a conversation with no vehicle data — verify vehicle section shows placeholder
- [ ] Select a conversation with no matching bookings — verify "No appointment history"
- [ ] Select a conversation with matching bookings — verify appointments render with status tags
- [ ] Verify Notes textarea is always visible
- [ ] Verify no backend files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)