### PR TITLE
fix: dashboard renders fallback content for weak/partial backend data

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -2242,7 +2242,7 @@ function renderHealthGrid() {
   let html = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:0;">';
   cells.forEach(function(cell, i) {
     var border = i < 3 ? 'border-right:1px solid var(--border);' : '';
-    var isOk = cell.status === 'ok' || cell.status === 'connected' || cell.status === 'operational';
+    var isOk = cell.status === 'ok' || cell.status === 'connected' || cell.status === 'operational' || cell.status === 'healthy';
     var dotColor = isOk ? '#10B981' : '#F59E0B';
     var statusText = isOk ? 'Operational' : 'Degraded';
     var statusColor = isOk ? '#10B981' : '#F59E0B';
@@ -2290,7 +2290,9 @@ function renderDashConvTable(data) {
   if (countEl) countEl.textContent = (activeCount || data.length || 3) + ' Active';
 
   var container = document.getElementById('dashConvBody');
-  if (!data.length) {
+  // Show fallback when data is empty OR too weak to render meaningful rows
+  var usableConvs = data.filter(function(c) { return c.phone && c.phone !== '—' && c.issue && c.issue !== '—'; });
+  if (!usableConvs.length || usableConvs.length < 2) {
     // Premium fallback demo content — reference data
     container.innerHTML =
       '<div class="conv-card-item">' +
@@ -2858,30 +2860,33 @@ function renderSystemHero() {
 function renderLiveKPIs() {
   var s = dashboardStats;
   var defaultARO = 540;
-  var recoveredRev = (s.total_appointments || 0) * defaultARO;
-  var monthRev = (s.appointments_this_month || 0) * defaultARO;
-  var totalConvs = s.total_conversations || 0;
-  var captureRate = totalConvs > 0 ? '94.2%' : '94.2%';
-  // Use premium fallback values for demo when no real data
-  if (recoveredRev === 0) recoveredRev = 24580;
-  if (monthRev === 0) monthRev = 4320;
+
+  // Treat weak data (below meaningful thresholds) same as no data
+  var hasStrongRevenue = (s.total_appointments || 0) >= 10;
+  var hasStrongAppts = (s.appointments_this_month || 0) >= 5;
+  var hasStrongConvs = (s.total_conversations || 0) >= 5;
+  var hasStrongActive = (s.active_conversations || 0) >= 3;
+
+  var recoveredRev = hasStrongRevenue ? (s.total_appointments * defaultARO) : 24580;
+  var monthRev = hasStrongAppts ? (s.appointments_this_month * defaultARO) : 4320;
+  var captureRate = '94.2%';
 
   var iconDollar = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>';
   var iconCal = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>';
   var iconPhone = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 2 16 8 22 8"/><line x1="23" y1="1" x2="16" y2="8"/><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg>';
   var iconMsg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>';
 
-  var apptMonth = s.appointments_this_month || 127;
-  var totalAppt = s.total_appointments || 127;
-  var convsMonth = s.conversations_this_month || 43;
-  var activeConvs = s.active_conversations || 43;
+  var apptMonth = hasStrongAppts ? s.appointments_this_month : 127;
+  var totalAppt = hasStrongRevenue ? s.total_appointments : 127;
+  var convsMonth = hasStrongConvs ? s.conversations_this_month : 43;
+  var activeConvs = hasStrongActive ? s.active_conversations : 43;
   var apptToday = s.appointments_today || 3;
 
-  // Use reference change values for fallback display
-  var revChange = (s.total_appointments > 0) ? ('+$' + monthRev.toLocaleString() + ' this month') : '+18.2%';
-  var apptChange = (s.appointments_this_month > 0) ? (totalAppt + ' all time') : '+12.5%';
-  var captureChange = (s.total_conversations > 0) ? (convsMonth + ' this month') : '+5.1%';
-  var activeChange = (s.active_conversations > 0) ? (apptToday + ' appointments today') : '12 today';
+  // Use reference change values when data is weak
+  var revChange = hasStrongRevenue ? ('+$' + monthRev.toLocaleString() + ' this month') : '+18.2%';
+  var apptChange = hasStrongAppts ? (totalAppt + ' all time') : '+12.5%';
+  var captureChange = hasStrongConvs ? (convsMonth + ' this month') : '+5.1%';
+  var activeChange = hasStrongActive ? (apptToday + ' appointments today') : '12 today';
 
   document.getElementById('kpiGrid').innerHTML =
     '<div class="kpi-card fade-in">' +
@@ -3339,13 +3344,9 @@ function renderTodayAppointments() {
 
   var body = document.getElementById('todayApptsBody');
   if (!body) return;
-  if (!todayAppts.length) {
-    var apptCount = dashboardStats.appointments_today || 0;
-    if (apptCount > 0) {
-      body.innerHTML = '<div class="appt-card-list">' +
-        '<div class="appt-card-item"><div class="appt-card-top"><div class="appt-card-time">' + apptCount + ' scheduled</div></div><div class="appt-card-service">Appointments today</div></div>' +
-      '</div>';
-    } else {
+  if (!todayAppts.length || todayAppts.length < 2) {
+    // Show reference demo appointments when real data is absent or too weak
+    {
       // Premium fallback demo appointments — reference data
       body.innerHTML = '<div class="appt-card-list">' +
         '<div class="appt-card-item" style="border-left-color:#10B981;">' +
@@ -3373,7 +3374,6 @@ function renderTodayAppointments() {
           '<div class="appt-card-source">Source: AI</div>' +
         '</div>' +
       '</div>';
-    }
     return;
   }
   body.innerHTML = '<div class="appt-card-list">' + todayAppts.slice(0, 6).map(function(b) {


### PR DESCRIPTION
## Summary
- **KPI Row**: Uses meaningful thresholds (not just zero-check) before displaying real data; shows reference values ($24,580 / 127 / 94.2% / 43) when backend data is too weak
- **Live Conversations**: Falls back to 3 demo rows when conversation data is empty OR has fewer than 2 usable entries
- **Today's Appointments**: Always shows 4 reference appointment rows when real data is absent or insufficient, removing the weak "X scheduled" middle state
- **System Status**: Fixed status check to recognize `'healthy'` (the value the code actually sets) so all 4 rows show "Operational" with green dots instead of "Degraded"

## Root Cause
Backend returns partial/weak data (e.g., 1 appointment, empty conversation objects), causing the UI to skip fallback content while rendering near-empty blocks.

## Test plan
- [ ] Load dashboard with no backend data — all 4 sections show reference content
- [ ] Load dashboard with weak backend data (1-2 items) — fallback still renders
- [ ] Load dashboard with strong real data (10+ appointments) — real data displays
- [ ] System Status shows green "Operational" for all 4 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)