### PR TITLE
fix: allow inline scripts via CSP and fix syntax error

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,7 +89,20 @@ async function bootstrap() {
   const billingWorker = startBillingEventsWorker();
 
   // ── Security ──────────────────────────────────────────────
-  await app.register(helmet);
+  await app.register(helmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "https:", "'unsafe-inline'"],
+        fontSrc: ["'self'", "https:", "data:"],
+        imgSrc: ["'self'", "data:"],
+        connectSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameSrc: ["'none'"],
+      },
+    },
+  });
   await app.register(rateLimit, {
     max: 100,
     timeWindow: "1 minute",

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -3343,10 +3343,8 @@ function renderTodayAppointments() {
   var body = document.getElementById('todayApptsBody');
   if (!body) return;
   if (!todayAppts.length || todayAppts.length < 2) {
-    // Show reference demo appointments when real data is absent or too weak
-    {
-      // Premium fallback demo appointments — reference data
-      body.innerHTML = '<div class="appt-card-list">' +
+    // Premium fallback demo appointments — reference data
+    body.innerHTML = '<div class="appt-card-list">' +
         '<div class="appt-card-item" style="border-left-color:#10B981;">' +
           '<div class="appt-card-top"><div class="appt-card-time">9:00 AM</div><span class="appt-card-status confirmed">Confirmed</span></div>' +
           '<div class="appt-card-customer">Robert Williams</div>' +


### PR DESCRIPTION
## Summary
- `@fastify/helmet` default CSP blocked all inline `<script>` blocks with `script-src 'self'` — added `'unsafe-inline'` to helmet config in `apps/api/src/index.ts`
- `renderTodayAppointments()` in script block 2 had a spurious `{` block leaving the function unclosed — "Unexpected end of input" parse error killed the entire script block, making `renderConvInbox` undefined, crashing the init chain before `renderLiveKPIs()` could execute

## Test plan
- [x] Puppeteer runtime verification: 4 KPI cards visible, 213px height, opacity 1
- [x] All 3 script blocks pass `node --check` syntax validation
- [x] CSP header confirmed: `script-src 'self' 'unsafe-inline'`
- [x] Zero JS console errors at runtime

## Verified KPI values
| Card | Value | Label |
|------|-------|-------|
| 1 | $24,580 | Recovered Revenue |
| 2 | 127 | AI Booked Appointments |
| 3 | 94.2% | Missed Calls Captured |
| 4 | 43 | Active Conversations |

🤖 Generated with [Claude Code](https://claude.com/claude-code)