### PR TITLE
fix: add Vercel-CDN-Cache-Control to prevent stale HTML

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,6 +5,7 @@
       "source": "/app.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -13,6 +14,7 @@
       "source": "/admin.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -21,6 +23,7 @@
       "source": "/login.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -29,6 +32,7 @@
       "source": "/signup.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -37,12 +41,14 @@
       "source": "/internal/admin/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
     }
   ],
   "rewrites": [
+    { "source": "/admin.html", "destination": "https://autoshop-api-7ek9.onrender.com/admin.html" },
     { "source": "/health", "destination": "https://autoshop-api-7ek9.onrender.com/health" },
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },
     { "source": "/billing/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/billing/:path*" },

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
       "source": "/app.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -14,6 +15,7 @@
       "source": "/admin.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -22,6 +24,7 @@
       "source": "/login.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -30,6 +33,7 @@
       "source": "/signup.html",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -38,6 +42,7 @@
       "source": "/internal/admin/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Vercel-CDN-Cache-Control", "value": "max-age=0, must-revalidate" },
         { "key": "Pragma", "value": "no-cache" },
         { "key": "Expires", "value": "0" }
       ]
@@ -49,6 +54,7 @@
     { "source": "/auth/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/auth/:path*" },
     { "source": "/billing/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/billing/:path*" },
     { "source": "/webhooks/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/webhooks/:path*" },
-    { "source": "/internal/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/internal/:path*" }
+    { "source": "/internal/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/internal/:path*" },
+    { "source": "/tenant/:path*", "destination": "https://autoshop-api-7ek9.onrender.com/tenant/:path*" }
   ]
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `autoshopsmsai.com` is served by Vercel's CDN, but `Cache-Control: no-store` only controls browser caching — Vercel's edge CDN ignores it and caches HTML files indefinitely (`X-Vercel-Cache: HIT`, `Age: 1500+`)
- Added `Vercel-CDN-Cache-Control: max-age=0, must-revalidate` header to all HTML routes in both `vercel.json` files, forcing Vercel's edge to revalidate on every request
- Synced `apps/web/vercel.json` with root config and added missing `/tenant/:path*` rewrite

## Investigation findings

| Source | MD5 | Status |
|--------|-----|--------|
| Vercel (autoshopsmsai.com) | `224dc0710e9039a8324fceb0da87ee29` | ✅ matches |
| Render API | `224dc0710e9039a8324fceb0da87ee29` | ✅ matches |
| Git HEAD | `224dc0710e9039a8324fceb0da87ee29` | ✅ matches |

Pipeline is deploying correctly. The issue was **Vercel CDN edge caching** between deployments causing stale content to be served.

## Test plan

- [x] All 374 tests pass (24 test files, 0 failures)
- [ ] After merge, verify `X-Vercel-Cache` shows `MISS` on first request
- [ ] Verify `Vercel-CDN-Cache-Control` header appears in response headers
- [ ] Make a trivial HTML change, push, confirm UI updates within 2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)