### PR TITLE
fix: replace misleading fallback branding text

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -923,7 +923,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
   <aside class="sidebar">
     <div class="sidebar-brand">
       <div class="sidebar-brand-name">Auto<span>Shop</span> AI</div>
-      <div class="sidebar-brand-shop" id="sidebarShopName">Texas Demo Shop</div>
+      <div class="sidebar-brand-shop" id="sidebarShopName">Loading shop...</div>
     </div>
     <div class="sidebar-section">
       <a class="sidebar-item active" href="#" onclick="switchView('dashboard');return false;">


### PR DESCRIPTION
## Summary
- Replace hardcoded 'Texas Demo Shop' sidebar fallback with neutral 'Loading shop...' placeholder
- Only affects the brief moment before JS loads the real shop name from tenant state
- Prevents confusion during live deployment verification

## Test plan
- [ ] Verify sidebar shows 'Loading shop...' briefly on page load before real name appears
- [ ] Verify real shop name still loads correctly via JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)