### PR TITLE
fix: replace placeholder Google config in LT Proteros SMS workflows

### DIFF
--- a/n8n/workflows/LT_Proteros/lt-missed-call-to-sms.json
+++ b/n8n/workflows/LT_Proteros/lt-missed-call-to-sms.json
@@ -101,7 +101,7 @@
         "operation": "append",
         "documentId": {
           "__rl": true,
-          "value": "GOOGLE_SHEET_ID_PLACEHOLDER",
+          "value": "1ypxUbbPkd4l-96K8vMQgwMHv4ek6Q4p1ScbXOrd15rI",
           "mode": "id"
         },
         "sheetName": {
@@ -136,11 +136,11 @@
       "position": [1500, 200],
       "credentials": {
         "googleSheetsOAuth2Api": {
-          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "id": "APKOpIYNrXjjc3U7",
           "name": "Google Sheets account"
         }
       },
-      "notes": "SETUP: 1) Create Google Sheet with columns: Call ID, Caller Phone, Timestamp, SMS Sent, Status. 2) Replace GOOGLE_SHEET_ID_PLACEHOLDER with the actual sheet ID. 3) Replace credential ID."
+      "notes": "Logs missed calls to Google Sheet: 1ypxUbbPkd4l-96K8vMQgwMHv4ek6Q4p1ScbXOrd15rI, tab 'Missed Calls'."
     },
     {
       "parameters": {
@@ -342,7 +342,7 @@
     "saveManualExecutions": true,
     "errorWorkflow": ""
   },
-  "active": false,
+  "active": true,
   "tags": [
     { "name": "LT_Proteros" },
     { "name": "missed-call" },

--- a/n8n/workflows/LT_Proteros/lt-sms-booking-agent.json
+++ b/n8n/workflows/LT_Proteros/lt-sms-booking-agent.json
@@ -133,7 +133,7 @@
         "operation": "append",
         "documentId": {
           "__rl": true,
-          "value": "GOOGLE_SHEET_ID_PLACEHOLDER",
+          "value": "1ypxUbbPkd4l-96K8vMQgwMHv4ek6Q4p1ScbXOrd15rI",
           "mode": "id"
         },
         "sheetName": {
@@ -170,7 +170,7 @@
       "position": [2250, 500],
       "credentials": {
         "googleSheetsOAuth2Api": {
-          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "id": "APKOpIYNrXjjc3U7",
           "name": "Google Sheets account"
         }
       },
@@ -202,8 +202,9 @@
       "parameters": {
         "calendar": {
           "__rl": true,
-          "value": "PROTEROS_TEST_CALENDAR_ID",
-          "mode": "id"
+          "value": "mantas.gipiskis@gmail.com",
+          "mode": "list",
+          "cachedResultName": "mantas.gipiskis@gmail.com"
         },
         "start": "={{ $json.startDateTime }}",
         "end": "={{ $json.endDateTime }}",
@@ -220,18 +221,18 @@
       "retryOnFail": true,
       "credentials": {
         "googleCalendarOAuth2Api": {
-          "id": "GOOGLE_CALENDAR_CREDENTIAL_ID",
-          "name": "Google Calendar account"
+          "id": "hriZCE0YmnVPrXid",
+          "name": "Google Calendar account 4"
         }
       },
-      "notes": "SETUP: 1) Create calendar 'Proteros Test Registracijos'. 2) Replace PROTEROS_TEST_CALENDAR_ID with the actual calendar ID. 3) Replace credential ID."
+      "notes": "Google Calendar: mantas.gipiskis@gmail.com. Credential: Google Calendar account 4."
     },
     {
       "parameters": {
         "operation": "append",
         "documentId": {
           "__rl": true,
-          "value": "GOOGLE_SHEET_ID_PLACEHOLDER",
+          "value": "1ypxUbbPkd4l-96K8vMQgwMHv4ek6Q4p1ScbXOrd15rI",
           "mode": "id"
         },
         "sheetName": {
@@ -272,7 +273,7 @@
       "position": [2500, 200],
       "credentials": {
         "googleSheetsOAuth2Api": {
-          "id": "GOOGLE_SHEETS_CREDENTIAL_ID",
+          "id": "APKOpIYNrXjjc3U7",
           "name": "Google Sheets account"
         }
       },
@@ -522,7 +523,7 @@
     "saveManualExecutions": true,
     "errorWorkflow": ""
   },
-  "active": false,
+  "active": true,
   "tags": [
     { "name": "LT_Proteros" },
     { "name": "sms-booking" },


### PR DESCRIPTION
## Summary
- Replace all placeholder Google credential/resource IDs in LT Proteros SMS workflows with real values from the working voice-booking-agent
- Fix `active: false` → `active: true` on both SMS workflows so deploy doesn't deactivate them
- Zero logic changes — config-only corrections

## Exact placeholders replaced

| Placeholder | Real Value | Nodes Affected |
|-------------|-----------|----------------|
| `GOOGLE_SHEETS_CREDENTIAL_ID` | `APKOpIYNrXjjc3U7` | 3 (SMS Conversation log, Booking log, Missed Call log) |
| `GOOGLE_CALENDAR_CREDENTIAL_ID` | `hriZCE0YmnVPrXid` | 1 (Create Google Calendar Event) |
| `GOOGLE_SHEET_ID_PLACEHOLDER` | `1ypxUbbPkd4l-96K8vMQgwMHv4ek6Q4p1ScbXOrd15rI` | 3 (same sheet nodes) |
| `PROTEROS_TEST_CALENDAR_ID` | `mantas.gipiskis@gmail.com` | 1 (Calendar event node) |
| `active: false` | `active: true` | 2 workflow roots |

## Files changed
- `n8n/workflows/LT_Proteros/lt-sms-booking-agent.json`
- `n8n/workflows/LT_Proteros/lt-missed-call-to-sms.json`

## Test plan
- [ ] Verify deploy pipeline picks up the real credential IDs
- [ ] Confirm SMS Booking Agent can write to Google Calendar after deploy
- [ ] Confirm SMS Conversation logging writes to the Proteros sheet
- [ ] Verify no USA workflow files were touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)