### PR TITLE
fix: remove fade-in from KPI cards to fix invisible rendering

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -2886,25 +2886,25 @@ function renderLiveKPIs() {
   var activeChange = hasStrongActive ? (apptToday + ' appointments today') : '12 today';
 
   document.getElementById('kpiGrid').innerHTML =
-    '<div class="kpi-card fade-in">' +
+    '<div class="kpi-card">' +
       '<div class="kpi-icon-box green">' + iconDollar + '</div>' +
       '<div class="kpi-value">$' + recoveredRev.toLocaleString() + '</div>' +
       '<div class="kpi-label">Recovered Revenue</div>' +
       '<div class="kpi-change up">&#9650; ' + revChange + '</div>' +
     '</div>' +
-    '<div class="kpi-card fade-in">' +
+    '<div class="kpi-card">' +
       '<div class="kpi-icon-box blue">' + iconCal + '</div>' +
       '<div class="kpi-value">' + apptMonth + '</div>' +
       '<div class="kpi-label">AI Booked Appointments</div>' +
       '<div class="kpi-change up">&#9650; ' + apptChange + '</div>' +
     '</div>' +
-    '<div class="kpi-card fade-in">' +
+    '<div class="kpi-card">' +
       '<div class="kpi-icon-box amber">' + iconPhone + '</div>' +
       '<div class="kpi-value">' + captureRate + '</div>' +
       '<div class="kpi-label">Missed Calls Captured</div>' +
       '<div class="kpi-change up">&#9650; ' + captureChange + '</div>' +
     '</div>' +
-    '<div class="kpi-card fade-in">' +
+    '<div class="kpi-card">' +
       '<div class="kpi-icon-box purple">' + iconMsg + '</div>' +
       '<div class="kpi-value">' + activeConvs + '</div>' +
       '<div class="kpi-label">Active Conversations</div>' +


### PR DESCRIPTION
## Summary
- KPI cards in `renderLiveKPIs()` used `.fade-in` CSS class (opacity:0 + animation)
- Animation was not reliably completing for dynamically inserted innerHTML elements
- Cards remained permanently at opacity:0 — invisible but occupying space
- Removed `fade-in` class so cards render immediately at full opacity

## Test plan
- [ ] Load dashboard in browser
- [ ] Verify 4 KPI cards visible directly under dashboard title
- [ ] Verify values: Recovered Revenue, AI Booked Appointments, Missed Calls Captured, Active Conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)