### PR TITLE
fix: close three live-path routing gaps in billing enforcement

### DIFF
--- a/apps/api/src/db/tenants.ts
+++ b/apps/api/src/db/tenants.ts
@@ -25,6 +25,12 @@ export interface Tenant {
 /**
  * Look up tenant by their Twilio inbound phone number.
  * Used in webhook handler — no tenant context needed (lookup only).
+ *
+ * Matches both 'active' and 'suspended' numbers so that:
+ *   - Active tenants proceed to normal AI pipeline
+ *   - Canceled/blocked tenants (with suspended numbers) still reach the
+ *     billing enforcement check, which sends a polite auto-reply instead
+ *     of silently dropping the customer's message
  */
 export async function getTenantByPhoneNumber(
   phoneNumber: string
@@ -34,7 +40,7 @@ export async function getTenantByPhoneNumber(
      FROM tenants t
      JOIN tenant_phone_numbers tpn ON tpn.tenant_id = t.id
      WHERE tpn.phone_number = $1
-       AND tpn.status = 'active'
+       AND tpn.status IN ('active', 'suspended')
      LIMIT 1`,
     [phoneNumber]
   );

--- a/apps/api/src/routes/webhooks/twilio-voice-status.ts
+++ b/apps/api/src/routes/webhooks/twilio-voice-status.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { validateTwilioSignature } from "../../middleware/twilio-validate";
-import { getTenantByPhoneNumber } from "../../db/tenants";
+import { getTenantByPhoneNumber, getBlockReason } from "../../db/tenants";
 import { smsInboundQueue, checkIdempotency, markIdempotency } from "../../queues/redis";
 import { startTrace, resumeTrace } from "../../services/pipeline-trace";
 
@@ -83,6 +83,24 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
           await t.setTenant(tenant.id);
           await t.step("tenant_resolved", "ok", `${tenant.shop_name ?? "unknown"} (${tenant.id.slice(0, 8)})`);
         } catch { /* non-fatal */ }
+      }
+
+      // ── Billing enforcement ────────────────────────────────────────────
+      // Don't send missed-call SMS for blocked tenants (canceled, paused, etc.)
+      const blockReason = getBlockReason(tenant);
+      if (blockReason) {
+        request.log.info(
+          { tenantId: tenant.id, blockReason },
+          "Tenant blocked — skipping missed-call SMS"
+        );
+        if (traceId) {
+          try {
+            const t = await resumeTrace(traceId);
+            await t.step("billing_check", "fail", `Blocked: ${blockReason}`);
+            await t.fail(`Tenant blocked: ${blockReason}`);
+          } catch { /* non-fatal */ }
+        }
+        return reply.status(200).type("text/xml").send("<Response/>");
       }
 
       // Enqueue missed-call SMS trigger

--- a/apps/api/src/services/missed-call-sms.ts
+++ b/apps/api/src/services/missed-call-sms.ts
@@ -155,7 +155,8 @@ export async function handleMissedCallSms(
   }
 
   // 2. Check billing — don't send SMS if tenant is blocked
-  if (billingStatus === "blocked") {
+  const BLOCKED_STATUSES = ["canceled", "paused", "past_due_blocked", "trial_expired"];
+  if (BLOCKED_STATUSES.includes(billingStatus)) {
     return {
       success: false,
       conversationId: null,

--- a/apps/api/src/tests/missed-call-sms.test.ts
+++ b/apps/api/src/tests/missed-call-sms.test.ts
@@ -183,9 +183,18 @@ describe("handleMissedCallSms", () => {
     expect(result.error).toBe("Tenant not found");
   });
 
-  it("returns error when tenant billing is blocked", async () => {
+  it("returns error when tenant billing is canceled", async () => {
     mocks.query.mockResolvedValueOnce([
-      { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "blocked" },
+      { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "canceled" },
+    ]);
+    const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Tenant billing is blocked");
+  });
+
+  it("returns error when tenant billing is past_due_blocked", async () => {
+    mocks.query.mockResolvedValueOnce([
+      { id: TENANT_ID, shop_name: "Joe's Auto", billing_status: "past_due_blocked" },
     ]);
     const result = await handleMissedCallSms(validInput(), mockFetchSuccess());
     expect(result.success).toBe(false);
@@ -379,7 +388,7 @@ describe("POST /internal/missed-call-sms — route", () => {
 
   it("returns 402 when tenant billing is blocked", async () => {
     mocks.query.mockResolvedValueOnce([
-      { id: TENANT_ID, shop_name: "Test Shop", billing_status: "blocked" },
+      { id: TENANT_ID, shop_name: "Test Shop", billing_status: "canceled" },
     ]);
 
     const app = await buildApp();

--- a/apps/api/src/tests/tenants.test.ts
+++ b/apps/api/src/tests/tenants.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
 
+const mockQuery = vi.fn().mockResolvedValue([]);
+
 // db/client throws at module level when DATABASE_URL is missing.
 // getBlockReason is a pure function; no real DB connection needed.
 vi.mock("../db/client", () => ({
   db: { end: vi.fn() },
-  query: vi.fn(),
+  query: (...args: unknown[]) => mockQuery(...args),
   withTenant: vi.fn(),
 }));
 
-import { getBlockReason } from "../db/tenants";
+import { getBlockReason, getTenantByPhoneNumber } from "../db/tenants";
 import type { Tenant, BillingStatus } from "../db/tenants";
 
 function makeTenant(overrides: Partial<Tenant> = {}): Tenant {
@@ -83,5 +85,31 @@ describe("getBlockReason", () => {
     });
     // Paid plans: soft block only (AI sends upgrade message, no hard block)
     expect(getBlockReason(tenant)).toBeNull();
+  });
+});
+
+describe("getTenantByPhoneNumber", () => {
+  it("queries for both active and suspended phone numbers", async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    await getTenantByPhoneNumber("+15551234567");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("'active'");
+    expect(sql).toContain("'suspended'");
+    expect(mockQuery.mock.calls[0][1]).toEqual(["+15551234567"]);
+  });
+
+  it("returns tenant when found", async () => {
+    const tenant = makeTenant();
+    mockQuery.mockResolvedValueOnce([tenant]);
+    const result = await getTenantByPhoneNumber("+15551234567");
+    expect(result).toEqual(tenant);
+  });
+
+  it("returns null when no matching number", async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    const result = await getTenantByPhoneNumber("+15559999999");
+    expect(result).toBeNull();
   });
 });

--- a/apps/api/src/tests/voice-status.test.ts
+++ b/apps/api/src/tests/voice-status.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   checkIdempotency: vi.fn().mockResolvedValue(false),
   markIdempotency: vi.fn().mockResolvedValue(undefined),
   getTenantByPhoneNumber: vi.fn(),
+  getBlockReason: vi.fn((): string | null => null),
 }));
 
 vi.mock("../db/client", () => ({
@@ -24,7 +25,7 @@ vi.mock("../queues/redis", () => ({
 
 vi.mock("../db/tenants", () => ({
   getTenantByPhoneNumber: mocks.getTenantByPhoneNumber,
-  getBlockReason: vi.fn(() => null),
+  getBlockReason: mocks.getBlockReason,
 }));
 
 vi.mock("../services/pipeline-trace", () => ({
@@ -396,6 +397,39 @@ describe("POST /webhooks/twilio/voice-status", () => {
       expect.objectContaining({ callStatus: "busy" }),
       expect.anything()
     );
+    await app.close();
+  });
+
+  it("does not enqueue when tenant is blocked (canceled)", async () => {
+    mocks.getBlockReason.mockReturnValueOnce("service_canceled");
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/twilio/voice-status",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: voicePayload({ CallStatus: "no-answer" }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain("<Response");
+    expect(mocks.add).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("does not enqueue when tenant is blocked (trial_expired)", async () => {
+    mocks.getBlockReason.mockReturnValueOnce("trial_expired");
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/twilio/voice-status",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: voicePayload({ DialCallStatus: "no-answer" }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.add).not.toHaveBeenCalled();
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
Verification of PRs #174/#175 found three real runtime gaps in the live pipeline:

- **Suspended numbers = silent drop**: `getTenantByPhoneNumber` only matched `status='active'`, so canceled tenants bypassed auto-reply entirely. Now matches `IN ('active', 'suspended')`.
- **Voice-status webhook had NO billing check**: missed calls for blocked tenants triggered the full SMS pipeline. Now checks `getBlockReason` before enqueueing.
- **Missed-call-sms billing check was dead code**: compared against `"blocked"` which isn't a valid status. Now checks real blocked statuses.

## Why this matters
Without these fixes:
- Canceled tenant's customers get silence (no auto-reply)
- Blocked tenants waste Twilio resources on missed-call SMS sends
- The billing check in missed-call-sms never actually blocked anything

## Test plan
- [x] 6 new tests: suspended number routing, voice-status billing block, service billing check with real statuses
- [x] 431/431 tests passing (28 test files)
- [x] TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)