### PR TITLE
feat: add tenant-facing conversation detail endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,6 +25,7 @@ import { billingPortalRoute } from "./routes/billing/portal";
 import { tenantDashboardRoute } from "./routes/tenant/dashboard";
 import { tenantKpiRoute } from "./routes/tenant/kpi";
 import { tenantSettingsRoute } from "./routes/tenant/settings";
+import { tenantConversationsRoute } from "./routes/tenant/conversations";
 import { calendarTokensRoute } from "./routes/internal/calendar-tokens";
 import { bookingIntentRoute } from "./routes/internal/booking-intent";
 import { calendarEventRoute } from "./routes/internal/calendar-event";
@@ -142,6 +143,7 @@ async function bootstrap() {
   await app.register(tenantDashboardRoute, { prefix: "/tenant" });
   await app.register(tenantKpiRoute, { prefix: "/tenant" });
   await app.register(tenantSettingsRoute, { prefix: "/tenant" });
+  await app.register(tenantConversationsRoute, { prefix: "/tenant" });
 
   // ── Static frontend (login.html, signup.html, etc.) ───────
   // Served AFTER API routes so API paths are never shadowed.

--- a/apps/api/src/routes/tenant/conversations.ts
+++ b/apps/api/src/routes/tenant/conversations.ts
@@ -1,0 +1,42 @@
+import { FastifyInstance } from "fastify";
+import { query } from "../../db/client";
+import { requireAuth } from "../../middleware/require-auth";
+
+/**
+ * GET /tenant/conversations/:id
+ *
+ * Returns conversation metadata + full message thread for a conversation
+ * belonging to the authenticated tenant. Used by the dashboard slide panel.
+ */
+export async function tenantConversationsRoute(app: FastifyInstance) {
+  app.get("/conversations/:id", { preHandler: [requireAuth] }, async (request, reply) => {
+    const { tenantId } = request.user as { tenantId: string; email: string };
+    const { id } = request.params as { id: string };
+
+    const [convRows, messagesRows] = await Promise.all([
+      query(
+        `SELECT id, tenant_id, customer_phone, status, turn_count,
+                opened_at, last_message_at, closed_at, close_reason
+         FROM conversations
+         WHERE id = $1 AND tenant_id = $2`,
+        [id, tenantId]
+      ),
+      query(
+        `SELECT id, direction, body, sent_at
+         FROM messages
+         WHERE conversation_id = $1 AND tenant_id = $2
+         ORDER BY sent_at ASC`,
+        [id, tenantId]
+      ),
+    ]);
+
+    if (!(convRows as any[]).length) {
+      return reply.status(404).send({ error: "Conversation not found" });
+    }
+
+    return reply.status(200).send({
+      conversation: (convRows as any[])[0],
+      messages: messagesRows,
+    });
+  });
+}

--- a/apps/api/src/tests/tenant-conversations.test.ts
+++ b/apps/api/src/tests/tenant-conversations.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import fastifyJwt from "@fastify/jwt";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+import { tenantConversationsRoute } from "../routes/tenant/conversations";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const CONV_ID = "11111111-1111-1111-1111-111111111111";
+const EMAIL = "owner@shop.com";
+const JWT_SECRET = "test-secret";
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  app.register(fastifyJwt, { secret: JWT_SECRET });
+  await app.register(tenantConversationsRoute, { prefix: "/tenant" });
+  return app;
+}
+
+function makeToken(app: ReturnType<typeof Fastify>) {
+  return (app as any).jwt.sign({ tenantId: TENANT_ID, email: EMAIL });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /tenant/conversations/:id
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /tenant/conversations/:id", () => {
+  it("returns conversation with messages for authenticated tenant", async () => {
+    const conv = {
+      id: CONV_ID,
+      tenant_id: TENANT_ID,
+      customer_phone: "+15551234567",
+      status: "open",
+      turn_count: 3,
+      opened_at: "2026-03-18T10:00:00Z",
+      last_message_at: "2026-03-18T10:05:00Z",
+      closed_at: null,
+      close_reason: null,
+    };
+    const messages = [
+      { id: "m1", direction: "outbound", body: "Hello!", sent_at: "2026-03-18T10:00:00Z" },
+      { id: "m2", direction: "inbound", body: "Hi, I need service", sent_at: "2026-03-18T10:01:00Z" },
+      { id: "m3", direction: "outbound", body: "Sure, when works?", sent_at: "2026-03-18T10:02:00Z" },
+    ];
+
+    mocks.query
+      .mockResolvedValueOnce([conv])     // conversation query
+      .mockResolvedValueOnce(messages);   // messages query
+
+    const app = await buildApp();
+    const token = makeToken(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenant/conversations/${CONV_ID}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.conversation.id).toBe(CONV_ID);
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[0].direction).toBe("outbound");
+    expect(body.messages[1].body).toBe("Hi, I need service");
+  });
+
+  it("returns 404 when conversation does not exist or belongs to another tenant", async () => {
+    mocks.query
+      .mockResolvedValueOnce([])    // conversation not found (tenant_id filter)
+      .mockResolvedValueOnce([]);   // messages (empty)
+
+    const app = await buildApp();
+    const token = makeToken(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenant/conversations/${CONV_ID}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("Conversation not found");
+  });
+
+  it("returns 401 without auth token", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenant/conversations/${CONV_ID}`,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("queries filter by tenant_id to prevent cross-tenant access", async () => {
+    mocks.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const token = makeToken(app);
+
+    await app.inject({
+      method: "GET",
+      url: `/tenant/conversations/${CONV_ID}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    // Both queries should include tenant_id filter
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+    const convCall = mocks.query.mock.calls[0];
+    const msgCall = mocks.query.mock.calls[1];
+
+    // Conversation query filters by id AND tenant_id
+    expect(convCall[1]).toEqual([CONV_ID, TENANT_ID]);
+    // Messages query filters by conversation_id AND tenant_id
+    expect(msgCall[1]).toEqual([CONV_ID, TENANT_ID]);
+  });
+});

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -2862,7 +2862,7 @@ async function loadConversationPanel(id, conv) {
   // Try fetching from tenant API
   try {
     var token = localStorage.getItem('autoshop_jwt');
-    var res = await fetch('/api/conversations/' + id, {
+    var res = await fetch('/tenant/conversations/' + id, {
       headers: token ? { 'Authorization': 'Bearer ' + token } : {}
     });
     if (res.ok) {


### PR DESCRIPTION
## Summary
- Adds `GET /tenant/conversations/:id` — authenticated endpoint returning conversation metadata + full message thread
- Both SQL queries filter by `tenant_id` to prevent cross-tenant data access
- Updates dashboard frontend to call `/tenant/conversations/` instead of non-existent `/api/conversations/`
- Slide panel now loads real SMS thread data instead of falling back to partial info

## Test plan
- [x] 4 new tests: success, 404/cross-tenant, 401 no auth, tenant_id filter verification
- [x] Full test suite: 27 files, 398 tests, 0 failures
- [ ] Manual: click conversation card on dashboard → panel opens → real messages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)