### PR TITLE
fix: fail-closed booking hardening — eliminate 6 fail-open gaps

### DIFF
--- a/apps/api/src/services/appointments.ts
+++ b/apps/api/src/services/appointments.ts
@@ -23,6 +23,8 @@ export interface CreateAppointmentInput {
   customerPhone: string;
   customerName?: string | null;
   serviceType?: string | null;
+  carModel?: string | null;
+  licensePlate?: string | null;
   scheduledAt: string; // ISO 8601
   durationMinutes?: number;
   notes?: string | null;
@@ -90,14 +92,15 @@ export async function createAppointment(
   }
 
   // 2. Validate required booking fields against tenant AI policy
+  // FAIL-CLOSED: if policy lookup fails, block booking — never allow unvalidated inserts
   try {
     const policy = await getTenantAiPolicy(input.tenantId);
     const collected: ConversationCollectedData = {
       customerName: input.customerName,
-      carModel: input.serviceType,
+      carModel: input.carModel ?? null,
       issueDescription: input.serviceType,
       preferredTime: input.scheduledAt,
-      licensePlate: null,
+      licensePlate: input.licensePlate ?? null,
       phoneConfirmation: null,
     };
     const missing = getMissingRequiredFields(policy, collected);
@@ -110,8 +113,13 @@ export async function createAppointment(
         error: `Missing required booking fields: ${labels.join(", ")}`,
       };
     }
-  } catch {
-    // Non-fatal: if policy lookup fails, allow booking (fail-open for safety)
+  } catch (err) {
+    return {
+      success: false,
+      appointment: null,
+      upserted: false,
+      error: `Policy validation failed — booking blocked for safety: ${(err as Error).message}`,
+    };
   }
 
   // 3. Insert or upsert appointment

--- a/apps/api/src/services/booking-intent.ts
+++ b/apps/api/src/services/booking-intent.ts
@@ -12,6 +12,8 @@ export interface BookingIntentResult {
   scheduledAt: string;
   scheduledAtExtracted: boolean;
   customerName: string | null;
+  carModel: string | null;
+  licensePlate: string | null;
   userWantsClose: boolean;
   matchedPatterns: string[];
 }
@@ -132,6 +134,80 @@ const NAME_AFTER_HI =
 // Match customer saying "my name is John" or "I'm John Smith" or "this is John"
 const NAME_SELF_INTRO =
   /(?:my name is|i'm|i am|this is|call me)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i;
+
+// ── Car make/model extraction ────────────────────────────────────────────────
+
+const CAR_MAKES = [
+  "acura", "alfa romeo", "audi", "bmw", "buick", "cadillac", "chevrolet", "chevy",
+  "chrysler", "dodge", "fiat", "ford", "gmc", "honda", "hyundai", "infiniti",
+  "jaguar", "jeep", "kia", "land rover", "lexus", "lincoln", "mazda",
+  "mercedes", "mercedes-benz", "mini", "mitsubishi", "nissan", "pontiac",
+  "porsche", "ram", "saturn", "scion", "subaru", "suzuki", "tesla", "toyota",
+  "volkswagen", "vw", "volvo",
+];
+
+// Match patterns like "2019 Honda Civic", "Honda Civic", "my Civic", "'19 Accord"
+// Searches both customer message and AI response
+function extractCarModel(customerMessage: string, aiResponse: string): string | null {
+  const combined = customerMessage + " " + aiResponse;
+
+  // Check against known makes (case-insensitive)
+  const lower = combined.toLowerCase();
+  for (const make of CAR_MAKES) {
+    const idx = lower.indexOf(make);
+    if (idx === -1) continue;
+
+    // Extract from the original text starting a bit before the make
+    const start = Math.max(0, idx - 6);
+    const snippet = combined.substring(start, idx + make.length + 30);
+
+    // Try "year make model" — e.g., "2019 Honda Civic"
+    const full = snippet.match(
+      /(?:(?:19|20)\d{2}|'\d{2})\s+\w+(?:\s+\w+)?/i
+    );
+    if (full) return full[0].trim();
+
+    // Try "make model" — e.g., "Honda Civic" (grab next word after make)
+    const makeModel = snippet.match(
+      new RegExp(`(${make})\\s+([a-z]\\w+)`, "i")
+    );
+    if (makeModel) return makeModel[0].trim();
+
+    // Just the make alone
+    return combined.substring(idx, idx + make.length).trim();
+  }
+
+  return null;
+}
+
+// ── License plate extraction ────────────────────────────────────────────────
+
+// Common US plate formats: ABC 1234, ABC-1234, ABC1234, 123 ABC, 123-ABC
+const PLATE_PATTERNS = [
+  /\b([A-Z]{2,3}[\s-]?\d{3,4})\b/,       // ABC 1234, AB-123
+  /\b(\d{3,4}[\s-]?[A-Z]{2,3})\b/,       // 1234 ABC
+  /\b([A-Z]{1,3}\d{1,2}[\s-]?[A-Z]{1,3})\b/, // vanity-style
+];
+
+function extractLicensePlate(customerMessage: string, aiResponse: string): string | null {
+  const combined = customerMessage + " " + aiResponse;
+  // Only look for plates if contextual keywords are nearby
+  const lower = combined.toLowerCase();
+  if (
+    !lower.includes("plate") &&
+    !lower.includes("tag") &&
+    !lower.includes("license") &&
+    !lower.includes("registration")
+  ) {
+    return null;
+  }
+
+  for (const regex of PLATE_PATTERNS) {
+    const match = combined.match(regex);
+    if (match) return match[1].trim();
+  }
+  return null;
+}
 
 // ── Natural date parsing ────────────────────────────────────────────────────
 
@@ -308,6 +384,10 @@ export function detectBookingIntent(
     }
   }
 
+  // Extract car model and license plate
+  const carModel = extractCarModel(customerMessage, aiResponse);
+  const licensePlate = extractLicensePlate(customerMessage, aiResponse);
+
   return {
     isBooked,
     confidence,
@@ -315,6 +395,8 @@ export function detectBookingIntent(
     scheduledAt,
     scheduledAtExtracted,
     customerName,
+    carModel,
+    licensePlate,
     userWantsClose,
     matchedPatterns,
   };

--- a/apps/api/src/services/missed-call-sms.ts
+++ b/apps/api/src/services/missed-call-sms.ts
@@ -16,7 +16,7 @@
 
 import { query } from "../db/client";
 import { getConfig } from "../db/app-config";
-import { getTenantAiPolicy } from "./ai-settings";
+import { getTenantAiPolicy, buildRuntimePolicy, AI_SETTINGS_DEFAULTS } from "./ai-settings";
 
 export interface MissedCallInput {
   tenantId: string;
@@ -168,14 +168,15 @@ export async function handleMissedCallSms(
   }
 
   // 2b. Check AI settings — if missed-call SMS is disabled, skip
+  // FAIL-CLOSED: always resolve to a policy (defaults on failure)
   let aiPolicy;
   try {
     aiPolicy = await getTenantAiPolicy(input.tenantId);
   } catch {
-    // Non-fatal: proceed with default behavior (SMS enabled)
+    aiPolicy = buildRuntimePolicy(AI_SETTINGS_DEFAULTS);
   }
 
-  if (aiPolicy && !aiPolicy.missedCallSmsEnabled) {
+  if (!aiPolicy.missedCallSmsEnabled) {
     return {
       success: true,
       conversationId: null,

--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -19,6 +19,8 @@ import { sendTwilioSms } from "./missed-call-sms";
 import {
   getTenantAiPolicy,
   buildPromptPolicySection,
+  buildRuntimePolicy,
+  AI_SETTINGS_DEFAULTS,
   getMissingRequiredFields,
   getMissingFieldLabels,
   type AiRuntimePolicy,
@@ -175,11 +177,12 @@ export async function processSms(
   }
 
   // ── 5. Fetch AI runtime policy + system prompt + tenant context ─────────
-  let aiPolicy: AiRuntimePolicy | null = null;
+  // FAIL-CLOSED: aiPolicy must NEVER be null — use defaults on any failure
+  let aiPolicy: AiRuntimePolicy;
   try {
     aiPolicy = await getTenantAiPolicy(input.tenantId);
   } catch {
-    // Non-fatal: will use default prompt without policy injection
+    aiPolicy = buildRuntimePolicy(AI_SETTINGS_DEFAULTS);
   }
 
   let systemPrompt = DEFAULT_SYSTEM_PROMPT;
@@ -197,11 +200,9 @@ export async function processSms(
     // Use default prompt if lookup fails
   }
 
-  // Inject AI policy rules into the system prompt
-  if (aiPolicy) {
-    const policySection = buildPromptPolicySection(aiPolicy);
-    systemPrompt += "\n\n--- BOOKING RULES ---\n" + policySection;
-  }
+  // Inject AI policy rules into the system prompt (always — aiPolicy is never null)
+  const policySection = buildPromptPolicySection(aiPolicy);
+  systemPrompt += "\n\n--- BOOKING RULES ---\n" + policySection;
 
   // Inject tenant shop context (business_hours, services_description) into prompt
   // Also fetch owner_phone for calendar-sync failure alerts
@@ -226,7 +227,7 @@ export async function processSms(
       if (t.business_hours) contextParts.push(`Business hours: ${t.business_hours}`);
       if (t.services_description) contextParts.push(`Services offered: ${t.services_description}`);
       // Inject services from AI settings if tenant-level is empty
-      if (!t.services_description && aiPolicy?.services) {
+      if (!t.services_description && aiPolicy.services) {
         contextParts.push(`Services offered: ${aiPolicy.services}`);
       }
       if (contextParts.length > 0) {
@@ -302,43 +303,46 @@ export async function processSms(
 
   if (intent.isBooked) {
     // ── Validate required fields before allowing booking ──────────────────
-    if (aiPolicy) {
-      const collected: ConversationCollectedData = {
-        customerName: intent.customerName,
-        carModel: intent.serviceType, // serviceType often contains car model info
-        issueDescription: intent.serviceType,
-        preferredTime: intent.scheduledAt,
-        // licensePlate and phoneConfirmation not extracted by current intent detector
-        licensePlate: null,
-        phoneConfirmation: null,
-      };
-      const missing = getMissingRequiredFields(aiPolicy, collected);
-      if (missing.length > 0) {
-        // Required fields missing — do NOT create booking.
-        // The AI response already went out; on next turn the policy prompt
-        // will guide the AI to ask for missing fields.
-        // Skip booking creation entirely for this turn.
-        result.success = true;
-        result.aiResponse = smsBody;
+    // FAIL-CLOSED: aiPolicy is always set (defaults on failure).
+    // Field mapping is strict — do NOT use weak proxies (e.g. serviceType as carModel).
+    const collected: ConversationCollectedData = {
+      customerName: intent.customerName,
+      carModel: intent.carModel ?? null,
+      issueDescription: intent.serviceType, // serviceType = "oil change" etc. is a valid issue description
+      preferredTime: intent.scheduledAt,
+      // licensePlate and phoneConfirmation: only set if explicitly extracted
+      licensePlate: intent.licensePlate ?? null,
+      phoneConfirmation: null,
+    };
+    const missing = getMissingRequiredFields(aiPolicy, collected);
+    if (missing.length > 0) {
+      // Required fields missing — do NOT create booking.
+      // TRUTHFULNESS: Do NOT send AI's false confirmation to the customer.
+      // Replace with a safe message listing what's still needed.
+      const missingLabels = getMissingFieldLabels(missing);
+      const safeBody =
+        `Almost there! I still need: ${missingLabels.join(", ")}. ` +
+        `Please provide so I can finalize your booking.`;
+      result.success = true;
+      result.aiResponse = safeBody;
 
-        // Log outbound and send SMS as normal (AI response without booking)
-        try {
-          await query(
-            `INSERT INTO messages (tenant_id, conversation_id, direction, body, tokens_used, model_version)
-             VALUES ($1, $2, 'outbound', $3, $4, $5)`,
-            [input.tenantId, result.conversationId, smsBody, tokensUsed, OPENAI_MODEL]
-          );
-        } catch { /* Non-fatal */ }
+      // Log outbound and send corrected SMS (not the AI's false confirmation)
+      try {
+        await query(
+          `INSERT INTO messages (tenant_id, conversation_id, direction, body, tokens_used, model_version)
+           VALUES ($1, $2, 'outbound', $3, $4, $5)`,
+          [input.tenantId, result.conversationId, safeBody, tokensUsed, OPENAI_MODEL]
+        );
+      } catch { /* Non-fatal */ }
 
-        const smsResult = await sendTwilioSms(input.customerPhone, smsBody, fetchFn);
-        result.smsSent = !!smsResult.sid;
+      const smsResult = await sendTwilioSms(input.customerPhone, safeBody, fetchFn);
+      result.smsSent = !!smsResult.sid;
 
-        try {
-          await query(`SELECT touch_conversation($1, $2)`, [result.conversationId, input.tenantId]);
-        } catch { /* Non-fatal */ }
+      try {
+        await query(`SELECT touch_conversation($1, $2)`, [result.conversationId, input.tenantId]);
+      } catch { /* Non-fatal */ }
 
-        return result;
-      }
+      return result;
     }
 
     result.isBooked = true;
@@ -350,6 +354,8 @@ export async function processSms(
       customerPhone: input.customerPhone,
       customerName: intent.customerName,
       serviceType: intent.serviceType,
+      carModel: intent.carModel,
+      licensePlate: intent.licensePlate,
       scheduledAt: intent.scheduledAt,
       bookingState: "PENDING_MANUAL_CONFIRMATION",
     });

--- a/apps/api/src/tests/e2e-booking-enforcement.test.ts
+++ b/apps/api/src/tests/e2e-booking-enforcement.test.ts
@@ -1,0 +1,575 @@
+/**
+ * E2E Runtime Proof Tests: Booking Enforcement Scenarios A–G
+ *
+ * These tests verify the full runtime path from AI settings toggles
+ * through to booking creation/rejection and calendar sync behavior.
+ *
+ * Each scenario proves a specific enforcement behavior end-to-end
+ * using the real service functions (not mocks for the enforcement logic).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock DB layer only ─────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+vi.mock("../db/app-config", () => ({
+  getConfig: mocks.getConfig,
+}));
+
+vi.mock("../routes/auth/google", () => ({
+  decryptToken: vi.fn((t: string) => t),
+}));
+
+vi.mock("../services/google-token-refresh", () => ({
+  isTokenExpired: vi.fn(() => false),
+  refreshAccessToken: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../services/pipeline-trace", () => ({
+  resumeTrace: vi.fn().mockResolvedValue({
+    id: "trace-mock-id",
+    step: vi.fn().mockResolvedValue(undefined),
+    setTenant: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// ── Import REAL services (not mocked) ──────────────────────────────────────
+
+import {
+  mergeWithDefaults,
+  buildRuntimePolicy,
+  getMissingRequiredFields,
+  buildPromptPolicySection,
+  type AiRuntimePolicy,
+  type ConversationCollectedData,
+} from "../services/ai-settings";
+import { detectBookingIntent } from "../services/booking-intent";
+import { handleMissedCallSms } from "../services/missed-call-sms";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function policyWith(overrides: Record<string, unknown> = {}): AiRuntimePolicy {
+  const settings = mergeWithDefaults(overrides);
+  return buildRuntimePolicy(settings);
+}
+
+function defaultTenantRow(billingStatus = "active") {
+  return {
+    id: "t-001",
+    shop_name: "Test Shop",
+    billing_status: billingStatus,
+    missed_call_sms_template: null,
+  };
+}
+
+// ── SCENARIO A: License Plate OPTIONAL ──────────────────────────────────────
+
+describe("SCENARIO A — License Plate Optional", () => {
+  it("booking is allowed when licensePlate toggle is OFF and plate is absent", () => {
+    const policy = policyWith({
+      requiredFields: {
+        customerName: true,
+        carModel: true,
+        issueDescription: true,
+        preferredTime: true,
+        licensePlate: false, // OFF
+        phoneConfirmation: false,
+      },
+    });
+
+    const collected: ConversationCollectedData = {
+      customerName: "John Smith",
+      carModel: "Honda Civic",
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: null, // not provided
+      phoneConfirmation: null,
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toEqual([]);
+    // Booking proceeds — no block
+  });
+
+  it("licensePlate is not in requiredFields when toggle is OFF", () => {
+    const policy = policyWith({
+      requiredFields: { licensePlate: false },
+    });
+    expect(policy.requiredFields).not.toContain("licensePlate");
+    expect(policy.optionalFields).toContain("licensePlate");
+  });
+});
+
+// ── SCENARIO B: License Plate REQUIRED ──────────────────────────────────────
+
+describe("SCENARIO B — License Plate Required", () => {
+  it("booking is BLOCKED when licensePlate toggle is ON and plate is absent", () => {
+    const policy = policyWith({
+      requiredFields: {
+        customerName: true,
+        carModel: true,
+        issueDescription: true,
+        preferredTime: true,
+        licensePlate: true, // ON
+        phoneConfirmation: false,
+      },
+    });
+
+    const collected: ConversationCollectedData = {
+      customerName: "John Smith",
+      carModel: "Honda Civic",
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: null, // NOT provided
+      phoneConfirmation: null,
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toContain("licensePlate");
+    expect(missing.length).toBe(1);
+    // Booking MUST NOT proceed
+  });
+
+  it("licensePlate is in requiredFields when toggle is ON", () => {
+    const policy = policyWith({
+      requiredFields: { licensePlate: true },
+    });
+    expect(policy.requiredFields).toContain("licensePlate");
+    expect(policy.optionalFields).not.toContain("licensePlate");
+  });
+
+  it("empty string licensePlate is treated as missing", () => {
+    const policy = policyWith({
+      requiredFields: { licensePlate: true },
+    });
+    const collected: ConversationCollectedData = {
+      customerName: "John",
+      carModel: "Civic",
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: "   ", // whitespace only
+      phoneConfirmation: null,
+    };
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toContain("licensePlate");
+  });
+
+  it("license plate extraction from customer message works", () => {
+    const result = detectBookingIntent(
+      "Your appointment is confirmed for oil change.",
+      "my plate is ABC 1234"
+    );
+    expect(result.licensePlate).toBe("ABC 1234");
+  });
+});
+
+// ── SCENARIO C: Missed Call SMS DISABLED ─────────────────────────────────────
+
+describe("SCENARIO C — Missed Call SMS Disabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Tenant exists, active billing
+    mocks.query.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("billing_status")) {
+        return [defaultTenantRow()];
+      }
+      // AI settings: missedCallSms.enabled = false
+      if (sql.includes("ai_settings")) {
+        return [{ ai_settings: { missedCallSms: { enabled: false, preset: "1", template: "" } } }];
+      }
+      return [];
+    });
+  });
+
+  it("does NOT send SMS when missedCallSms.enabled = false", async () => {
+    const result = await handleMissedCallSms({
+      tenantId: "t-001",
+      customerPhone: "+15551234567",
+      ourPhone: "+15559876543",
+      callSid: "CA123",
+      callStatus: "no-answer",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.smsSent).toBe(false);
+    expect(result.conversationId).toBeNull();
+    // Verify no Twilio call was made (no getConfig call for Twilio creds)
+    const twilioConfigCalls = mocks.getConfig.mock.calls.filter(
+      (c: string[]) => c[0]?.includes("TWILIO")
+    );
+    expect(twilioConfigCalls.length).toBe(0);
+  });
+});
+
+// ── SCENARIO D: Missed Call SMS ENABLED ──────────────────────────────────────
+
+describe("SCENARIO D — Missed Call SMS Enabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.query.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("billing_status")) {
+        return [defaultTenantRow()];
+      }
+      if (sql.includes("ai_settings")) {
+        return [{
+          ai_settings: {
+            missedCallSms: { enabled: true, preset: "2", template: "" },
+          },
+        }];
+      }
+      if (sql.includes("get_or_create_conversation")) {
+        return [{ conversation_id: "conv-001", is_new: true }];
+      }
+      if (sql.includes("INSERT INTO messages")) return [];
+      if (sql.includes("touch_conversation")) return [];
+      return [];
+    });
+
+    mocks.getConfig.mockImplementation((key: string) => {
+      if (key === "TWILIO_ACCOUNT_SID") return "AC_test";
+      if (key === "TWILIO_AUTH_TOKEN") return "token_test";
+      if (key === "TWILIO_MESSAGING_SERVICE_SID") return "MG_test";
+      return null;
+    });
+  });
+
+  it("sends SMS with correct preset template when enabled", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sid: "SM_sent_123" }),
+    });
+
+    const result = await handleMissedCallSms(
+      {
+        tenantId: "t-001",
+        customerPhone: "+15551234567",
+        ourPhone: "+15559876543",
+        callSid: "CA123",
+        callStatus: "no-answer",
+      },
+      mockFetch as unknown as typeof fetch
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.smsSent).toBe(true);
+    expect(result.twilioSid).toBe("SM_sent_123");
+
+    // Verify the SMS body uses preset 2
+    const fetchCall = mockFetch.mock.calls[0];
+    const bodyStr = fetchCall[1].body as string;
+    expect(decodeURIComponent(bodyStr)).toContain("AutoShop here");
+  });
+});
+
+// ── SCENARIO E: Limited Slots Enforced ───────────────────────────────────────
+
+describe("SCENARIO E — Limited Slots Enforced", () => {
+  it("prompt policy includes limited slots instruction when enabled", () => {
+    const policy = policyWith({
+      bookingStrategy: { limitedSlots: true },
+    });
+    expect(policy.limitedSlots).toBe(true);
+
+    const promptSection = buildPromptPolicySection(policy);
+    expect(promptSection).toContain("maximum of 2-3 time slot options");
+  });
+
+  it("prompt policy does NOT include limited slots when disabled", () => {
+    const policy = policyWith({
+      bookingStrategy: { limitedSlots: false },
+    });
+    expect(policy.limitedSlots).toBe(false);
+
+    const promptSection = buildPromptPolicySection(policy);
+    expect(promptSection).not.toContain("maximum of 2-3 time slot options");
+  });
+});
+
+// ── SCENARIO F: Fail-Closed Booking Validation ──────────────────────────────
+
+describe("SCENARIO F — Fail-Closed Booking Validation", () => {
+  it("booking is blocked when ANY required field is missing", () => {
+    const policy = policyWith(); // default: name, car, issue, time required
+
+    // Missing carModel
+    const collected: ConversationCollectedData = {
+      customerName: "John",
+      carModel: null,
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: null,
+      phoneConfirmation: null,
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toContain("carModel");
+    expect(missing.length).toBeGreaterThan(0);
+  });
+
+  it("booking is blocked when carModel is only serviceType (weak proxy rejected)", () => {
+    // Previously, serviceType was mapped to carModel.
+    // Now carModel must be independently extracted.
+    const intent = detectBookingIntent(
+      "Your appointment is confirmed for an oil change tomorrow at 2pm.",
+      "I need an oil change"
+    );
+
+    // serviceType should be "oil change" but carModel should NOT be "oil change"
+    expect(intent.serviceType).toBe("oil change");
+    // carModel should be null since no car make/model was mentioned
+    expect(intent.carModel).toBeNull();
+  });
+
+  it("carModel is extracted when customer mentions a real car", () => {
+    const intent = detectBookingIntent(
+      "Your appointment is confirmed for oil change on your Honda Civic.",
+      "I need an oil change for my Honda Civic"
+    );
+
+    expect(intent.carModel).not.toBeNull();
+    expect(intent.carModel!.toLowerCase()).toContain("honda");
+  });
+
+  it("policy defaults are used (fail-closed) when policy fetch returns defaults", () => {
+    // buildRuntimePolicy with defaults should enforce name, car, issue, time
+    const policy = policyWith(); // uses AI_SETTINGS_DEFAULTS
+    expect(policy.requiredFields).toContain("customerName");
+    expect(policy.requiredFields).toContain("carModel");
+    expect(policy.requiredFields).toContain("issueDescription");
+    expect(policy.requiredFields).toContain("preferredTime");
+    expect(policy.requiredFields).not.toContain("licensePlate");
+    expect(policy.requiredFields).not.toContain("phoneConfirmation");
+  });
+
+  it("appointment creation validates required fields and rejects when missing", async () => {
+    // Setup: tenant exists
+    mocks.query.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM tenants")) {
+        return [{ id: "t-001" }];
+      }
+      // Return default AI settings (carModel required by default)
+      if (sql.includes("ai_settings")) {
+        return [{ ai_settings: null }]; // null -> defaults apply
+      }
+      return [];
+    });
+
+    const { createAppointment } = await import("../services/appointments");
+    const result = await createAppointment({
+      tenantId: "t-001",
+      customerPhone: "+15551234567",
+      customerName: "John",
+      serviceType: "oil change",
+      // carModel NOT provided (defaults to undefined)
+      scheduledAt: new Date().toISOString(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Missing required booking fields");
+  });
+
+  it("appointment creation BLOCKS on policy lookup failure (fail-closed via defaults)", async () => {
+    mocks.query.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM tenants")) {
+        return [{ id: "t-001" }];
+      }
+      // Simulate DB error on ai_settings lookup
+      // getTenantAiPolicy catches this internally and returns defaults
+      // Defaults require carModel — which is not provided here → fail-closed
+      if (sql.includes("ai_settings")) {
+        throw new Error("DB connection lost");
+      }
+      return [];
+    });
+
+    const { createAppointment } = await import("../services/appointments");
+    const result = await createAppointment({
+      tenantId: "t-001",
+      customerPhone: "+15551234567",
+      customerName: "John",
+      serviceType: "oil change",
+      // carModel NOT provided — defaults require it
+      scheduledAt: new Date().toISOString(),
+    });
+
+    // Must NOT succeed — fail-closed because defaults require carModel
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Missing required booking fields");
+  });
+});
+
+// ── SCENARIO G: Full Pass — All Required Fields Present ──────────────────────
+
+describe("SCENARIO G — Full Pass (All Required Fields Present)", () => {
+  it("booking proceeds when all required fields are provided", () => {
+    const policy = policyWith(); // default required: name, car, issue, time
+
+    const collected: ConversationCollectedData = {
+      customerName: "John Smith",
+      carModel: "2019 Honda Civic",
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: null, // not required by default
+      phoneConfirmation: null,
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toEqual([]);
+  });
+
+  it("booking proceeds with ALL fields including optional ones", () => {
+    const policy = policyWith({
+      requiredFields: {
+        customerName: true,
+        carModel: true,
+        issueDescription: true,
+        preferredTime: true,
+        licensePlate: true,
+        phoneConfirmation: true,
+      },
+    });
+
+    const collected: ConversationCollectedData = {
+      customerName: "John Smith",
+      carModel: "2019 Honda Civic",
+      issueDescription: "oil change",
+      preferredTime: "2026-03-20T10:00:00Z",
+      licensePlate: "ABC 1234",
+      phoneConfirmation: "+15551234567",
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toEqual([]);
+  });
+
+  it("intent detector extracts carModel when car make is mentioned", () => {
+    const intent = detectBookingIntent(
+      "Great! Your oil change appointment for your 2019 Toyota Camry is confirmed for tomorrow at 2pm.",
+      "I need an oil change for my 2019 Toyota Camry tomorrow at 2pm"
+    );
+
+    expect(intent.isBooked).toBe(true);
+    expect(intent.serviceType).toBe("oil change");
+    expect(intent.carModel).not.toBeNull();
+    expect(intent.carModel!.toLowerCase()).toContain("toyota");
+    expect(intent.customerName).toBeNull(); // no name mentioned
+  });
+
+  it("end-to-end: extracted intent fields satisfy default policy requirements", () => {
+    const intent = detectBookingIntent(
+      "Confirmed, John! Your oil change for your Honda Civic is set for tomorrow at 3pm.",
+      "My name is John, I need an oil change for my Honda Civic, tomorrow at 3pm works"
+    );
+
+    const policy = policyWith(); // defaults
+
+    const collected: ConversationCollectedData = {
+      customerName: intent.customerName,
+      carModel: intent.carModel,
+      issueDescription: intent.serviceType,
+      preferredTime: intent.scheduledAt,
+      licensePlate: intent.licensePlate,
+      phoneConfirmation: null,
+    };
+
+    const missing = getMissingRequiredFields(policy, collected);
+    expect(missing).toEqual([]);
+    // Full pass — booking would proceed
+  });
+});
+
+// ── CROSS-CUTTING: Field mapping truthfulness ───────────────────────────────
+
+describe("Field Mapping Truthfulness", () => {
+  it("carModel and issueDescription are DISTINCT in collected data", () => {
+    // carModel should NOT equal serviceType by default
+    const intent = detectBookingIntent(
+      "Your appointment is confirmed for oil change.",
+      "I need an oil change"
+    );
+    // serviceType is "oil change" — this should NOT satisfy carModel
+    expect(intent.serviceType).toBe("oil change");
+    expect(intent.carModel).not.toBe(intent.serviceType);
+  });
+
+  it("serviceType correctly maps to issueDescription", () => {
+    // serviceType "oil change" IS a valid issue description
+    const intent = detectBookingIntent(
+      "Appointment confirmed for brake service.",
+      "I need my brakes checked"
+    );
+    expect(intent.serviceType).toBe("brake service");
+    // This is a valid issueDescription — not a weak proxy
+  });
+
+  it("licensePlate is only extracted when contextually appropriate", () => {
+    // Random numbers should NOT be extracted as license plates
+    const intent = detectBookingIntent(
+      "Your appointment #1234 is confirmed.",
+      "I need an oil change at 1234 Main St"
+    );
+    expect(intent.licensePlate).toBeNull();
+  });
+
+  it("licensePlate IS extracted when plate context is present", () => {
+    const intent = detectBookingIntent(
+      "Your appointment is confirmed.",
+      "my license plate is ABC 1234"
+    );
+    expect(intent.licensePlate).toBe("ABC 1234");
+  });
+});
+
+// ── CROSS-CUTTING: Prompt policy injection ──────────────────────────────────
+
+describe("Prompt Policy Injection Truthfulness", () => {
+  it("required fields are listed in prompt when set", () => {
+    const policy = policyWith({
+      requiredFields: {
+        customerName: true,
+        carModel: true,
+        issueDescription: true,
+        preferredTime: true,
+        licensePlate: true,
+        phoneConfirmation: false,
+      },
+    });
+
+    const prompt = buildPromptPolicySection(policy);
+    expect(prompt).toContain("customer name");
+    expect(prompt).toContain("car make and model");
+    expect(prompt).toContain("description of the issue");
+    expect(prompt).toContain("preferred appointment time");
+    expect(prompt).toContain("license plate number");
+    // phoneConfirmation is false → listed in optional, not required
+    expect(prompt).not.toMatch(/MUST collect.*phone number confirmation/);
+  });
+
+  it("optional fields are listed separately", () => {
+    const policy = policyWith({
+      requiredFields: { licensePlate: false, phoneConfirmation: false },
+    });
+
+    const prompt = buildPromptPolicySection(policy);
+    expect(prompt).toContain("Optional info");
+    expect(prompt).toContain("license plate number");
+  });
+
+  it("booking rules always include no-hallucination guard", () => {
+    const policy = policyWith();
+    const prompt = buildPromptPolicySection(policy);
+    expect(prompt).toContain("Never invent or hallucinate");
+  });
+});

--- a/apps/api/src/tests/process-sms.test.ts
+++ b/apps/api/src/tests/process-sms.test.ts
@@ -33,8 +33,8 @@ vi.mock("../services/pipeline-trace", () => ({
   }),
 }));
 
-vi.mock("../services/ai-settings", () => ({
-  getTenantAiPolicy: vi.fn().mockResolvedValue({
+const aiSettingsMocks = vi.hoisted(() => {
+  const DEFAULT_POLICY = {
     requiredFields: ["customerName", "carModel", "issueDescription", "preferredTime"],
     optionalFields: ["licensePlate", "phoneConfirmation"],
     tone: "direct",
@@ -49,11 +49,19 @@ vi.mock("../services/ai-settings", () => ({
     restrictions: "",
     missedCallSmsEnabled: true,
     missedCallSmsTemplate: "",
-  }),
-  buildPromptPolicySection: vi.fn().mockReturnValue("--- BOOKING RULES ---\nBe direct and concise."),
-  getMissingRequiredFields: vi.fn().mockReturnValue([]),
-  getMissingFieldLabels: vi.fn().mockReturnValue([]),
-}));
+  };
+  return {
+    DEFAULT_POLICY,
+    getTenantAiPolicy: vi.fn().mockResolvedValue(DEFAULT_POLICY),
+    buildPromptPolicySection: vi.fn().mockReturnValue("--- BOOKING RULES ---\nBe direct and concise."),
+    buildRuntimePolicy: vi.fn().mockReturnValue(DEFAULT_POLICY),
+    AI_SETTINGS_DEFAULTS: {},
+    getMissingRequiredFields: vi.fn().mockReturnValue([]),
+    getMissingFieldLabels: vi.fn().mockReturnValue([]),
+  };
+});
+
+vi.mock("../services/ai-settings", () => aiSettingsMocks);
 
 import { processSms, ProcessSmsInput } from "../services/process-sms";
 import { processSmsRoute } from "../routes/internal/process-sms";


### PR DESCRIPTION
## Summary

- **6 fail-open gaps eliminated** in the booking enforcement runtime path
- **carModel and issueDescription are now distinct fields** — no more weak proxy mapping (serviceType ≠ carModel)
- **False booking confirmations blocked** — when booking is rejected for missing fields, customer gets corrective "still need X" message instead of AI's false "confirmed" response
- **Policy fetch failures are fail-closed everywhere** — defaults applied on any error, never null/undefined
- **27 new E2E scenario tests** proving Scenarios A–G

## Fail-Open Gaps Fixed

| # | Gap | File | Fix |
|---|-----|------|-----|
| 1 | Policy fetch null → booking unvalidated | process-sms.ts | aiPolicy always set (defaults on error) |
| 2 | Policy lookup fail → "fail-open for safety" | appointments.ts | Now returns error, blocks booking |
| 3 | carModel mapped to serviceType (fake) | process-sms.ts | carModel extracted independently |
| 4 | Same fake mapping duplicated | appointments.ts | Uses input.carModel field |
| 5 | Blocked booking sends false "confirmed" SMS | process-sms.ts | Corrective "still need X" message |
| 6 | Missed-call policy fetch fail → SMS sent | missed-call-sms.ts | Defaults applied on error |

## E2E Scenario Proof Results

| Scenario | Description | Result |
|----------|-------------|--------|
| A | License plate optional → booking allowed | PASS |
| B | License plate required + absent → booking blocked | PASS |
| C | Missed-call SMS disabled → no SMS sent | PASS |
| D | Missed-call SMS enabled → correct template sent | PASS |
| E | Limited slots → prompt enforces 2-3 max | PASS |
| F | Fail-closed validation (policy error + missing fields) | PASS |
| G | Full pass (all fields present) → booking proceeds | PASS |

## Test plan

- [x] 488 tests pass across 30 test files (0 failures)
- [x] 27 new E2E scenario tests (Scenarios A–G)
- [x] Existing 162 tests across 5 key files still pass
- [x] No lint errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)