### PR TITLE
feat: add pipeline failure alerting system

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,30 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: pipeline-alerts — 2026-03-18
+
+**Branch:** ai/pipeline-alerts
+**Status:** COMPLETE — Pipeline failure alerting system
+
+### Why This is BUILD Work
+Before this change, when the core pipeline failed (OpenAI down, SMS send fails, booking breaks, worker retries exhausted), the failure was silent — logged to console only. No operator or tenant owner was notified. This directly reduces execution risk in the live missed-call → SMS → AI → booking → calendar path.
+
+### Changes
+1. **Migration 021** — `pipeline_alerts` table with severity, alert_type, owner notification tracking, admin acknowledgement
+2. **Pipeline alerts service** (`services/pipeline-alerts.ts`) — `raiseAlert()`, `classifyError()`, `alertFromTraceFailure()`, `getAlerts()`, `acknowledgeAlert()`, `countUnacknowledgedAlerts()`
+3. **Route integration** — `process-sms.ts` and `missed-call-sms.ts` routes now raise alerts on pipeline failure
+4. **Worker dead-letter capture** — BullMQ sms-inbound worker raises alert when jobs exhaust all retries
+5. **Admin endpoints** — `GET /internal/admin/alerts`, `POST /internal/admin/alerts/:id/acknowledge`
+6. **Overview badge** — `unacknowledged_alerts` count added to admin overview response
+7. **Owner SMS notification** — Critical alerts send SMS to tenant `owner_phone` via Twilio
+
+### Verification
+- 417/417 tests passed (28 test files)
+- TypeScript: clean (no errors)
+- 19 new tests in pipeline-alerts.test.ts
+
+---
+
 ## TASK: dashboard-kpi-customers-analytics-fix — 2026-03-17
 
 **Branch:** ai/dashboard-kpi-customers-analytics-fix

--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -6,6 +6,7 @@ import { adminGuard } from "../../middleware/admin-guard";
 import { fetchTwilioNumberConfig, verifyWebhookUrls } from "../../services/twilio-verify";
 import { getConfig } from "../../db/app-config";
 import { getRecentTraces, getTraceById } from "../../services/pipeline-trace";
+import { getAlerts, acknowledgeAlert, countUnacknowledgedAlerts } from "../../services/pipeline-alerts";
 
 /**
  * Internal Admin API
@@ -116,6 +117,7 @@ export async function adminRoute(app: FastifyInstance) {
       recentConversationsRows,
       pendingManualRows,
       failedBookingsRows,
+      unackedAlertsRows,
     ] = await Promise.all([
       query(`SELECT billing_status, COUNT(*) as count FROM tenants WHERE is_test = FALSE GROUP BY billing_status`),
       query(`SELECT COUNT(*)::int FROM tenants WHERE created_at > NOW() - INTERVAL '7 days' AND is_test = FALSE`),
@@ -148,6 +150,7 @@ export async function adminRoute(app: FastifyInstance) {
          ORDER BY c.opened_at DESC LIMIT 5`),
       query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.booking_state = 'PENDING_MANUAL_CONFIRMATION'`),
       query(`SELECT COUNT(*)::int FROM appointments a JOIN tenants t ON t.id = a.tenant_id AND t.is_test = FALSE WHERE a.booking_state = 'FAILED'`),
+      query(`SELECT COUNT(*)::int FROM pipeline_alerts WHERE acknowledged = FALSE`),
     ]);
 
     // Build status map
@@ -176,6 +179,7 @@ export async function adminRoute(app: FastifyInstance) {
       recent_conversations: recentConversationsRows,
       pending_manual_bookings: (pendingManualRows as any[])[0]?.count ?? 0,
       failed_bookings: (failedBookingsRows as any[])[0]?.count ?? 0,
+      unacknowledged_alerts: (unackedAlertsRows as any[])[0]?.count ?? 0,
     });
   });
 
@@ -1326,5 +1330,24 @@ export async function adminRoute(app: FastifyInstance) {
     const trace = await getTraceById(id);
     if (!trace) return reply.status(404).send({ error: "Trace not found" });
     return reply.send(trace);
+  });
+
+  // ── GET /internal/admin/alerts ──────────────────────────────────────────────
+  // Returns pipeline failure alerts. Default: unacknowledged only.
+  app.get("/admin/alerts", { preHandler: [adminGuard] }, async (req, reply) => {
+    const q = req.query as { acknowledged?: string };
+    const acknowledged = q.acknowledged === "1";
+    const alerts = await getAlerts({ acknowledged, limit: 50 });
+    const unacknowledgedCount = acknowledged ? await countUnacknowledgedAlerts() : alerts.length;
+    return reply.send({ alerts, unacknowledged_count: unacknowledgedCount });
+  });
+
+  // ── POST /internal/admin/alerts/:id/acknowledge ────────────────────────────
+  app.post("/admin/alerts/:id/acknowledge", { preHandler: [adminGuard] }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const adminEmail = (req as any).adminEmail ?? "unknown";
+    const updated = await acknowledgeAlert(id, adminEmail);
+    if (!updated) return reply.status(404).send({ error: "Alert not found or already acknowledged" });
+    return reply.send({ acknowledged: true });
   });
 }

--- a/apps/api/src/routes/internal/missed-call-sms.ts
+++ b/apps/api/src/routes/internal/missed-call-sms.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { handleMissedCallSms } from "../../services/missed-call-sms";
 import { resumeTrace } from "../../services/pipeline-trace";
+import { alertFromTraceFailure } from "../../services/pipeline-alerts";
 
 const BodySchema = z.object({
   tenantId: z.string().uuid(),
@@ -76,6 +77,16 @@ export async function missedCallSmsRoute(app: FastifyInstance) {
     );
 
     if (!result.success) {
+      // Raise pipeline alert (non-fatal)
+      try {
+        await alertFromTraceFailure(
+          parsed.data.tenantId,
+          traceId ?? null,
+          result.error,
+          parsed.data.customerPhone
+        );
+      } catch { /* non-fatal */ }
+
       const status =
         result.error === "Tenant not found"
           ? 404

--- a/apps/api/src/routes/internal/process-sms.ts
+++ b/apps/api/src/routes/internal/process-sms.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { processSms } from "../../services/process-sms";
 import { resumeTrace } from "../../services/pipeline-trace";
+import { alertFromTraceFailure } from "../../services/pipeline-alerts";
 
 const BodySchema = z.object({
   tenantId: z.string().uuid(),
@@ -94,6 +95,16 @@ export async function processSmsRoute(app: FastifyInstance) {
     );
 
     if (!result.success) {
+      // Raise pipeline alert (non-fatal)
+      try {
+        await alertFromTraceFailure(
+          parsed.data.tenantId,
+          traceId ?? null,
+          result.error,
+          parsed.data.customerPhone
+        );
+      } catch { /* non-fatal */ }
+
       return reply.status(500).send(result);
     }
 

--- a/apps/api/src/services/pipeline-alerts.ts
+++ b/apps/api/src/services/pipeline-alerts.ts
@@ -1,0 +1,224 @@
+/**
+ * Pipeline Alert Service
+ *
+ * Creates alerts when the core pipeline fails and notifies tenant owners
+ * via SMS. Alerts persist in the database until acknowledged by an admin.
+ *
+ * Alert types:
+ *   - sms_send_failed:       Reply SMS could not be delivered
+ *   - ai_error:              OpenAI API failure
+ *   - booking_failed:        Appointment creation failed
+ *   - calendar_sync_failed:  Google Calendar write failed
+ *   - worker_exhausted:      BullMQ job exhausted all retries
+ *   - pipeline_failed:       Generic pipeline failure
+ */
+
+import { query } from "../db/client";
+import { sendTwilioSms } from "./missed-call-sms";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type AlertSeverity = "critical" | "warning";
+
+export type AlertType =
+  | "sms_send_failed"
+  | "ai_error"
+  | "booking_failed"
+  | "calendar_sync_failed"
+  | "worker_exhausted"
+  | "pipeline_failed";
+
+export interface RaiseAlertInput {
+  tenantId: string | null;
+  traceId: string | null;
+  severity: AlertSeverity;
+  alertType: AlertType;
+  summary: string;
+  details?: string | null;
+}
+
+export interface PipelineAlert {
+  id: string;
+  tenant_id: string | null;
+  trace_id: string | null;
+  severity: string;
+  alert_type: string;
+  summary: string;
+  details: string | null;
+  owner_notified: boolean;
+  acknowledged: boolean;
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
+  created_at: string;
+  shop_name?: string | null;
+}
+
+// ── Core functions ───────────────────────────────────────────────────────────
+
+/**
+ * Create a pipeline alert and optionally notify the tenant owner via SMS.
+ * Non-fatal: never throws — alerting must not break the pipeline.
+ */
+export async function raiseAlert(
+  input: RaiseAlertInput,
+  fetchFn: typeof fetch = fetch
+): Promise<string | null> {
+  try {
+    // Insert alert record
+    const rows = await query<{ id: string }>(
+      `INSERT INTO pipeline_alerts (tenant_id, trace_id, severity, alert_type, summary, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [
+        input.tenantId,
+        input.traceId,
+        input.severity,
+        input.alertType,
+        input.summary,
+        input.details ?? null,
+      ]
+    );
+
+    const alertId = rows[0]?.id ?? null;
+
+    // Notify owner via SMS if tenant has owner_phone
+    if (input.tenantId && input.severity === "critical") {
+      try {
+        const tenantRows = await query<{ owner_phone: string | null; shop_name: string | null }>(
+          `SELECT owner_phone, shop_name FROM tenants WHERE id = $1`,
+          [input.tenantId]
+        );
+
+        const ownerPhone = tenantRows[0]?.owner_phone;
+        if (ownerPhone) {
+          const shopLabel = tenantRows[0]?.shop_name ?? "Your shop";
+          const alertSms =
+            `AutoShop AI Alert (${shopLabel}): ${input.summary}. ` +
+            `Check your dashboard or contact support.`;
+
+          const smsResult = await sendTwilioSms(ownerPhone, alertSms, fetchFn);
+
+          if (smsResult.sid && alertId) {
+            await query(
+              `UPDATE pipeline_alerts SET owner_notified = TRUE WHERE id = $1`,
+              [alertId]
+            );
+          }
+        }
+      } catch {
+        // Non-fatal: alert was created even if SMS notification fails
+      }
+    }
+
+    return alertId;
+  } catch (err) {
+    // Non-fatal: alerting must never break the pipeline
+    console.error(`[pipeline-alerts] Failed to raise alert: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Classify a pipeline error into an alert type and severity.
+ */
+export function classifyError(error: string | null): { alertType: AlertType; severity: AlertSeverity } {
+  if (!error) return { alertType: "pipeline_failed", severity: "critical" };
+
+  const lower = error.toLowerCase();
+
+  if (lower.includes("openai") || lower.includes("api error")) {
+    return { alertType: "ai_error", severity: "critical" };
+  }
+  if (lower.includes("sms send failed") || lower.includes("sms not sent")) {
+    return { alertType: "sms_send_failed", severity: "critical" };
+  }
+  if (lower.includes("calendar sync") || lower.includes("calendar") && lower.includes("fail")) {
+    return { alertType: "calendar_sync_failed", severity: "warning" };
+  }
+  if (lower.includes("appointment") && lower.includes("fail")) {
+    return { alertType: "booking_failed", severity: "critical" };
+  }
+
+  return { alertType: "pipeline_failed", severity: "critical" };
+}
+
+/**
+ * Raise an alert from a failed pipeline trace result.
+ * Call this after trace.fail() in route handlers.
+ */
+export async function alertFromTraceFailure(
+  tenantId: string | null,
+  traceId: string | null,
+  error: string | null,
+  customerPhone: string | null,
+  fetchFn: typeof fetch = fetch
+): Promise<void> {
+  const { alertType, severity } = classifyError(error);
+
+  const phoneSuffix = customerPhone ? ` (customer: ${customerPhone.slice(-4)})` : "";
+  const summary = `Pipeline failed: ${error ?? "unknown error"}${phoneSuffix}`;
+
+  await raiseAlert(
+    {
+      tenantId,
+      traceId,
+      severity,
+      alertType,
+      summary,
+      details: error,
+    },
+    fetchFn
+  );
+}
+
+// ── Admin queries ────────────────────────────────────────────────────────────
+
+/**
+ * Get unacknowledged alerts (for admin dashboard).
+ */
+export async function getAlerts(
+  opts: { acknowledged?: boolean; limit?: number } = {}
+): Promise<PipelineAlert[]> {
+  const acked = opts.acknowledged ?? false;
+  const limit = opts.limit ?? 50;
+
+  return query<PipelineAlert>(
+    `SELECT pa.id, pa.tenant_id, pa.trace_id, pa.severity, pa.alert_type,
+            pa.summary, pa.details, pa.owner_notified, pa.acknowledged,
+            pa.acknowledged_at, pa.acknowledged_by, pa.created_at,
+            t.shop_name
+     FROM pipeline_alerts pa
+     LEFT JOIN tenants t ON t.id = pa.tenant_id
+     WHERE pa.acknowledged = $1
+     ORDER BY pa.created_at DESC
+     LIMIT $2`,
+    [acked, limit]
+  );
+}
+
+/**
+ * Acknowledge an alert (admin action).
+ */
+export async function acknowledgeAlert(
+  alertId: string,
+  adminEmail: string
+): Promise<boolean> {
+  const rows = await query(
+    `UPDATE pipeline_alerts
+     SET acknowledged = TRUE, acknowledged_at = now(), acknowledged_by = $1
+     WHERE id = $2 AND acknowledged = FALSE
+     RETURNING id`,
+    [adminEmail, alertId]
+  );
+  return (rows as any[]).length > 0;
+}
+
+/**
+ * Count unacknowledged alerts (for overview badge).
+ */
+export async function countUnacknowledgedAlerts(): Promise<number> {
+  const rows = await query<{ count: number }>(
+    `SELECT COUNT(*)::int AS count FROM pipeline_alerts WHERE acknowledged = FALSE`
+  );
+  return rows[0]?.count ?? 0;
+}

--- a/apps/api/src/tests/admin-booking-state.test.ts
+++ b/apps/api/src/tests/admin-booking-state.test.ts
@@ -126,7 +126,7 @@ describe("GET /internal/admin/overview — booking_state counts", () => {
   });
 
   it("returns pending_manual_bookings and failed_bookings counts", async () => {
-    // The overview endpoint runs 16 parallel queries
+    // The overview endpoint runs 17 parallel queries
     // We need to mock all of them in order
     const overviewMocks = [
       [{ billing_status: "active", count: "2" }], // statusCountsRows
@@ -145,6 +145,7 @@ describe("GET /internal/admin/overview — booking_state counts", () => {
       [],               // recentConversationsRows
       [{ count: 4 }],  // pendingManualRows
       [{ count: 2 }],  // failedBookingsRows
+      [{ count: 0 }],  // unackedAlertsRows
     ];
     for (const mock of overviewMocks) {
       mocks.query.mockResolvedValueOnce(mock);

--- a/apps/api/src/tests/pipeline-alerts.test.ts
+++ b/apps/api/src/tests/pipeline-alerts.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: (...args: unknown[]) => mockQuery(...args),
+  withTenant: vi.fn(),
+}));
+
+vi.mock("../services/missed-call-sms", () => ({
+  sendTwilioSms: vi.fn().mockResolvedValue({ sid: "SM_ALERT_001" }),
+}));
+
+import {
+  raiseAlert,
+  classifyError,
+  alertFromTraceFailure,
+  getAlerts,
+  acknowledgeAlert,
+  countUnacknowledgedAlerts,
+} from "../services/pipeline-alerts";
+import { sendTwilioSms } from "../services/missed-call-sms";
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+const ALERT_ID = "11111111-2222-3333-4444-555555555555";
+const TENANT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const TRACE_ID = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockResolvedValue([]);
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("pipeline-alerts", () => {
+  describe("raiseAlert", () => {
+    it("inserts an alert record into pipeline_alerts", async () => {
+      // Insert alert
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+      // Tenant lookup for SMS (critical + tenantId triggers this)
+      mockQuery.mockResolvedValueOnce([{ owner_phone: null, shop_name: "Test" }]);
+
+      const alertId = await raiseAlert({
+        tenantId: TENANT_ID,
+        traceId: TRACE_ID,
+        severity: "critical",
+        alertType: "ai_error",
+        summary: "OpenAI API error 500",
+        details: "Internal server error",
+      });
+
+      expect(alertId).toBe(ALERT_ID);
+      expect(mockQuery.mock.calls[0][0]).toContain("INSERT INTO pipeline_alerts");
+      expect(mockQuery.mock.calls[0][1]).toEqual([
+        TENANT_ID,
+        TRACE_ID,
+        "critical",
+        "ai_error",
+        "OpenAI API error 500",
+        "Internal server error",
+      ]);
+    });
+
+    it("notifies owner via SMS for critical alerts", async () => {
+      // Insert alert
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+      // Tenant lookup
+      mockQuery.mockResolvedValueOnce([{ owner_phone: "+15559990000", shop_name: "Bob's Auto" }]);
+      // Update owner_notified
+      mockQuery.mockResolvedValueOnce([]);
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+
+      await raiseAlert(
+        {
+          tenantId: TENANT_ID,
+          traceId: TRACE_ID,
+          severity: "critical",
+          alertType: "sms_send_failed",
+          summary: "SMS delivery failed",
+        },
+        mockFetch as any
+      );
+
+      expect(sendTwilioSms).toHaveBeenCalledWith(
+        "+15559990000",
+        expect.stringContaining("AutoShop AI Alert"),
+        mockFetch
+      );
+      // Should update owner_notified
+      expect(mockQuery.mock.calls[2][0]).toContain("owner_notified = TRUE");
+    });
+
+    it("skips SMS notification for warning-severity alerts", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+
+      await raiseAlert({
+        tenantId: TENANT_ID,
+        traceId: TRACE_ID,
+        severity: "warning",
+        alertType: "calendar_sync_failed",
+        summary: "Calendar sync failed",
+      });
+
+      expect(sendTwilioSms).not.toHaveBeenCalled();
+    });
+
+    it("skips SMS when tenant has no owner_phone", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+      mockQuery.mockResolvedValueOnce([{ owner_phone: null, shop_name: "Test Shop" }]);
+
+      await raiseAlert({
+        tenantId: TENANT_ID,
+        traceId: TRACE_ID,
+        severity: "critical",
+        alertType: "ai_error",
+        summary: "AI failed",
+      });
+
+      expect(sendTwilioSms).not.toHaveBeenCalled();
+    });
+
+    it("never throws even on DB error", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("connection refused"));
+
+      const alertId = await raiseAlert({
+        tenantId: TENANT_ID,
+        traceId: null,
+        severity: "critical",
+        alertType: "pipeline_failed",
+        summary: "DB down",
+      });
+
+      expect(alertId).toBeNull();
+    });
+
+    it("handles null tenantId without SMS lookup", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+
+      const alertId = await raiseAlert({
+        tenantId: null,
+        traceId: null,
+        severity: "critical",
+        alertType: "worker_exhausted",
+        summary: "Worker died",
+      });
+
+      expect(alertId).toBe(ALERT_ID);
+      // Only 1 call (insert), no tenant lookup
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("classifyError", () => {
+    it("classifies OpenAI errors as ai_error/critical", () => {
+      expect(classifyError("OpenAI API error 500: Internal server error")).toEqual({
+        alertType: "ai_error",
+        severity: "critical",
+      });
+    });
+
+    it("classifies SMS failures as sms_send_failed/critical", () => {
+      expect(classifyError("SMS send failed: Twilio error")).toEqual({
+        alertType: "sms_send_failed",
+        severity: "critical",
+      });
+    });
+
+    it("classifies calendar failures as calendar_sync_failed/warning", () => {
+      expect(classifyError("Calendar sync failed: no tokens")).toEqual({
+        alertType: "calendar_sync_failed",
+        severity: "warning",
+      });
+    });
+
+    it("classifies appointment failures as booking_failed/critical", () => {
+      expect(classifyError("Appointment creation failed: DB error")).toEqual({
+        alertType: "booking_failed",
+        severity: "critical",
+      });
+    });
+
+    it("defaults to pipeline_failed/critical for unknown errors", () => {
+      expect(classifyError("Something weird happened")).toEqual({
+        alertType: "pipeline_failed",
+        severity: "critical",
+      });
+    });
+
+    it("handles null error", () => {
+      expect(classifyError(null)).toEqual({
+        alertType: "pipeline_failed",
+        severity: "critical",
+      });
+    });
+  });
+
+  describe("alertFromTraceFailure", () => {
+    it("creates alert with classified type and customer phone suffix", async () => {
+      // Insert alert
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+      // Tenant lookup for SMS notification (critical severity)
+      mockQuery.mockResolvedValueOnce([{ owner_phone: null, shop_name: "Test" }]);
+
+      await alertFromTraceFailure(
+        TENANT_ID,
+        TRACE_ID,
+        "OpenAI API error 429: rate limited",
+        "+15551234567"
+      );
+
+      const args = mockQuery.mock.calls[0][1];
+      expect(args[0]).toBe(TENANT_ID);
+      expect(args[1]).toBe(TRACE_ID);
+      expect(args[2]).toBe("critical");
+      expect(args[3]).toBe("ai_error");
+      expect(args[4]).toContain("4567"); // last 4 digits
+    });
+  });
+
+  describe("getAlerts", () => {
+    it("queries unacknowledged alerts by default", async () => {
+      const mockAlert = {
+        id: ALERT_ID,
+        tenant_id: TENANT_ID,
+        severity: "critical",
+        alert_type: "ai_error",
+        summary: "AI failed",
+        acknowledged: false,
+      };
+      mockQuery.mockResolvedValueOnce([mockAlert]);
+
+      const alerts = await getAlerts();
+
+      expect(mockQuery.mock.calls[0][0]).toContain("acknowledged = $1");
+      expect(mockQuery.mock.calls[0][1]).toEqual([false, 50]);
+      expect(alerts).toEqual([mockAlert]);
+    });
+
+    it("supports acknowledged filter and custom limit", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+
+      await getAlerts({ acknowledged: true, limit: 10 });
+
+      expect(mockQuery.mock.calls[0][1]).toEqual([true, 10]);
+    });
+  });
+
+  describe("acknowledgeAlert", () => {
+    it("marks alert as acknowledged", async () => {
+      mockQuery.mockResolvedValueOnce([{ id: ALERT_ID }]);
+
+      const result = await acknowledgeAlert(ALERT_ID, "admin@example.com");
+
+      expect(result).toBe(true);
+      expect(mockQuery.mock.calls[0][0]).toContain("acknowledged = TRUE");
+      expect(mockQuery.mock.calls[0][1]).toEqual(["admin@example.com", ALERT_ID]);
+    });
+
+    it("returns false if alert not found", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+
+      const result = await acknowledgeAlert("nonexistent", "admin@example.com");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("countUnacknowledgedAlerts", () => {
+    it("returns count from DB", async () => {
+      mockQuery.mockResolvedValueOnce([{ count: 5 }]);
+
+      const count = await countUnacknowledgedAlerts();
+
+      expect(count).toBe(5);
+      expect(mockQuery.mock.calls[0][0]).toContain("acknowledged = FALSE");
+    });
+
+    it("returns 0 when no alerts", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+
+      const count = await countUnacknowledgedAlerts();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/workers/sms-inbound.worker.ts
+++ b/apps/api/src/workers/sms-inbound.worker.ts
@@ -1,5 +1,6 @@
 import { Worker, Job } from "bullmq";
 import { bullmqConnection as connection } from "../queues/redis";
+import { raiseAlert } from "../services/pipeline-alerts";
 
 const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? "http://localhost:3000";
 const MISSED_CALL_ENDPOINT = `${API_INTERNAL_URL}/internal/missed-call-sms`;
@@ -53,6 +54,25 @@ export function startSmsInboundWorker(): Worker {
     console.error(
       `[sms-worker] job ${job?.id} (${job?.name}) failed: ${err.message}`
     );
+
+    // Raise alert when job exhausts all retries (dead letter)
+    const attempts = job?.attemptsMade ?? 0;
+    const maxAttempts = (job?.opts?.attempts ?? 3);
+    if (attempts >= maxAttempts) {
+      const tenantId = job?.data?.tenantId ?? null;
+      const customerPhone = job?.data?.customerPhone ?? null;
+      const traceId = job?.data?.traceId ?? null;
+      const phoneSuffix = customerPhone ? ` (customer: ${customerPhone.slice(-4)})` : "";
+
+      raiseAlert({
+        tenantId,
+        traceId,
+        severity: "critical",
+        alertType: "worker_exhausted",
+        summary: `Job ${job?.name ?? "unknown"} exhausted all ${maxAttempts} retries${phoneSuffix}`,
+        details: err.message,
+      }).catch(() => { /* non-fatal */ });
+    }
   });
 
   return worker;

--- a/db/migrations/021_pipeline_alerts.sql
+++ b/db/migrations/021_pipeline_alerts.sql
@@ -1,0 +1,25 @@
+-- Pipeline alerts: proactive notifications when the core flow fails.
+-- Created from failed pipeline traces. Operators must acknowledge to clear.
+
+CREATE TABLE IF NOT EXISTS pipeline_alerts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID,
+  trace_id        UUID REFERENCES pipeline_traces(id),
+  severity        TEXT NOT NULL DEFAULT 'critical',  -- 'critical' | 'warning'
+  alert_type      TEXT NOT NULL,                     -- 'sms_send_failed' | 'ai_error' | 'booking_failed' | 'calendar_sync_failed' | 'worker_exhausted' | 'pipeline_failed'
+  summary         TEXT NOT NULL,
+  details         TEXT,
+  owner_notified  BOOLEAN NOT NULL DEFAULT FALSE,
+  acknowledged    BOOLEAN NOT NULL DEFAULT FALSE,
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by TEXT,                              -- admin email
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Admin queries: unacknowledged alerts, most recent first
+CREATE INDEX IF NOT EXISTS idx_pipeline_alerts_unacked
+  ON pipeline_alerts (acknowledged, created_at DESC);
+
+-- Per-tenant alert lookup
+CREATE INDEX IF NOT EXISTS idx_pipeline_alerts_tenant
+  ON pipeline_alerts (tenant_id, created_at DESC);

--- a/project-brain/project_status.md
+++ b/project-brain/project_status.md
@@ -7,7 +7,7 @@
 
 ## Project Completion Estimate
 
-**~69%** (weighted)
+**~71%** (weighted)
 
 Calculated from weighted stage progress below. Only objectively verifiable progress counts. Code-complete but unverified stages are capped at 40-50%.
 
@@ -43,11 +43,11 @@ Phase: Production-verified, awaiting human demo run.
 | 3 | Core Messaging & AI Flow | 25% | in_progress | 80% | 20.0% |
 | 4 | Calendar & Booking Reliability | 15% | in_progress | 80% | 12.0% |
 | 5 | Admin Visibility & Control | 10% | done | 100% | 10.0% |
-| 6 | Production Readiness | 15% | in_progress | 40% | 6.0% |
+| 6 | Production Readiness | 15% | in_progress | 50% | 7.5% |
 | 7 | First Live Pilot | 10% | not_started | 0% | 0.0% |
-| | **Total** | **100%** | | | **~69%** |
+| | **Total** | **100%** | | | **~71%** |
 
-> Progress recalculated 2026-03-16: 10 + 13.5 + 20 + 12 + 10 + 6 + 0 = 71.5 → 69% (conservative)
+> Progress recalculated 2026-03-18: 10 + 13.5 + 20 + 12 + 10 + 7.5 + 0 = 73 → 71% (conservative)
 
 ## Active Tasks
 
@@ -57,10 +57,11 @@ Phase: Production-verified, awaiting human demo run.
 - Call +13257523890 and let it ring to test missed-call trigger
 
 ### AI Next
-- Remaining Stage 6 hardening (Stripe billing live-test, error alerting)
+- Remaining Stage 6 hardening (Stripe billing live-test)
 
 ## Done (Recent)
 
+- Pipeline failure alerting: alerts table, owner SMS notification, admin endpoints, dead-letter capture (ai/pipeline-alerts)
 - Tenant health monitoring: per-tenant conversation, booking, pipeline, calendar metrics with Health tab in admin (ai/tenant-health-monitoring)
 - Pilot tenant readiness check: per-tenant live-path checklist with ready/not_ready verdict, 9 checks, admin UI tab (PR #120)
 - Live environment hardening: startup env validation, graceful shutdown timeout, safe webhook enqueue, enhanced health check (PR #113)
@@ -86,6 +87,7 @@ Phase: Production-verified, awaiting human demo run.
 
 | Date | Change | Branch/PR |
 |------|--------|-----------|
+| 2026-03-18 | Pipeline failure alerting: alerts table, owner SMS, admin endpoints, dead-letter capture | ai/pipeline-alerts |
 | 2026-03-16 | Tenant health monitoring: per-tenant conversation, booking, pipeline, calendar metrics + admin tab | ai/tenant-health-monitoring |
 | 2026-03-15 | Pilot tenant readiness check: per-tenant live-path checklist with verdict | PR #120 |
 | 2026-03-15 | Live env hardening: startup env validation, shutdown timeout, safe webhook enqueue | PR #113 |

--- a/project-brain/project_status_v2.json
+++ b/project-brain/project_status_v2.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "version": 2,
-    "last_updated": "2026-03-16T18:00:00Z",
+    "last_updated": "2026-03-18T21:00:00Z",
     "updated_by": "claude",
     "repo_branch": "main"
   },
@@ -9,7 +9,7 @@
     "project_name": "AutoShop AI Agent SaaS",
     "current_mission": "Full SMS pipeline production-verified — awaiting human demo run and pilot onboarding",
     "current_node_id": "calendar_reliability",
-    "overall_progress": 69,
+    "overall_progress": 71,
     "momentum": "progressing",
     "ai_can_continue_now": true,
     "human_action_required": true,
@@ -276,7 +276,7 @@
       "title": "Production Readiness",
       "weight": 15,
       "status": "in_progress",
-      "progress": 40,
+      "progress": 50,
       "owner": "ai",
       "depends_on": [
         "calendar_reliability",
@@ -312,10 +312,16 @@
           "title": "Live environment hardening (startup env validation, shutdown timeout, safe webhook enqueue)",
           "status": "done",
           "owner": "ai"
+        },
+        {
+          "id": "pipeline_error_alerting",
+          "title": "Pipeline failure alerting (alerts table, owner SMS notification, admin endpoints, dead-letter capture)",
+          "status": "done",
+          "owner": "ai"
         }
       ],
-      "next_task": "Remaining: Stripe billing live-test, error alerting",
-      "last_change": "2026-03-15"
+      "next_task": "Remaining: Stripe billing live-test",
+      "last_change": "2026-03-18"
     },
     {
       "id": "first_live_pilot",
@@ -376,6 +382,13 @@
     }
   ],
   "recent_movements": [
+    {
+      "date": "2026-03-18",
+      "type": "task_done",
+      "title": "Pipeline failure alerting — alerts table, owner SMS, admin endpoints, dead-letter capture",
+      "impact": "Pipeline failures now create persistent alerts, notify tenant owners via SMS, and surface in admin dashboard. Dead-letter jobs captured when BullMQ retries exhausted.",
+      "branch": "ai/pipeline-alerts"
+    },
     {
       "date": "2026-03-16",
       "type": "task_done",


### PR DESCRIPTION
## Summary
- Pipeline failures were silent — now they create persistent alerts, notify tenant owners via SMS, and surface in admin dashboard
- Covers all failure types: AI errors, SMS send failures, booking failures, calendar sync failures, BullMQ dead-letter (exhausted retries)
- Admin endpoints to list and acknowledge alerts; unacknowledged count added to overview

## Changes
- `db/migrations/021_pipeline_alerts.sql` — alerts table with severity, type, owner notification, admin acknowledgement
- `apps/api/src/services/pipeline-alerts.ts` — core service (raiseAlert, classifyError, alertFromTraceFailure, getAlerts, acknowledgeAlert)
- `apps/api/src/routes/internal/process-sms.ts` — raises alert on pipeline failure
- `apps/api/src/routes/internal/missed-call-sms.ts` — raises alert on pipeline failure
- `apps/api/src/workers/sms-inbound.worker.ts` — dead-letter capture when jobs exhaust retries
- `apps/api/src/routes/internal/admin.ts` — GET /admin/alerts, POST /admin/alerts/:id/acknowledge, overview badge

## Why this is BUILD work
Reduces real execution risk in the live missed-call → SMS → AI → booking → calendar pipeline. Without alerting, production failures are invisible.

## Test plan
- [x] 19 new tests in pipeline-alerts.test.ts
- [x] 417/417 tests passing (28 test files)
- [x] TypeScript: clean (no errors)
- [x] Existing admin-booking-state test updated for new overview field

🤖 Generated with [Claude Code](https://claude.com/claude-code)