### PR TITLE
fix: server-side onboarding state for dashboard API

### DIFF
--- a/apps/api/src/routes/tenant/dashboard.ts
+++ b/apps/api/src/routes/tenant/dashboard.ts
@@ -27,12 +27,13 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
       recentConvRows,
       recentBookingRows,
     ] = await Promise.all([
-      // Tenant identity + billing
+      // Tenant identity + billing + business hours (for onboarding check)
       query(
         `SELECT id, shop_name, owner_email, billing_status, plan_id,
                 conv_used_this_cycle, conv_limit_this_cycle,
                 trial_started_at, trial_ends_at,
-                warned_80pct, warned_100pct, created_at
+                warned_80pct, warned_100pct, created_at,
+                business_hours
          FROM tenants WHERE id = $1`,
         [tenantId]
       ),
@@ -142,6 +143,19 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
       }
     }
 
+    // ── Compute server-side onboarding state ──
+    const phoneConnected = phone?.status === "active";
+    // business_hours is free-form TEXT; consider "configured" if non-empty/non-null
+    const hoursConfigured = !!(tenant.business_hours && tenant.business_hours.trim().length > 0);
+    const calendarConnected = calendarStatus === "connected";
+    const totalConvs = (totalConvsRows as any[])[0]?.count ?? 0;
+    const totalAppts = (totalAppointmentsRows as any[])[0]?.count ?? 0;
+    const hasActivity = totalConvs > 0 || totalAppts > 0;
+    // Onboarding complete when phone is active AND system has received real activity.
+    // Calendar and hours are important but not blocking — a shop can operate
+    // with default hours and manual calendar. Phone + activity = system is live.
+    const onboardingComplete = phoneConnected && hasActivity;
+
     return reply.status(200).send({
       tenant: {
         id: tenant.id,
@@ -177,6 +191,13 @@ export async function tenantDashboardRoute(app: FastifyInstance) {
         appointments_this_month: (appointmentsThisMonthRows as any[])[0]?.count ?? 0,
         total_conversations: (totalConvsRows as any[])[0]?.count ?? 0,
         total_appointments: (totalAppointmentsRows as any[])[0]?.count ?? 0,
+      },
+      onboarding: {
+        phone_connected: phoneConnected,
+        hours_configured: hoursConfigured,
+        calendar_connected: calendarConnected,
+        has_activity: hasActivity,
+        onboarding_complete: onboardingComplete,
       },
       recent_conversations: recentConvRows,
       recent_bookings: recentBookingRows,

--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -2156,6 +2156,9 @@ async function loadDashboardData() {
     tenantState._calendarId = cal.calendar_id || null;
     tenantState.created_at = t.created_at;
 
+    // Server-side onboarding state (single source of truth)
+    tenantState.onboarding = data.onboarding || {};
+
     // Health — derive from integration status
     tenantState.health.calendarSync.status = cal.status === 'connected' ? 'healthy' : (cal.status === 'token_expired' ? 'token_expired' : 'failing');
     tenantState.health.calendarSync.lastAt = cal.connected_at ? fmtDate(cal.connected_at) : '—';
@@ -2621,22 +2624,13 @@ function renderNav() {
 // ════════════════════════════════════════════
 function renderChecklist() {
   var s = tenantState;
-  var phoneConnected = s.integrations.twilioNumber === 'active';
-  var hasHours = true; // Business hours have defaults (Mon-Sat 8-5), so consider set
-  var hasConversations = conversationsData.length > 0;
+  var ob = s.onboarding || {};
+  // All onboarding booleans come from server — single source of truth
+  var phoneConnected = !!ob.phone_connected;
+  var hasHours = !!ob.hours_configured;
+  var hasConversations = !!ob.has_activity;
   var hasBookings = bookingsData.length > 0;
   var twilioPhone = s._twilioPhone || '';
-
-  // Check business hours from settings — if all days are closed or no hours saved, mark incomplete
-  var hoursRows = document.querySelectorAll('#hoursRows .hours-row');
-  if (hoursRows.length > 0) {
-    var openDays = 0;
-    hoursRows.forEach(function(row) {
-      var cb = row.querySelector('input[type="checkbox"]');
-      if (!cb || !cb.checked) openDays++;
-    });
-    hasHours = openDays > 0;
-  }
 
   var steps = [
     {
@@ -2692,8 +2686,9 @@ function renderChecklist() {
   var guide = document.getElementById('onboardingGuide');
   if (!guide) return;
 
-  // Always show if not all done; hide if dismissed and all done
-  if (doneCount === 4) {
+  // Server decides onboarding completion — hide when server says complete and user dismissed
+  var serverComplete = !!ob.onboarding_complete;
+  if (serverComplete) {
     if (localStorage.getItem('onboarding_dismissed') === '1') {
       guide.style.display = 'none';
       renderOnboardingWarnings(steps);
@@ -2715,7 +2710,7 @@ function renderChecklist() {
   // Title update
   var titleEl = document.getElementById('onboardingTitle');
   var subEl = document.getElementById('onboardingSub');
-  if (doneCount === 4) {
+  if (serverComplete) {
     if (titleEl) titleEl.textContent = 'You\'re all set!';
     if (subEl) subEl.textContent = 'Your AI receptionist is live and ready to book appointments.';
   } else if (doneCount >= 2) {


### PR DESCRIPTION
## Summary
- Adds explicit `onboarding` object to `/tenant/dashboard` API response with 5 server-computed booleans: `phone_connected`, `hours_configured`, `calendar_connected`, `has_activity`, `onboarding_complete`
- Frontend `renderChecklist()` now reads these server booleans instead of deriving state from DOM checkboxes, `conversationsData.length`, or localStorage
- Eliminates client/server state disagreement on onboarding completion

## Persisted sources for each signal
| Signal | DB Source |
|---|---|
| `phone_connected` | `tenant_phone_numbers.status = 'active'` |
| `hours_configured` | `tenants.business_hours` (non-empty TEXT) |
| `calendar_connected` | `tenant_calendar_tokens.integration_status = 'active'` |
| `has_activity` | `COUNT(conversations) > 0 OR COUNT(appointments) > 0` |
| `onboarding_complete` | `phone_connected AND has_activity` |

## Formula
```
onboarding_complete = phone_connected && has_activity
```
Calendar and hours are exposed but not blocking — a shop can operate with default hours and manual calendar management. The system is considered "live" when phone is active AND real activity exists.

## Test plan
- [x] All 531 tests pass (vitest run, EXIT_CODE=0)
- [ ] Verify dashboard API returns `onboarding` object with correct booleans
- [ ] Verify onboarding guide hides when server says `onboarding_complete: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)