### PR TITLE
fix: add SPA route handlers so OAuth redirect lands correctly on localhost

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -158,7 +158,7 @@ async function bootstrap() {
   await app.register(fastifyStatic, {
     root: staticDir,
     prefix: "/",
-    decorateReply: false,
+    decorateReply: true,
     setHeaders: (res, filePath) => {
       // Prevent caching of all HTML pages so users always see fresh content
       if (typeof filePath === "string" && filePath.endsWith(".html")) {
@@ -167,6 +167,37 @@ async function bootstrap() {
         res.setHeader("Expires", "0");
       }
     },
+  });
+
+  // ── SPA route handlers (mirrors vercel.json rewrites for local dev / Docker) ──
+  // Vercel rewrites /app/:view → /app.html, /login → /login.html, etc.
+  // Fastify needs explicit handlers so these clean URLs resolve locally.
+  app.get("/app/:view", (_req, reply) => {
+    reply.header("Cache-Control", "no-store, no-cache, must-revalidate");
+    reply.header("Pragma", "no-cache");
+    reply.header("Expires", "0");
+    void reply.sendFile("app.html");
+  });
+
+  app.get("/login", (_req, reply) => {
+    reply.header("Cache-Control", "no-store, no-cache, must-revalidate");
+    reply.header("Pragma", "no-cache");
+    reply.header("Expires", "0");
+    void reply.sendFile("login.html");
+  });
+
+  app.get("/signup", (_req, reply) => {
+    reply.header("Cache-Control", "no-store, no-cache, must-revalidate");
+    reply.header("Pragma", "no-cache");
+    reply.header("Expires", "0");
+    void reply.sendFile("signup.html");
+  });
+
+  app.get("/onboarding/:step", (_req, reply) => {
+    reply.header("Cache-Control", "no-store, no-cache, must-revalidate");
+    reply.header("Pragma", "no-cache");
+    reply.header("Expires", "0");
+    void reply.sendFile("onboarding.html");
   });
 
   // ── Graceful shutdown ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- Google OAuth callback stored tokens successfully but the post-auth redirect to `/app/dashboard?calendar=connected` returned "Route not found" on localhost
- Root cause: Vercel rewrites (`/app/:view` → `app.html`, `/login` → `login.html`) don't exist in the local Fastify server
- Added 4 Fastify route handlers mirroring `vercel.json` rewrites: `/app/:view`, `/login`, `/signup`, `/onboarding/:step`
- Changed `decorateReply: false` → `true` on `@fastify/static` so `reply.sendFile()` is available

## Proof
- **Tokens already stored before fix**: `integration_status=active`, `google_account_email=mantas.gipiskis@gmail.com`, both tokens present
- **Routes return 200 after fix**: `/app/dashboard`, `/login`, `/signup`, `/onboarding/business` all verified
- **Calendar API confirmed working**: Google Calendar API returned real calendar data ("Proteros Servisas Robotas")
- **531/531 tests passed** (32 test files, 0 failures)

## Test plan
- [x] Verify `/app/dashboard?calendar=connected` returns 200 on localhost
- [x] Verify `/login?next=/app/dashboard` returns 200 on localhost
- [x] Verify Google Calendar API responds with real data using stored tokens
- [x] Full test suite passes (531/531)

🤖 Generated with [Claude Code](https://claude.com/claude-code)