### PR TITLE
docs: add CLAUDE_RULES.md as mandatory dashboard execution rules

### DIFF
--- a/project-brain/CLAUDE_RULES.md
+++ b/project-brain/CLAUDE_RULES.md
@@ -1,0 +1,121 @@
+AUTOLOAD: TRUE
+PRIORITY: CRITICAL
+
+PROJECT: AutoShop AI Dashboard
+
+════════════════════════════════════════
+CORE EXECUTION RULE
+════════════════════════════════════════
+
+This is a LIVE SaaS product.
+
+Work is NOT evaluated by:
+- code changes
+- commits
+- PR merges
+- deploy success
+
+Work is evaluated ONLY by:
+VISIBLE RESULT in the LIVE UI.
+
+If the UI looks the same → task is NOT complete.
+
+════════════════════════════════════════
+MANDATORY LOADING RULE
+════════════════════════════════════════
+
+This file MUST be treated as ALWAYS LOADED CONTEXT.
+
+Before making ANY change, the agent MUST:
+1. Read this file
+2. Follow ALL rules strictly
+3. Not override or ignore these rules
+
+════════════════════════════════════════
+UI COMPLETENESS RULE
+════════════════════════════════════════
+
+Dashboard must NEVER look:
+- empty
+- weak
+- partial
+- like a dev/skeleton UI
+
+"Missing data" includes:
+- null / undefined
+- 0 values
+- empty arrays
+- empty strings
+- partially usable backend data
+
+In ALL such cases:
+→ fallback/demo content MUST be rendered
+
+════════════════════════════════════════
+DASHBOARD CONTRACT (STRICT)
+════════════════════════════════════════
+
+Dashboard MUST ALWAYS show:
+
+1. KPI ROW
+- 4 KPI cards
+- never empty
+
+2. MAIN VALUE BLOCK (Revenue / Chart)
+- must look primary
+- never small or weak
+
+3. LIVE ACTIVITY
+- minimum 3 visible rows
+
+4. APPOINTMENTS
+- multiple rows
+- never empty state
+
+5. SYSTEM STATUS
+- always filled
+- always readable
+
+════════════════════════════════════════
+NO HALF-FIX RULE
+════════════════════════════════════════
+
+Forbidden:
+- partial fixes
+- cosmetic-only edits
+- fallback applied only in some cases
+- "improved but still weak UI"
+
+Every fix MUST:
+→ fully solve the visible problem
+
+════════════════════════════════════════
+SCOPE RULE
+════════════════════════════════════════
+
+- DO NOT change architecture
+- DO NOT rewrite system
+- DO NOT touch backend unless required
+
+Modify ONLY what is needed to achieve visible UI result.
+
+════════════════════════════════════════
+VERIFICATION RULE
+════════════════════════════════════════
+
+Before finishing, validate:
+
+"Would a user instantly see the improvement?"
+
+If NO → continue working.
+
+════════════════════════════════════════
+FAIL CONDITION
+════════════════════════════════════════
+
+If after deploy UI still looks:
+- similar
+- empty
+- incomplete
+
+→ task is FAILED and must be redone.

--- a/project-brain/README.md
+++ b/project-brain/README.md
@@ -1,5 +1,14 @@
 # Project Brain — Shared Memory for Claude Execution
 
+## SYSTEM ENTRY POINT
+
+Before ANY task:
+→ Read `CLAUDE_RULES.md`
+
+If rules are ignored → output is invalid.
+
+---
+
 This directory is **working memory for Claude sessions**, not documentation for humans or customers.
 
 `project-brain/` is the canonical shared-memory directory for this repository. All session-persistent context, status tracking, and architectural decisions live here.
@@ -11,6 +20,8 @@ Enable execution continuity across Claude sessions. Every session starts faster 
 ## Session Start Protocol
 
 At the beginning of every session, read these files in order:
+
+0. `CLAUDE_RULES.md` — **MANDATORY** — Dashboard execution rules (autoloaded, critical priority)
 
 1. `current_focus.md` — What to work on right now
 2. `blockers.md` — What is currently blocked and why


### PR DESCRIPTION
## Summary
- Adds `project-brain/CLAUDE_RULES.md` with critical-priority autoloaded rules for all dashboard UI work
- Rules enforce: visible UI result as completion criteria, fallback content for all missing data, strict dashboard contract (KPI row, revenue block, live activity, appointments, system status), no half-fixes, and verification before finishing
- Updates `project-brain/README.md` to reference CLAUDE_RULES.md as mandatory entry point (step 0)

## Test plan
- [ ] Verify CLAUDE_RULES.md loads correctly in project-brain/
- [ ] Verify README.md entry point block renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)