### PR TITLE
fix: hide unavailable KPI cards from Revenue summary bar

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -2297,15 +2297,11 @@ async function loadRevenueChart() {
       totalRev += days[i].total;
     }
 
-    // Render summary bar — only total revenue (real data)
-    // Bookings, avg ticket, and growth require real data sources that don't exist yet
+    // Render summary bar — only metrics backed by real data
     if (summaryBar) {
       summaryBar.style.display = 'flex';
       summaryBar.innerHTML =
-        '<div class="rev-metric"><div class="rev-metric-label">Total Revenue</div><div class="rev-metric-value">' + formatCurrency(totalRev) + '</div></div>' +
-        '<div class="rev-metric"><div class="rev-metric-label">Bookings</div><div class="rev-metric-value">\u2014</div></div>' +
-        '<div class="rev-metric"><div class="rev-metric-label">Avg Ticket</div><div class="rev-metric-value">\u2014</div></div>' +
-        '<div class="rev-metric"><div class="rev-metric-label">Period Growth</div><div class="rev-metric-value">\u2014</div></div>';
+        '<div class="rev-metric"><div class="rev-metric-label">Total Revenue</div><div class="rev-metric-value">' + formatCurrency(totalRev) + '</div></div>';
     }
 
     // Prepare labels and data


### PR DESCRIPTION
## Summary
- Remove placeholder Bookings, Avg Ticket, and Period Growth cards that displayed "—" dashes
- Summary bar now renders only Total Revenue (the only metric backed by real data)
- No changes to chart, tooltip, empty state, or visual styling

## Test plan
- [ ] Load dashboard with revenue data — summary bar shows only Total Revenue
- [ ] Chart behavior unchanged (gradient, hover line, sparse-data bars)
- [ ] Empty state still renders when no revenue exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)