### PR TITLE
feat: billing hardening — auto-reply, Twilio suspension, chargeback alerts

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,29 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: billing-hardening — 2026-03-18
+
+**Branch:** ai/billing-hardening
+**Status:** COMPLETE — Three billing gaps closed: blocked tenant auto-reply, Twilio suspension on cancel, chargeback admin alert
+
+### Why This is BUILD Work
+All three changes reduce real execution risk in the live pipeline:
+1. Blocked tenants' customers were getting silent drops — now they get a polite reply directing them to call
+2. Canceled tenants kept active Twilio numbers routing messages to a dead account
+3. Chargebacks required admin action but generated no alert
+
+### Changes
+1. **Blocked tenant auto-reply SMS** — TwiML `<Message>` response for each block reason (trial_expired, canceled, payment_failed, paused) with shop name. Customer is never left hanging.
+2. **Twilio number suspension on cancel** — `subscription.deleted` webhook now sets phone number status to `suspended`. Reversible (number not released from Twilio).
+3. **Chargeback admin alert** — `charge.dispute.created` webhook now raises a critical pipeline alert via the alerting system (PR #174).
+
+### Verification
+- 425/425 tests passed (28 test files)
+- TypeScript: clean (no errors)
+- 8 new tests (auto-reply variants, phone suspension, chargeback alert)
+
+---
+
 ## TASK: pipeline-alerts — 2026-03-18
 
 **Branch:** ai/pipeline-alerts

--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -181,13 +181,33 @@ async function routeStripeEvent(event: Stripe.Event, tenantId: string) {
 
     case "customer.subscription.deleted": {
       await updateBillingStatus(tenantId, "canceled");
-      // TODO: suspend Twilio number (async job)
+      // Suspend Twilio number(s) so inbound messages stop routing to this tenant.
+      // Number is NOT released from Twilio (reversible if tenant resubscribes).
+      await query(
+        `UPDATE tenant_phone_numbers SET status = 'suspended', updated_at = NOW()
+         WHERE tenant_id = $1 AND status = 'active'`,
+        [tenantId]
+      );
+      console.info(`[stripe] Suspended Twilio number(s) for canceled tenant ${tenantId}`);
       break;
     }
 
     case "charge.dispute.created": {
       await updateBillingStatus(tenantId, "paused");
-      // TODO: alert admin channel
+      // Alert admin via pipeline alerts system
+      try {
+        const { raiseAlert } = await import("../../services/pipeline-alerts");
+        await raiseAlert({
+          tenantId,
+          traceId: null,
+          severity: "critical",
+          alertType: "pipeline_failed",
+          summary: `Chargeback/dispute filed — tenant paused`,
+          details: `Stripe event: charge.dispute.created. Tenant ${tenantId} billing set to paused. Requires admin review.`,
+        });
+      } catch {
+        // Non-fatal: billing state change already applied
+      }
       break;
     }
 

--- a/apps/api/src/routes/webhooks/twilio-sms.ts
+++ b/apps/api/src/routes/webhooks/twilio-sms.ts
@@ -82,7 +82,7 @@ export async function twilioSmsRoute(app: FastifyInstance) {
       if (blockReason) {
         request.log.info(
           { tenantId: tenant.id, blockReason },
-          "Tenant blocked — queuing block-response job"
+          "Tenant blocked — sending auto-reply"
         );
         if (traceId) {
           try {
@@ -92,9 +92,10 @@ export async function twilioSmsRoute(app: FastifyInstance) {
             await t.fail(`Tenant blocked: ${blockReason}`);
           } catch { /* non-fatal */ }
         }
-        // TODO: enqueue a job to send a "service unavailable" SMS reply
-        // This keeps the response fast and moves SMS sending to worker
-        return reply.status(200).type("text/xml").send("<Response/>");
+        // Send polite auto-reply via TwiML so the customer isn't left hanging
+        const autoReply = getBlockedAutoReply(blockReason, tenant.shop_name);
+        const twiml = `<Response><Message>${escapeXml(autoReply)}</Message></Response>`;
+        return reply.status(200).type("text/xml").send(twiml);
       }
 
       // ── 4. Check if active plan is at soft limit (paid, 100% used) ─────────
@@ -153,4 +154,57 @@ export async function twilioSmsRoute(app: FastifyInstance) {
       return reply.status(200).type("text/xml").send("<Response/>");
     }
   );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a polite auto-reply message for blocked tenants.
+ * The customer should never get silence — that damages the shop's reputation.
+ */
+export function getBlockedAutoReply(
+  blockReason: string,
+  shopName: string | null
+): string {
+  const name = shopName ?? "this business";
+
+  switch (blockReason) {
+    case "trial_expired":
+    case "trial_limit_reached":
+      return (
+        `Thank you for reaching out! ${name}'s automated messaging ` +
+        `service is temporarily unavailable. Please call them directly ` +
+        `for assistance.`
+      );
+    case "service_canceled":
+      return (
+        `Thank you for your message. ${name}'s automated messaging ` +
+        `is no longer active. Please call them directly.`
+      );
+    case "payment_failed":
+      return (
+        `Thank you for reaching out! ${name}'s messaging service is ` +
+        `temporarily unavailable. Please call them directly for assistance.`
+      );
+    case "service_paused":
+      return (
+        `Thank you for your message. ${name}'s messaging service is ` +
+        `temporarily paused. Please call them directly.`
+      );
+    default:
+      return (
+        `Thank you for reaching out! ${name} is currently unavailable ` +
+        `via text. Please call them directly for assistance.`
+      );
+  }
+}
+
+/** Escape special XML characters for TwiML body. */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
 }

--- a/apps/api/src/tests/sms-inbound.test.ts
+++ b/apps/api/src/tests/sms-inbound.test.ts
@@ -46,7 +46,7 @@ vi.mock("../services/pipeline-trace", () => ({
   }),
 }));
 
-import { twilioSmsRoute } from "../routes/webhooks/twilio-sms";
+import { twilioSmsRoute, getBlockedAutoReply } from "../routes/webhooks/twilio-sms";
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -215,7 +215,7 @@ describe("POST /webhooks/twilio/sms", () => {
     await app.close();
   });
 
-  it("returns 200 without enqueueing when tenant is blocked", async () => {
+  it("returns 200 with auto-reply TwiML when tenant is blocked", async () => {
     mocks.getBlockReason.mockReturnValueOnce("trial_limit_reached");
 
     const app = await buildApp();
@@ -227,7 +227,27 @@ describe("POST /webhooks/twilio/sms", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toContain("<Response");
+    expect(res.body).toContain("<Message>");
+    expect(res.body).toContain("Test Shop");
+    expect(res.body).toContain("temporarily unavailable");
+    expect(mocks.add).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("returns canceled auto-reply for canceled tenant", async () => {
+    mocks.getBlockReason.mockReturnValueOnce("service_canceled");
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/twilio/sms",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: smsPayload(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("<Message>");
+    expect(res.body).toContain("no longer active");
     expect(mocks.add).not.toHaveBeenCalled();
     await app.close();
   });
@@ -304,5 +324,44 @@ describe("POST /webhooks/twilio/sms", () => {
       expect.anything()
     );
     await app.close();
+  });
+});
+
+describe("getBlockedAutoReply", () => {
+  it("returns trial message for trial_expired", () => {
+    const msg = getBlockedAutoReply("trial_expired", "Bob's Auto");
+    expect(msg).toContain("Bob's Auto");
+    expect(msg).toContain("temporarily unavailable");
+    expect(msg).toContain("call them directly");
+  });
+
+  it("returns trial message for trial_limit_reached", () => {
+    const msg = getBlockedAutoReply("trial_limit_reached", "Bob's Auto");
+    expect(msg).toContain("temporarily unavailable");
+  });
+
+  it("returns canceled message for service_canceled", () => {
+    const msg = getBlockedAutoReply("service_canceled", "Bob's Auto");
+    expect(msg).toContain("no longer active");
+  });
+
+  it("returns payment message for payment_failed", () => {
+    const msg = getBlockedAutoReply("payment_failed", "Bob's Auto");
+    expect(msg).toContain("temporarily unavailable");
+  });
+
+  it("returns paused message for service_paused", () => {
+    const msg = getBlockedAutoReply("service_paused", "Bob's Auto");
+    expect(msg).toContain("temporarily paused");
+  });
+
+  it("uses fallback name when shopName is null", () => {
+    const msg = getBlockedAutoReply("trial_expired", null);
+    expect(msg).toContain("this business");
+  });
+
+  it("returns generic fallback for unknown block reason", () => {
+    const msg = getBlockedAutoReply("some_future_reason", "Bob's Auto");
+    expect(msg).toContain("currently unavailable");
   });
 });

--- a/apps/api/src/tests/stripe-webhook.test.ts
+++ b/apps/api/src/tests/stripe-webhook.test.ts
@@ -30,6 +30,11 @@ vi.mock("../db/tenants", () => ({
   updateBillingStatus: mocks.updateBillingStatus,
 }));
 
+const mockRaiseAlert = vi.fn().mockResolvedValue("alert-id");
+vi.mock("../services/pipeline-alerts", () => ({
+  raiseAlert: (...args: unknown[]) => mockRaiseAlert(...args),
+}));
+
 // Mock Stripe constructor so constructEvent is controllable
 vi.mock("stripe", () => {
   return {
@@ -376,7 +381,7 @@ describe("POST /webhooks/stripe", () => {
 
   // ── Event: customer.subscription.deleted ──────────────────────────────────
 
-  it("sets canceled on subscription.deleted", async () => {
+  it("sets canceled on subscription.deleted and suspends phone number", async () => {
     const sub = subscriptionObject();
     const evt = makeEvent("customer.subscription.deleted", sub);
     mocks.constructEvent.mockReturnValue(evt);
@@ -385,12 +390,18 @@ describe("POST /webhooks/stripe", () => {
     await postStripe(app);
 
     expect(mocks.updateBillingStatus).toHaveBeenCalledWith(TEST_TENANT_ID, "canceled");
+    // Should suspend tenant phone numbers
+    const suspendCalls = mocks.query.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("tenant_phone_numbers") && (c[0] as string).includes("suspended")
+    );
+    expect(suspendCalls).toHaveLength(1);
+    expect(suspendCalls[0][1]).toEqual([TEST_TENANT_ID]);
     await app.close();
   });
 
   // ── Event: charge.dispute.created ─────────────────────────────────────────
 
-  it("pauses tenant on charge.dispute.created", async () => {
+  it("pauses tenant on charge.dispute.created and raises admin alert", async () => {
     const obj = { id: "dp_test_001", metadata: { tenant_id: TEST_TENANT_ID } };
     const evt = makeEvent("charge.dispute.created", obj);
     mocks.constructEvent.mockReturnValue(evt);
@@ -399,6 +410,13 @@ describe("POST /webhooks/stripe", () => {
     await postStripe(app);
 
     expect(mocks.updateBillingStatus).toHaveBeenCalledWith(TEST_TENANT_ID, "paused");
+    expect(mockRaiseAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        severity: "critical",
+        summary: expect.stringContaining("Chargeback"),
+      })
+    );
     await app.close();
   });
 

--- a/project-brain/project_status.md
+++ b/project-brain/project_status.md
@@ -57,10 +57,11 @@ Phase: Production-verified, awaiting human demo run.
 - Call +13257523890 and let it ring to test missed-call trigger
 
 ### AI Next
-- Remaining Stage 6 hardening (Stripe billing live-test)
+- Stage 6 billing code complete — Stripe live-test requires real credentials (human)
 
 ## Done (Recent)
 
+- Billing hardening: blocked tenant auto-reply, Twilio suspension on cancel, chargeback admin alert (ai/billing-hardening)
 - Pipeline failure alerting: alerts table, owner SMS notification, admin endpoints, dead-letter capture (ai/pipeline-alerts)
 - Tenant health monitoring: per-tenant conversation, booking, pipeline, calendar metrics with Health tab in admin (ai/tenant-health-monitoring)
 - Pilot tenant readiness check: per-tenant live-path checklist with ready/not_ready verdict, 9 checks, admin UI tab (PR #120)
@@ -87,6 +88,7 @@ Phase: Production-verified, awaiting human demo run.
 
 | Date | Change | Branch/PR |
 |------|--------|-----------|
+| 2026-03-18 | Billing hardening: blocked tenant auto-reply, Twilio suspension on cancel, chargeback alert | ai/billing-hardening |
 | 2026-03-18 | Pipeline failure alerting: alerts table, owner SMS, admin endpoints, dead-letter capture | ai/pipeline-alerts |
 | 2026-03-16 | Tenant health monitoring: per-tenant conversation, booking, pipeline, calendar metrics + admin tab | ai/tenant-health-monitoring |
 | 2026-03-15 | Pilot tenant readiness check: per-tenant live-path checklist with verdict | PR #120 |

--- a/project-brain/project_status_v2.json
+++ b/project-brain/project_status_v2.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "version": 2,
-    "last_updated": "2026-03-18T21:00:00Z",
+    "last_updated": "2026-03-18T21:10:00Z",
     "updated_by": "claude",
     "repo_branch": "main"
   },
@@ -318,9 +318,15 @@
           "title": "Pipeline failure alerting (alerts table, owner SMS notification, admin endpoints, dead-letter capture)",
           "status": "done",
           "owner": "ai"
+        },
+        {
+          "id": "billing_hardening",
+          "title": "Billing hardening: blocked tenant auto-reply, Twilio suspension on cancel, chargeback admin alert",
+          "status": "done",
+          "owner": "ai"
         }
       ],
-      "next_task": "Remaining: Stripe billing live-test",
+      "next_task": "Stripe billing live-test requires real Stripe credentials (human)",
       "last_change": "2026-03-18"
     },
     {
@@ -382,6 +388,13 @@
     }
   ],
   "recent_movements": [
+    {
+      "date": "2026-03-18",
+      "type": "task_done",
+      "title": "Billing hardening: blocked tenant auto-reply, Twilio suspension on cancel, chargeback admin alert",
+      "impact": "Customers texting blocked shops get polite auto-reply instead of silence. Canceled tenants' phone numbers suspended. Chargebacks raise admin alerts.",
+      "branch": "ai/billing-hardening"
+    },
     {
       "date": "2026-03-18",
       "type": "task_done",


### PR DESCRIPTION
## Summary
- **Blocked tenant auto-reply**: customers texting a blocked shop get a polite TwiML response instead of silence, tailored per block reason (trial expired, canceled, payment failed, paused)
- **Twilio number suspension**: `subscription.deleted` webhook suspends phone numbers (reversible — not released from Twilio)
- **Chargeback admin alert**: `charge.dispute.created` raises a critical pipeline alert for admin review

## Why this is BUILD work
All three gaps are in the live pipeline path. Without auto-reply, customers texting blocked shops get zero response — damaging shop reputation. Without suspension, canceled tenants waste Twilio resources. Without chargeback alerts, admins don't know action is needed.

## Test plan
- [x] 8 new tests: auto-reply variants (7 block reasons), phone suspension, chargeback alert
- [x] 425/425 tests passing (28 test files)
- [x] TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)