### PR TITLE
fix: add vitest config to exclude dist/ from test runner

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `apps/api/vitest.config.ts` with explicit `include`/`exclude` patterns
- Prevents vitest from picking up compiled `.js` test files in `dist/` directory
- Eliminates 34 false test failures (CommonJS import errors from compiled artifacts)

## Verification
- 32 test files, 531 tests, 0 failures
- TypeScript: clean

## Test plan
- [x] `npx vitest run` passes with 531/531 tests
- [x] No `dist/` test files are executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)