### PR TITLE
fix: match dashboard layout to visual reference screenshot

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -104,8 +104,8 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
 /* ── MAIN ── */
 .main{flex:1;padding:28px 36px 60px;overflow-x:hidden;min-width:0}
 .page-header{display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:28px;gap:12px;flex-wrap:wrap}
-.page-title{font-size:22px;font-weight:700;color:var(--text);letter-spacing:-.02em;line-height:1.2;display:none}
-.page-subtitle{font-size:13px;color:var(--text-tertiary);margin-top:4px;display:none}
+.page-title{font-size:22px;font-weight:700;color:var(--text);letter-spacing:-.02em;line-height:1.2}
+.page-subtitle{font-size:13px;color:var(--text-tertiary);margin-top:4px}
 .page-actions{display:flex;gap:8px;align-items:center}
 .btn-sm{font-size:13px;font-weight:500;padding:7px 14px;border:1px solid var(--border);background:var(--bg-panel);color:var(--text-secondary);cursor:pointer;transition:all .15s;text-decoration:none;border-radius:8px}
 .btn-sm:hover{border-color:var(--border-mid);background:var(--bg-hover);box-shadow:var(--shadow-sm)}
@@ -994,14 +994,9 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
     <div class="view active" id="view-dashboard">
 
       <!-- ── PAGE HEADER (page-title style) ── -->
-      <div class="page-header">
-        <div>
-          <div class="page-title" id="dashPageTitle">Dashboard</div>
-          <div class="page-subtitle" id="dashSubtitle">Real-time performance metrics and AI-driven customer engagement</div>
-        </div>
-        <div class="page-actions">
-          <button class="btn-sm" onclick="location.reload()">Refresh</button>
-        </div>
+      <div class="dash-welcome">
+        <h2 id="dashPageTitle">Revenue Intelligence Dashboard</h2>
+        <p id="dashSubtitle">Real-time performance metrics and AI-driven customer engagement</p>
       </div>
 
       <!-- ── 1. KPI ROW (4 cards) ── -->
@@ -1039,7 +1034,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
       <!-- ── 3. REVENUE ANALYTICS + SYSTEM STATUS (2/3 + 1/3 grid) ── -->
       <div class="dash-body">
         <!-- Revenue Analytics -->
-        <div class="log-wrap" style="overflow:hidden;">
+        <div class="log-wrap">
           <div style="padding:20px 24px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;">
             <div class="log-title" style="font-size:16px;font-weight:700;">Revenue Analytics</div>
             <div class="chart-trend" id="dashRevTrend" style="padding:6px 14px;background:#ECFDF5;border-radius:8px;">
@@ -1047,36 +1042,36 @@ body{background:var(--bg);color:var(--text);font-family:var(--body);line-height:
               <span id="dashRevTrendText">+18.2% vs last week</span>
             </div>
           </div>
-          <div style="height:280px;padding:20px 24px 0;position:relative;overflow:hidden;">
-            <svg class="chart-svg" viewBox="0 0 800 200" preserveAspectRatio="none" style="height:100%;width:100%;">
+          <div style="height:280px;padding:20px 24px 30px;position:relative;overflow:visible;">
+            <!-- Y-axis labels -->
+            <div style="position:absolute;left:0;top:20px;bottom:30px;width:44px;display:flex;flex-direction:column;justify-content:space-between;pointer-events:none;">
+              <span style="font-size:11px;color:var(--text-tertiary);text-align:right;padding-right:8px;">$26k</span>
+              <span style="font-size:11px;color:var(--text-tertiary);text-align:right;padding-right:8px;">$20k</span>
+              <span style="font-size:11px;color:var(--text-tertiary);text-align:right;padding-right:8px;">$13k</span>
+              <span style="font-size:11px;color:var(--text-tertiary);text-align:right;padding-right:8px;">$7k</span>
+              <span style="font-size:11px;color:var(--text-tertiary);text-align:right;padding-right:8px;">$0k</span>
+            </div>
+            <svg class="chart-svg" viewBox="0 0 800 200" preserveAspectRatio="none" style="height:100%;width:100%;margin-left:20px;">
               <defs>
                 <linearGradient id="dcg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#2563EB" stop-opacity="0.18"/><stop offset="100%" stop-color="#2563EB" stop-opacity="0.01"/></linearGradient>
-                <linearGradient id="dcg2" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#10B981" stop-opacity="0.08"/><stop offset="100%" stop-color="#10B981" stop-opacity="0"/></linearGradient>
               </defs>
               <line x1="0" y1="40" x2="800" y2="40" stroke="rgba(0,0,0,.03)" stroke-width="1"/>
               <line x1="0" y1="80" x2="800" y2="80" stroke="rgba(0,0,0,.03)" stroke-width="1"/>
               <line x1="0" y1="120" x2="800" y2="120" stroke="rgba(0,0,0,.03)" stroke-width="1"/>
               <line x1="0" y1="160" x2="800" y2="160" stroke="rgba(0,0,0,.03)" stroke-width="1"/>
-              <!-- Target line (dashed) -->
-              <path d="M0,160 C100,155 200,140 300,125 C400,110 500,100 600,90 C700,80 800,72 800,72" fill="none" stroke="#10B981" stroke-width="1.5" stroke-dasharray="6 4" opacity="0.5"/>
-              <!-- Revenue area -->
-              <path d="M0,165 C50,155 80,130 130,110 C180,90 200,80 250,85 C300,90 320,60 380,45 C440,30 460,55 520,65 C580,80 600,38 650,28 C700,20 740,42 800,35 L800,200 L0,200 Z" fill="url(#dcg)"/>
-              <path d="M0,165 C50,155 80,130 130,110 C180,90 200,80 250,85 C300,90 320,60 380,45 C440,30 460,55 520,65 C580,80 600,38 650,28 C700,20 740,42 800,35" fill="none" stroke="#2563EB" stroke-width="2.5"/>
-              <!-- Data points -->
-              <circle cx="130" cy="110" r="4" fill="#fff" stroke="#2563EB" stroke-width="2"/>
-              <circle cx="380" cy="45" r="4" fill="#fff" stroke="#2563EB" stroke-width="2"/>
-              <circle cx="650" cy="28" r="5" fill="#2563EB"/>
-              <circle cx="800" cy="35" r="5" fill="#2563EB"/>
+              <!-- Revenue line -->
+              <path d="M0,165 C60,160 100,150 130,145 C200,135 250,130 300,125 C350,120 400,110 450,95 C500,80 550,55 600,40 C650,30 700,25 750,22 C780,20 800,20 800,20 L800,200 L0,200 Z" fill="url(#dcg)"/>
+              <path d="M0,165 C60,160 100,150 130,145 C200,135 250,130 300,125 C350,120 400,110 450,95 C500,80 550,55 600,40 C650,30 700,25 750,22 C780,20 800,20 800,20" fill="none" stroke="#2563EB" stroke-width="2.5"/>
             </svg>
-          </div>
-          <div style="display:grid;grid-template-columns:1fr 1fr;gap:0;border-top:1px solid var(--border);margin-top:8px;">
-            <div style="padding:16px 24px;border-right:1px solid var(--border);">
-              <div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:4px;">Recovered Revenue</div>
-              <div style="font-size:22px;font-weight:700;color:var(--text);letter-spacing:-.02em;" id="dashRevRecovered">$24,580</div>
-            </div>
-            <div style="padding:16px 24px;">
-              <div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:4px;">Avg. Booking Value</div>
-              <div style="font-size:22px;font-weight:700;color:#059669;letter-spacing:-.02em;" id="dashAvgBooking">$540</div>
+            <!-- X-axis labels -->
+            <div style="display:flex;justify-content:space-between;padding:6px 0 0 44px;">
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 10</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 11</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 12</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 13</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 14</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 15</span>
+              <span style="font-size:11px;color:var(--text-tertiary);">Mar 16</span>
             </div>
           </div>
         </div>
@@ -2297,7 +2292,7 @@ function renderDashConvTable(data) {
       '<div class="conv-card-item">' +
         '<div class="conv-avatar">J</div>' +
         '<div class="conv-card-body">' +
-          '<div class="conv-card-top"><div class="conv-card-name">John Martinez — Oil Change</div><div class="conv-card-time">2 min ago</div></div>' +
+          '<div class="conv-card-top"><div class="conv-card-name">John Martinez</div><div class="conv-card-time">2 min ago</div></div>' +
           '<div class="conv-card-phone">(512) 555-0198</div>' +
           '<div class="conv-card-msg">Interested in oil change appointment</div>' +
           '<span class="conv-card-badge">AI Handling</span>' +
@@ -2306,7 +2301,7 @@ function renderDashConvTable(data) {
       '<div class="conv-card-item">' +
         '<div class="conv-avatar" style="background:linear-gradient(135deg,#10B981,#34D399);">S</div>' +
         '<div class="conv-card-body">' +
-          '<div class="conv-card-top"><div class="conv-card-name">Sarah Johnson — Brake Inspection</div><div class="conv-card-time">5 min ago</div></div>' +
+          '<div class="conv-card-top"><div class="conv-card-name">Sarah Johnson</div><div class="conv-card-time">5 min ago</div></div>' +
           '<div class="conv-card-phone">(512) 555-0142</div>' +
           '<div class="conv-card-msg">Requesting brake inspection quote</div>' +
           '<span class="conv-card-badge booking">Booking</span>' +
@@ -2315,7 +2310,7 @@ function renderDashConvTable(data) {
       '<div class="conv-card-item">' +
         '<div class="conv-avatar" style="background:linear-gradient(135deg,#F59E0B,#FBBF24);">M</div>' +
         '<div class="conv-card-body">' +
-          '<div class="conv-card-top"><div class="conv-card-name">Mike Chen — Transmission Service</div><div class="conv-card-time">8 min ago</div></div>' +
+          '<div class="conv-card-top"><div class="conv-card-name">Mike Chen</div><div class="conv-card-time">8 min ago</div></div>' +
           '<div class="conv-card-phone">(512) 555-0187</div>' +
           '<div class="conv-card-msg">Following up on transmission service</div>' +
           '<span class="conv-card-badge">AI Handling</span>' +


### PR DESCRIPTION
## Summary
- Made dashboard title/subtitle visible and changed to "Revenue Intelligence Dashboard"
- Fixed conversation card names to show just the person name (no service suffix)
- Added Y-axis ($0k–$26k) and X-axis (Mar 10–16) labels to Revenue Analytics chart
- Removed summary boxes below chart and smoothed revenue curve to match screenshot reference
- Removed overflow:hidden from Revenue Analytics card to allow axis labels

## Test plan
- [ ] Open dashboard in browser and verify title shows "Revenue Intelligence Dashboard"
- [ ] Verify 4 KPI cards render in one row with populated data
- [ ] Verify Live Conversations shows 3 card rows with correct names
- [ ] Verify Today's Appointments shows 4 entries with status badges
- [ ] Verify Revenue Analytics chart has Y-axis and X-axis labels
- [ ] Verify System Status shows 4 operational rows
- [ ] Compare layout visually against reference screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)