### PR TITLE
feat: persist tenant shop name to backend DB

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ import { billingCheckoutRoute } from "./routes/billing/checkout";
 import { billingPortalRoute } from "./routes/billing/portal";
 import { tenantDashboardRoute } from "./routes/tenant/dashboard";
 import { tenantKpiRoute } from "./routes/tenant/kpi";
+import { tenantSettingsRoute } from "./routes/tenant/settings";
 import { calendarTokensRoute } from "./routes/internal/calendar-tokens";
 import { bookingIntentRoute } from "./routes/internal/booking-intent";
 import { calendarEventRoute } from "./routes/internal/calendar-event";
@@ -140,6 +141,7 @@ async function bootstrap() {
   await app.register(billingPortalRoute, { prefix: "/billing" });
   await app.register(tenantDashboardRoute, { prefix: "/tenant" });
   await app.register(tenantKpiRoute, { prefix: "/tenant" });
+  await app.register(tenantSettingsRoute, { prefix: "/tenant" });
 
   // ── Static frontend (login.html, signup.html, etc.) ───────
   // Served AFTER API routes so API paths are never shadowed.

--- a/apps/api/src/routes/tenant/settings.ts
+++ b/apps/api/src/routes/tenant/settings.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+import { requireAuth } from "../../middleware/require-auth";
+
+const UpdateSettingsSchema = z.object({
+  shop_name: z.string().min(1).max(200),
+});
+
+/**
+ * PUT /tenant/settings
+ *
+ * Updates tenant settings (currently shop_name).
+ * Protected by JWT auth — tenantId comes from the verified token.
+ */
+export async function tenantSettingsRoute(app: FastifyInstance) {
+  app.put("/settings", { preHandler: [requireAuth] }, async (request, reply) => {
+    const { tenantId } = request.user as { tenantId: string; email: string };
+
+    const parsed = UpdateSettingsSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: "Validation failed",
+        details: parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`),
+      });
+    }
+
+    const { shop_name } = parsed.data;
+
+    await query(
+      `UPDATE tenants SET shop_name = $1, updated_at = NOW() WHERE id = $2`,
+      [shop_name, tenantId]
+    );
+
+    return reply.status(200).send({ success: true, shop_name });
+  });
+}

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -3907,20 +3907,35 @@ function updateSidebarBadge() {
     // Apply tenant name on load
     applyTenantName();
 
-    // Settings: save tenant name
+    // Settings: save tenant name (persists to backend DB)
     var saveBtn = document.getElementById('save-settings-btn');
     var nameInput = document.getElementById('shop-name-input');
     if (saveBtn) {
-      saveBtn.addEventListener('click', function() {
-        if (nameInput) {
-          var val = nameInput.value.trim();
-          if (val) {
-            localStorage.setItem('tenant_name', val);
-            tenantState.shopName = val;
-            applyTenantName();
-          }
+      saveBtn.addEventListener('click', async function() {
+        var val = nameInput ? nameInput.value.trim() : '';
+        if (!val) { showToast('Shop name cannot be empty.', 'error'); return; }
+
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving...';
+        try {
+          var token = localStorage.getItem('autoshop_jwt') || '';
+          var res = await fetch('/tenant/settings', {
+            method: 'PUT',
+            headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ shop_name: val })
+          });
+          if (!res.ok) { var err = await res.text().catch(function() { return ''; }); throw new Error(err || res.statusText); }
+          // Success — update local state
+          localStorage.setItem('tenant_name', val);
+          tenantState.shopName = val;
+          applyTenantName();
+          showToast('Shop name saved.');
+        } catch (e) {
+          showToast('Failed to save: ' + (e.message || 'unknown error'), 'error');
+        } finally {
+          saveBtn.disabled = false;
+          saveBtn.textContent = 'Save Changes';
         }
-        showToast('Shop profile saved.');
       });
     }
   });


### PR DESCRIPTION
## Summary
- Adds `PUT /tenant/settings` endpoint (JWT-authenticated) that updates `tenants.shop_name` in the database
- Settings save in `app.html` now calls the backend API instead of writing to localStorage only
- On reload, the DB-authoritative value is loaded via `/tenant/dashboard`, ensuring persistence across page reloads and new sessions

## What changed
| File | Change |
|------|--------|
| `apps/api/src/routes/tenant/settings.ts` | New endpoint — validates with zod, updates DB |
| `apps/api/src/index.ts` | Register new route at `/tenant` prefix |
| `apps/web/app.html` | Save handler calls API, updates localStorage on success |

## Flow
1. User edits shop name in Settings → clicks Save
2. `PUT /tenant/settings` sends `{ shop_name }` to backend
3. Backend validates (1–200 chars) and updates `tenants.shop_name` + `updated_at`
4. On success: localStorage, tenantState, and UI are updated
5. On reload: `/tenant/dashboard` returns DB value → syncs to localStorage → UI reflects it

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 389 existing tests pass (25 test files, 0 failures)
- [ ] Manual: change shop name in Settings, reload page, verify name persists
- [ ] Manual: verify name appears in nav, sidebar, dashboard subtitle after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)