### PR TITLE
fix: type assertions to unblock Docker build for dashboard deploy

### DIFF
--- a/apps/api/src/services/ai-settings.ts
+++ b/apps/api/src/services/ai-settings.ts
@@ -180,7 +180,7 @@ export function mergeWithDefaults(stored: unknown): AiSettings {
       suggestAdditionalServices: bs.suggestAdditionalServices === true,
       escalateUncertainCases: bs.escalateUncertainCases !== false,
       afterHoursBehavior:
-        (bs.afterHoursBehavior as string) || d.bookingStrategy.afterHoursBehavior,
+        ((bs.afterHoursBehavior as string) || d.bookingStrategy.afterHoursBehavior) as AiSettings["bookingStrategy"]["afterHoursBehavior"],
     };
   } else if ("offerEarliest" in legacyReq || "limitedSlots" in legacyReq) {
     bookingStrategy = {
@@ -190,7 +190,7 @@ export function mergeWithDefaults(stored: unknown): AiSettings {
       suggestAdditionalServices: legacyReq.upsellEnabled === true,
       escalateUncertainCases: legacyReq.escalationEnabled !== false,
       afterHoursBehavior:
-        (legacyReq.afterHours as string) || d.bookingStrategy.afterHoursBehavior,
+        ((legacyReq.afterHours as string) || d.bookingStrategy.afterHoursBehavior) as AiSettings["bookingStrategy"]["afterHoursBehavior"],
     };
   }
 
@@ -199,13 +199,13 @@ export function mergeWithDefaults(stored: unknown): AiSettings {
     const mc = s.missedCallSms as Record<string, unknown>;
     missedCallSms = {
       enabled: mc.enabled !== false,
-      preset: (mc.preset as string) || d.missedCallSms.preset,
+      preset: ((mc.preset as string) || d.missedCallSms.preset) as AiSettings["missedCallSms"]["preset"],
       template: (mc.template as string) || d.missedCallSms.template,
     };
   } else if ("missedSmsEnabled" in legacyReq) {
     missedCallSms = {
       enabled: legacyReq.missedSmsEnabled !== false,
-      preset: (legacyReq.smsPreset as string) || d.missedCallSms.preset,
+      preset: ((legacyReq.smsPreset as string) || d.missedCallSms.preset) as AiSettings["missedCallSms"]["preset"],
       template: (legacyReq.smsTemplate as string) || d.missedCallSms.template,
     };
   }


### PR DESCRIPTION
## Summary
- Adds 4 type assertions in `ai-settings.ts` `mergeWithDefaults()` to fix TS2322 errors blocking `docker compose build`
- This unblocks rebuilding the API container so the dashboard `appointments_today` fix (scheduled_at instead of created_at) is deployed to runtime

## Verification
- `tsc` compiles cleanly (EXIT_CODE=0)
- Docker image rebuilt and container restarted successfully
- Live `/tenant/dashboard` returns `appointments_today: 0` for an appointment scheduled tomorrow but created today — confirms `scheduled_at` logic is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)