### PR TITLE
feat: persistent two-tier webhook idempotency layer

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,41 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: idempotency-hardening — 2026-03-19
+
+**Branch:** ai/idempotency-hardening
+**Status:** COMPLETE — Full production idempotency layer for all webhooks
+
+### Why This is P0 Production Safety
+
+Twilio retries webhooks on timeout. Network glitches cause replays. Queue retries re-process events. Without persistent idempotency, this causes duplicate conversations, double bookings, SMS spam, and incorrect billing counts — all trust-destroying for paying customers.
+
+### Changes
+
+1. **Migration 024: `webhook_events` table** — Persistent idempotency source of truth with `UNIQUE(source, event_sid)`. Survives Redis flush/TTL expiry.
+2. **Two-tier dedup module** (`db/webhook-events.ts`) — `deduplicateWebhook()`: Redis fast check (24h TTL) + PostgreSQL permanent check. Graceful degradation if either tier is down.
+3. **Twilio SMS webhook** — Replaced Redis-only `checkIdempotency`/`markIdempotency` with `deduplicateWebhook("twilio_sms", MessageSid)`.
+4. **Twilio Voice webhook** — Added idempotency on `CallSid` (previously had ZERO dedup). `deduplicateWebhook("twilio_voice", CallSid)`.
+5. **Twilio Voice Status webhook** — Upgraded from Redis-only to two-tier `deduplicateWebhook("twilio_voice_status", CallSid)`.
+6. **Stripe webhook** — Upgraded from Redis-only to two-tier `deduplicateWebhook("stripe", event.id)`. DB `billing_events` UNIQUE constraint preserved as additional safety.
+7. **SMS send dedup** (`services/process-sms.ts`) — Before sending outbound SMS, checks if identical message was sent in the same conversation within 30 seconds. Blocks duplicate sends from queue retries.
+8. **Booking duplicate logging** (`services/appointments.ts`) — Structured `booking_duplicate_blocked` log when appointment upsert detects existing record.
+9. **Structured logging** — All duplicate detection emits structured JSON with `event`, `tenant_id`, `conversation_id`/`event_sid` for monitoring.
+10. **10 new idempotency tests** — Covers: first encounter, Redis hit, DB conflict, Redis down, DB down, all source types, correct insert values.
+
+### What This Fixes
+- Before: Redis flush or 24h TTL expiry → duplicate processing on webhook replays
+- Before: Voice webhook had no idempotency at all
+- Before: Queue retry could send identical SMS twice
+- After: Permanent DB-backed dedup for all webhooks + SMS send dedup + structured logging
+
+### Verification
+- 548 tests passed, 0 failed
+- TypeScript compiles clean
+- Lint: 0 errors on changed files
+
+---
+
 ## TASK: calendar-sync-retry — 2026-03-19
 
 **Branch:** ai/calendar-sync-retry

--- a/apps/api/src/db/webhook-events.ts
+++ b/apps/api/src/db/webhook-events.ts
@@ -1,0 +1,86 @@
+/**
+ * Persistent webhook idempotency layer.
+ *
+ * Two-tier dedup:
+ *   1. Redis (fast, ephemeral — 24h TTL)
+ *   2. PostgreSQL webhook_events table (permanent)
+ *
+ * A webhook is considered duplicate if EITHER tier reports it as seen.
+ * On first processing, BOTH tiers are written to ensure coverage.
+ */
+
+import { query } from "./client";
+import { checkIdempotency, markIdempotency } from "../queues/redis";
+
+export type WebhookSource =
+  | "twilio_sms"
+  | "twilio_voice"
+  | "twilio_voice_status"
+  | "stripe";
+
+interface DeduplicateResult {
+  isDuplicate: boolean;
+  source: WebhookSource;
+  eventSid: string;
+}
+
+/**
+ * Check-and-mark idempotency for a webhook event.
+ *
+ * Returns { isDuplicate: true } if this event was already processed.
+ * Returns { isDuplicate: false } and marks both Redis + DB if new.
+ *
+ * IMPORTANT: Always returns 200 to the webhook caller regardless — the
+ * caller is responsible for short-circuiting on isDuplicate === true.
+ */
+export async function deduplicateWebhook(
+  source: WebhookSource,
+  eventSid: string,
+  tenantId?: string | null
+): Promise<DeduplicateResult> {
+  const redisKey = `${source}:${eventSid}`;
+
+  // ── Tier 1: Redis fast check ──────────────────────────────────────────────
+  try {
+    const redisHit = await checkIdempotency(redisKey);
+    if (redisHit) {
+      return { isDuplicate: true, source, eventSid };
+    }
+  } catch {
+    // Redis down — fall through to DB check
+  }
+
+  // ── Tier 2: PostgreSQL persistent check + insert ──────────────────────────
+  try {
+    const rows = await query<{ id: number }>(
+      `INSERT INTO webhook_events (source, event_sid, tenant_id)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (source, event_sid) DO NOTHING
+       RETURNING id`,
+      [source, eventSid, tenantId ?? null]
+    );
+
+    if (rows.length === 0) {
+      // Conflict — event already exists in DB
+      // Backfill Redis so future checks are fast
+      try {
+        await markIdempotency(redisKey);
+      } catch {
+        // Non-fatal
+      }
+      return { isDuplicate: true, source, eventSid };
+    }
+  } catch {
+    // DB insert failed (not a conflict) — this is unexpected but not fatal.
+    // Fall through and process (better to double-process once than drop events).
+  }
+
+  // ── Mark Redis for fast future lookups ────────────────────────────────────
+  try {
+    await markIdempotency(redisKey);
+  } catch {
+    // Non-fatal: DB has the record
+  }
+
+  return { isDuplicate: false, source, eventSid };
+}

--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -2,12 +2,8 @@ import { FastifyInstance, FastifyRequest } from "fastify";
 import Stripe from "stripe";
 import { query } from "../../db/client";
 import { updateBillingStatus } from "../../db/tenants";
-import {
-  billingQueue,
-  provisionNumberQueue,
-  checkIdempotency,
-  markIdempotency,
-} from "../../queues/redis";
+import { billingQueue, provisionNumberQueue } from "../../queues/redis";
+import { deduplicateWebhook } from "../../db/webhook-events";
 
 type BillingStatus =
   | "trial" | "trial_expired" | "active"
@@ -63,12 +59,15 @@ export async function stripeRoute(app: FastifyInstance) {
       return reply.status(400).send({ error: `Webhook error: ${message}` });
     }
 
-    // ── Idempotency ──────────────────────────────────────────────────────────
-    const alreadyProcessed = await checkIdempotency(`stripe:${event.id}`);
-    if (alreadyProcessed) {
+    // ── Idempotency (two-tier: Redis + PostgreSQL) ──────────────────────────
+    const dedup = await deduplicateWebhook("stripe", event.id);
+    if (dedup.isDuplicate) {
+      app.log.info(
+        { eventId: event.id, source: "stripe", event: "webhook_duplicate_detected" },
+        "Duplicate Stripe webhook — skipping"
+      );
       return reply.status(200).send({ received: true });
     }
-    await markIdempotency(`stripe:${event.id}`);
 
     // ── Log to billing_events ────────────────────────────────────────────────
     // TODO: extract tenantId from event metadata

--- a/apps/api/src/routes/webhooks/twilio-sms.ts
+++ b/apps/api/src/routes/webhooks/twilio-sms.ts
@@ -2,11 +2,8 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { validateTwilioSignature } from "../../middleware/twilio-validate";
 import { getTenantByPhoneNumber, getBlockReason } from "../../db/tenants";
-import {
-  smsInboundQueue,
-  checkIdempotency,
-  markIdempotency,
-} from "../../queues/redis";
+import { smsInboundQueue } from "../../queues/redis";
+import { deduplicateWebhook } from "../../db/webhook-events";
 import { startTrace } from "../../services/pipeline-trace";
 
 // Twilio sends form-encoded body
@@ -47,12 +44,15 @@ export async function twilioSmsRoute(app: FastifyInstance) {
       }
 
       // ── 1. Idempotency (Twilio retries if no 200 within 15s) ──────────────
-      const alreadyProcessed = await checkIdempotency(`twilio:${MessageSid}`);
-      if (alreadyProcessed) {
-        request.log.info({ MessageSid }, "Duplicate webhook — skipping");
+      // Two-tier: Redis (fast) + PostgreSQL webhook_events (persistent)
+      const dedup = await deduplicateWebhook("twilio_sms", MessageSid);
+      if (dedup.isDuplicate) {
+        request.log.info(
+          { MessageSid, source: "twilio_sms", event: "webhook_duplicate_detected" },
+          "Duplicate SMS webhook — skipping"
+        );
         return reply.status(200).type("text/xml").send("<Response/>");
       }
-      await markIdempotency(`twilio:${MessageSid}`);
 
       // ── 2. Tenant lookup by inbound phone number ───────────────────────────
       const tenant = await getTenantByPhoneNumber(To);

--- a/apps/api/src/routes/webhooks/twilio-voice-status.ts
+++ b/apps/api/src/routes/webhooks/twilio-voice-status.ts
@@ -2,7 +2,8 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { validateTwilioSignature } from "../../middleware/twilio-validate";
 import { getTenantByPhoneNumber, getBlockReason } from "../../db/tenants";
-import { smsInboundQueue, checkIdempotency, markIdempotency } from "../../queues/redis";
+import { smsInboundQueue } from "../../queues/redis";
+import { deduplicateWebhook } from "../../db/webhook-events";
 import { startTrace, resumeTrace } from "../../services/pipeline-trace";
 
 const TwilioVoiceStatusBody = z.object({
@@ -57,12 +58,15 @@ export async function twilioVoiceStatusRoute(app: FastifyInstance) {
         // Non-fatal
       }
 
-      // Idempotency
-      const key = `voice:${CallSid}`;
-      if (await checkIdempotency(key)) {
+      // ── Idempotency (two-tier: Redis + PostgreSQL) ────────────────────────
+      const dedup = await deduplicateWebhook("twilio_voice_status", CallSid);
+      if (dedup.isDuplicate) {
+        request.log.info(
+          { CallSid, source: "twilio_voice_status", event: "webhook_duplicate_detected" },
+          "Duplicate voice-status webhook — skipping"
+        );
         return reply.status(200).type("text/xml").send("<Response/>");
       }
-      await markIdempotency(key);
 
       const tenant = await getTenantByPhoneNumber(To);
       if (!tenant) {

--- a/apps/api/src/routes/webhooks/twilio-voice.ts
+++ b/apps/api/src/routes/webhooks/twilio-voice.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { validateTwilioSignature } from "../../middleware/twilio-validate";
 import { query } from "../../db/client";
+import { deduplicateWebhook } from "../../db/webhook-events";
 
 const TwilioVoiceBody = z.object({
   CallSid: z.string(),
@@ -31,7 +32,17 @@ export async function twilioVoiceRoute(app: FastifyInstance) {
         return reply.status(400).send({ error: "Invalid body" });
       }
 
-      const { To, From } = parsed.data;
+      const { CallSid, To, From } = parsed.data;
+
+      // ── Idempotency (Twilio retries voice webhooks on timeout) ────────────
+      const dedup = await deduplicateWebhook("twilio_voice", CallSid);
+      if (dedup.isDuplicate) {
+        request.log.info(
+          { CallSid, source: "twilio_voice", event: "webhook_duplicate_detected" },
+          "Duplicate voice webhook — skipping"
+        );
+        return reply.status(200).type("text/xml").send("<Response/>");
+      }
 
       // Look up the forwarding number for this Twilio number
       let forwardTo: string | null = null;

--- a/apps/api/src/services/appointments.ts
+++ b/apps/api/src/services/appointments.ts
@@ -224,6 +224,17 @@ export async function createAppointment(
     // xmax > 0 means the row was updated (upsert), not inserted
     const upserted = row.xmax !== "0";
 
+    if (upserted) {
+      console.info(
+        JSON.stringify({
+          event: "booking_duplicate_blocked",
+          tenant_id: input.tenantId,
+          conversation_id: input.conversationId,
+          appointment_id: row.id,
+        })
+      );
+    }
+
     return {
       success: true,
       appointment: {

--- a/apps/api/src/services/process-sms.ts
+++ b/apps/api/src/services/process-sms.ts
@@ -494,8 +494,40 @@ export async function processSms(
     // Non-fatal
   }
 
-  // ── 10. Send SMS reply ─────────────────────────────────────────────────
-  const smsResult = await sendTwilioSms(input.customerPhone, smsBody, fetchFn);
+  // ── 10. Send SMS reply (with dedup protection) ────────────────────────
+  // Check if identical message was sent in this conversation within the last 30s.
+  // Prevents double-sends from queue retries or race conditions.
+  let smsDuplicate = false;
+  try {
+    const dupeCheck = await query<{ id: string }>(
+      `SELECT id FROM messages
+       WHERE conversation_id = $1 AND tenant_id = $2
+         AND direction = 'outbound' AND body = $3
+         AND sent_at > NOW() - INTERVAL '30 seconds'
+       LIMIT 1`,
+      [result.conversationId, input.tenantId, smsBody]
+    );
+    if (dupeCheck.length > 0) {
+      smsDuplicate = true;
+      console.info(
+        JSON.stringify({
+          event: "sms_duplicate_blocked",
+          tenant_id: input.tenantId,
+          conversation_id: result.conversationId,
+          message_preview: smsBody.slice(0, 50),
+        })
+      );
+    }
+  } catch {
+    // Non-fatal: if check fails, send anyway (better to double-send than not send)
+  }
+
+  let smsResult: { sid: string | null; error: string | null };
+  if (smsDuplicate) {
+    smsResult = { sid: "skipped-duplicate", error: null };
+  } else {
+    smsResult = await sendTwilioSms(input.customerPhone, smsBody, fetchFn);
+  }
   result.smsSent = !!smsResult.sid;
   result.aiResponse = smsBody;
 

--- a/apps/api/src/tests/sms-inbound.test.ts
+++ b/apps/api/src/tests/sms-inbound.test.ts
@@ -5,8 +5,7 @@ import formbody from "@fastify/formbody";
 // vi.hoisted ensures these are available inside vi.mock factories (hoisted before imports)
 const mocks = vi.hoisted(() => ({
   add: vi.fn().mockResolvedValue({ id: "job-1" }),
-  checkIdempotency: vi.fn().mockResolvedValue(false),
-  markIdempotency: vi.fn().mockResolvedValue(undefined),
+  deduplicateWebhook: vi.fn().mockResolvedValue({ isDuplicate: false, source: "twilio_sms", eventSid: "" }),
   getTenantByPhoneNumber: vi.fn(),
   getBlockReason: vi.fn((): string | null => null),
 }));
@@ -20,8 +19,10 @@ vi.mock("../db/client", () => ({
 
 vi.mock("../queues/redis", () => ({
   smsInboundQueue: { add: mocks.add },
-  checkIdempotency: mocks.checkIdempotency,
-  markIdempotency: mocks.markIdempotency,
+}));
+
+vi.mock("../db/webhook-events", () => ({
+  deduplicateWebhook: mocks.deduplicateWebhook,
 }));
 
 vi.mock("../db/tenants", () => ({
@@ -100,7 +101,7 @@ describe("POST /webhooks/twilio/sms", () => {
 
     mocks.getTenantByPhoneNumber.mockResolvedValue(MOCK_TENANT);
     mocks.getBlockReason.mockReturnValue(null);
-    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "twilio_sms", eventSid: "" });
     mocks.add.mockResolvedValue({ id: "job-1" });
   });
 
@@ -150,7 +151,7 @@ describe("POST /webhooks/twilio/sms", () => {
     await app.close();
   });
 
-  it("writes idempotency key to Redis", async () => {
+  it("calls deduplicateWebhook with correct source and sid", async () => {
     const app = await buildApp();
 
     await app.inject({
@@ -160,14 +161,15 @@ describe("POST /webhooks/twilio/sms", () => {
       payload: smsPayload(),
     });
 
-    expect(mocks.markIdempotency).toHaveBeenCalledWith(
-      `twilio:${TEST_MESSAGE_SID}`
+    expect(mocks.deduplicateWebhook).toHaveBeenCalledWith(
+      "twilio_sms",
+      TEST_MESSAGE_SID
     );
     await app.close();
   });
 
   it("returns 200 and skips enqueue on duplicate MessageSid", async () => {
-    mocks.checkIdempotency.mockResolvedValueOnce(true); // already seen
+    mocks.deduplicateWebhook.mockResolvedValueOnce({ isDuplicate: true, source: "twilio_sms", eventSid: TEST_MESSAGE_SID });
 
     const app = await buildApp();
     const res = await app.inject({
@@ -183,8 +185,8 @@ describe("POST /webhooks/twilio/sms", () => {
     await app.close();
   });
 
-  it("does not write idempotency key on duplicate", async () => {
-    mocks.checkIdempotency.mockResolvedValueOnce(true);
+  it("does not process on duplicate", async () => {
+    mocks.deduplicateWebhook.mockResolvedValueOnce({ isDuplicate: true, source: "twilio_sms", eventSid: TEST_MESSAGE_SID });
 
     const app = await buildApp();
     await app.inject({
@@ -194,7 +196,7 @@ describe("POST /webhooks/twilio/sms", () => {
       payload: smsPayload(),
     });
 
-    expect(mocks.markIdempotency).not.toHaveBeenCalled();
+    expect(mocks.getTenantByPhoneNumber).not.toHaveBeenCalled();
     await app.close();
   });
 

--- a/apps/api/src/tests/stripe-webhook.test.ts
+++ b/apps/api/src/tests/stripe-webhook.test.ts
@@ -5,8 +5,7 @@ import Fastify from "fastify";
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn().mockResolvedValue([]),
-  checkIdempotency: vi.fn().mockResolvedValue(false),
-  markIdempotency: vi.fn().mockResolvedValue(undefined),
+  deduplicateWebhook: vi.fn().mockResolvedValue({ isDuplicate: false, source: "stripe", eventSid: "" }),
   billingQueueAdd: vi.fn().mockResolvedValue({ id: "job-1" }),
   provisionQueueAdd: vi.fn().mockResolvedValue({ id: "job-2" }),
   updateBillingStatus: vi.fn().mockResolvedValue(undefined),
@@ -22,8 +21,10 @@ vi.mock("../db/client", () => ({
 vi.mock("../queues/redis", () => ({
   billingQueue: { add: mocks.billingQueueAdd },
   provisionNumberQueue: { add: mocks.provisionQueueAdd },
-  checkIdempotency: mocks.checkIdempotency,
-  markIdempotency: mocks.markIdempotency,
+}));
+
+vi.mock("../db/webhook-events", () => ({
+  deduplicateWebhook: mocks.deduplicateWebhook,
 }));
 
 vi.mock("../db/tenants", () => ({
@@ -119,7 +120,7 @@ describe("POST /webhooks/stripe", () => {
     process.env.STRIPE_PRICE_PRO = "price_pro_test";
     process.env.STRIPE_PRICE_PREMIUM = "price_premium_test";
 
-    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "stripe", eventSid: "" });
     mocks.query.mockResolvedValue([]);
   });
 
@@ -171,7 +172,7 @@ describe("POST /webhooks/stripe", () => {
   // ── Idempotency ───────────────────────────────────────────────────────────
 
   it("skips processing on duplicate event (idempotency)", async () => {
-    mocks.checkIdempotency.mockResolvedValueOnce(true);
+    mocks.deduplicateWebhook.mockResolvedValueOnce({ isDuplicate: true, source: "stripe", eventSid: TEST_EVENT_ID });
     const evt = makeEvent("customer.subscription.created", subscriptionObject());
     mocks.constructEvent.mockReturnValue(evt);
     const app = await buildApp();
@@ -180,18 +181,17 @@ describe("POST /webhooks/stripe", () => {
 
     expect(res.statusCode).toBe(200);
     expect(mocks.query).not.toHaveBeenCalled(); // no DB write
-    expect(mocks.markIdempotency).not.toHaveBeenCalled();
     await app.close();
   });
 
-  it("marks idempotency key after first processing", async () => {
+  it("calls deduplicateWebhook with correct source and event id", async () => {
     const evt = makeEvent("customer.subscription.created", subscriptionObject());
     mocks.constructEvent.mockReturnValue(evt);
     const app = await buildApp();
 
     await postStripe(app);
 
-    expect(mocks.markIdempotency).toHaveBeenCalledWith(`stripe:${TEST_EVENT_ID}`);
+    expect(mocks.deduplicateWebhook).toHaveBeenCalledWith("stripe", TEST_EVENT_ID);
     await app.close();
   });
 

--- a/apps/api/src/tests/twilio-validate.test.ts
+++ b/apps/api/src/tests/twilio-validate.test.ts
@@ -6,8 +6,7 @@ import twilio from "twilio";
 // Mock DB and Redis to isolate middleware tests
 const mocks = vi.hoisted(() => ({
   add: vi.fn().mockResolvedValue({ id: "job-1" }),
-  checkIdempotency: vi.fn().mockResolvedValue(false),
-  markIdempotency: vi.fn().mockResolvedValue(undefined),
+  deduplicateWebhook: vi.fn().mockResolvedValue({ isDuplicate: false, source: "twilio_sms", eventSid: "" }),
   getTenantByPhoneNumber: vi.fn(),
   getBlockReason: vi.fn((): string | null => null),
 }));
@@ -20,8 +19,10 @@ vi.mock("../db/client", () => ({
 
 vi.mock("../queues/redis", () => ({
   smsInboundQueue: { add: mocks.add },
-  checkIdempotency: mocks.checkIdempotency,
-  markIdempotency: mocks.markIdempotency,
+}));
+
+vi.mock("../db/webhook-events", () => ({
+  deduplicateWebhook: mocks.deduplicateWebhook,
 }));
 
 vi.mock("../db/tenants", () => ({
@@ -96,7 +97,7 @@ describe("Twilio webhook signature validation", () => {
 
     mocks.getTenantByPhoneNumber.mockResolvedValue(MOCK_TENANT);
     mocks.getBlockReason.mockReturnValue(null);
-    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "twilio_sms", eventSid: "" });
   });
 
   afterEach(() => {
@@ -158,7 +159,7 @@ describe("Twilio webhook signature validation", () => {
     expect(res.json().error).toBe("Missing Twilio signature");
     // Handler should NOT have been reached
     expect(mocks.add).not.toHaveBeenCalled();
-    expect(mocks.checkIdempotency).not.toHaveBeenCalled();
+    expect(mocks.deduplicateWebhook).not.toHaveBeenCalled();
     await app.close();
   });
 
@@ -294,8 +295,7 @@ describe("Twilio webhook signature validation", () => {
 
     // Full flow executed
     expect(res.statusCode).toBe(200);
-    expect(mocks.checkIdempotency).toHaveBeenCalledWith(`twilio:${TEST_MESSAGE_SID}`);
-    expect(mocks.markIdempotency).toHaveBeenCalledWith(`twilio:${TEST_MESSAGE_SID}`);
+    expect(mocks.deduplicateWebhook).toHaveBeenCalledWith("twilio_sms", TEST_MESSAGE_SID);
     expect(mocks.getTenantByPhoneNumber).toHaveBeenCalledWith(TEST_TO);
     expect(mocks.add).toHaveBeenCalledWith(
       "process-sms",

--- a/apps/api/src/tests/twilio-voice.test.ts
+++ b/apps/api/src/tests/twilio-voice.test.ts
@@ -4,12 +4,17 @@ import formbody from "@fastify/formbody";
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
+  deduplicateWebhook: vi.fn().mockResolvedValue({ isDuplicate: false, source: "twilio_voice", eventSid: "" }),
 }));
 
 vi.mock("../db/client", () => ({
   db: { end: vi.fn() },
   query: mocks.query,
   withTenant: vi.fn(),
+}));
+
+vi.mock("../db/webhook-events", () => ({
+  deduplicateWebhook: mocks.deduplicateWebhook,
 }));
 
 import { twilioVoiceRoute } from "../routes/webhooks/twilio-voice";
@@ -52,6 +57,7 @@ describe("POST /webhooks/twilio/voice", () => {
     process.env.SKIP_TWILIO_VALIDATION = "true";
     process.env.API_BASE_URL = "https://autoshop-api.example.com";
 
+    mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "twilio_voice", eventSid: "" });
     mocks.query.mockResolvedValue([
       { forward_to: TEST_FORWARD, shop_name: "Test Auto Shop" },
     ]);

--- a/apps/api/src/tests/voice-status.test.ts
+++ b/apps/api/src/tests/voice-status.test.ts
@@ -5,8 +5,7 @@ import formbody from "@fastify/formbody";
 // vi.hoisted ensures mocks are available inside vi.mock factories
 const mocks = vi.hoisted(() => ({
   add: vi.fn().mockResolvedValue({ id: "job-1" }),
-  checkIdempotency: vi.fn().mockResolvedValue(false),
-  markIdempotency: vi.fn().mockResolvedValue(undefined),
+  deduplicateWebhook: vi.fn().mockResolvedValue({ isDuplicate: false, source: "twilio_voice_status", eventSid: "" }),
   getTenantByPhoneNumber: vi.fn(),
   getBlockReason: vi.fn((): string | null => null),
 }));
@@ -19,8 +18,10 @@ vi.mock("../db/client", () => ({
 
 vi.mock("../queues/redis", () => ({
   smsInboundQueue: { add: mocks.add },
-  checkIdempotency: mocks.checkIdempotency,
-  markIdempotency: mocks.markIdempotency,
+}));
+
+vi.mock("../db/webhook-events", () => ({
+  deduplicateWebhook: mocks.deduplicateWebhook,
 }));
 
 vi.mock("../db/tenants", () => ({
@@ -98,7 +99,7 @@ describe("POST /webhooks/twilio/voice-status", () => {
     process.env.SKIP_TWILIO_VALIDATION = "true";
 
     mocks.getTenantByPhoneNumber.mockResolvedValue(MOCK_TENANT);
-    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "twilio_voice_status", eventSid: "" });
     mocks.add.mockResolvedValue({ id: "job-1" });
   });
 
@@ -180,7 +181,7 @@ describe("POST /webhooks/twilio/voice-status", () => {
   });
 
   it("returns 200 and skips enqueue on duplicate CallSid (idempotency)", async () => {
-    mocks.checkIdempotency.mockResolvedValueOnce(true); // already seen
+    mocks.deduplicateWebhook.mockResolvedValueOnce({ isDuplicate: true, source: "twilio_voice_status", eventSid: TEST_CALL_SID });
 
     const app = await buildApp();
     const res = await app.inject({
@@ -232,7 +233,7 @@ describe("POST /webhooks/twilio/voice-status", () => {
     for (const status of ["ringing", "in-progress", "queued"]) {
       vi.clearAllMocks();
       mocks.getTenantByPhoneNumber.mockResolvedValue(MOCK_TENANT);
-      mocks.checkIdempotency.mockResolvedValue(false);
+      mocks.deduplicateWebhook.mockResolvedValue({ isDuplicate: false, source: "twilio_voice_status", eventSid: "" });
 
       const res = await app.inject({
         method: "POST",
@@ -247,7 +248,7 @@ describe("POST /webhooks/twilio/voice-status", () => {
     await app.close();
   });
 
-  it("writes idempotency key to Redis for missed calls", async () => {
+  it("calls deduplicateWebhook with correct source and sid for missed calls", async () => {
     const app = await buildApp();
 
     await app.inject({
@@ -257,12 +258,12 @@ describe("POST /webhooks/twilio/voice-status", () => {
       payload: voicePayload({ CallStatus: "no-answer" }),
     });
 
-    expect(mocks.markIdempotency).toHaveBeenCalledWith(`voice:${TEST_CALL_SID}`);
+    expect(mocks.deduplicateWebhook).toHaveBeenCalledWith("twilio_voice_status", TEST_CALL_SID);
     await app.close();
   });
 
-  it("does not write idempotency key on duplicate", async () => {
-    mocks.checkIdempotency.mockResolvedValueOnce(true);
+  it("does not process on duplicate", async () => {
+    mocks.deduplicateWebhook.mockResolvedValueOnce({ isDuplicate: true, source: "twilio_voice_status", eventSid: TEST_CALL_SID });
 
     const app = await buildApp();
     await app.inject({
@@ -272,7 +273,7 @@ describe("POST /webhooks/twilio/voice-status", () => {
       payload: voicePayload({ CallStatus: "no-answer" }),
     });
 
-    expect(mocks.markIdempotency).not.toHaveBeenCalled();
+    expect(mocks.getTenantByPhoneNumber).not.toHaveBeenCalled();
     await app.close();
   });
 

--- a/apps/api/src/tests/webhook-idempotency.test.ts
+++ b/apps/api/src/tests/webhook-idempotency.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the two-tier webhook idempotency layer.
+ *
+ * Verifies:
+ * 1. Same webhook sent twice → processed once
+ * 2. Redis down → DB catches duplicates
+ * 3. DB conflict → returns isDuplicate: true
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  checkIdempotency: vi.fn().mockResolvedValue(false),
+  markIdempotency: vi.fn().mockResolvedValue(undefined),
+  query: vi.fn().mockResolvedValue([{ id: 1 }]),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+  withTenant: vi.fn(),
+}));
+
+vi.mock("../queues/redis", () => ({
+  checkIdempotency: mocks.checkIdempotency,
+  markIdempotency: mocks.markIdempotency,
+}));
+
+import { deduplicateWebhook } from "../db/webhook-events";
+
+describe("deduplicateWebhook — two-tier idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.markIdempotency.mockResolvedValue(undefined);
+    mocks.query.mockResolvedValue([{ id: 1 }]); // INSERT succeeded
+  });
+
+  it("returns isDuplicate=false on first encounter", async () => {
+    const result = await deduplicateWebhook("twilio_sms", "SM_first_001");
+
+    expect(result.isDuplicate).toBe(false);
+    expect(result.source).toBe("twilio_sms");
+    expect(result.eventSid).toBe("SM_first_001");
+  });
+
+  it("checks Redis first", async () => {
+    await deduplicateWebhook("twilio_sms", "SM_redis_check");
+
+    expect(mocks.checkIdempotency).toHaveBeenCalledWith("twilio_sms:SM_redis_check");
+  });
+
+  it("returns isDuplicate=true when Redis reports hit", async () => {
+    mocks.checkIdempotency.mockResolvedValueOnce(true);
+
+    const result = await deduplicateWebhook("stripe", "evt_redis_hit");
+
+    expect(result.isDuplicate).toBe(true);
+    // Should NOT have queried DB (fast path)
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("returns isDuplicate=true when DB INSERT conflicts (Redis miss)", async () => {
+    mocks.checkIdempotency.mockResolvedValue(false);
+    // INSERT returns no rows = conflict (ON CONFLICT DO NOTHING)
+    mocks.query.mockResolvedValueOnce([]);
+
+    const result = await deduplicateWebhook("twilio_voice_status", "CA_db_conflict");
+
+    expect(result.isDuplicate).toBe(true);
+    // Should backfill Redis
+    expect(mocks.markIdempotency).toHaveBeenCalledWith("twilio_voice_status:CA_db_conflict");
+  });
+
+  it("marks Redis after successful DB insert (new event)", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: 42 }]); // INSERT succeeded
+
+    await deduplicateWebhook("twilio_sms", "SM_new_event");
+
+    expect(mocks.markIdempotency).toHaveBeenCalledWith("twilio_sms:SM_new_event");
+  });
+
+  it("inserts correct values into webhook_events table", async () => {
+    await deduplicateWebhook("stripe", "evt_insert_check", "tenant-uuid-123");
+
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO webhook_events"),
+      ["stripe", "evt_insert_check", "tenant-uuid-123"]
+    );
+  });
+
+  it("passes null tenant_id when not provided", async () => {
+    await deduplicateWebhook("twilio_voice", "CA_no_tenant");
+
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO webhook_events"),
+      ["twilio_voice", "CA_no_tenant", null]
+    );
+  });
+
+  it("handles Redis being down gracefully (falls through to DB)", async () => {
+    mocks.checkIdempotency.mockRejectedValueOnce(new Error("Redis connection refused"));
+    mocks.query.mockResolvedValueOnce([{ id: 1 }]); // DB insert succeeds
+
+    const result = await deduplicateWebhook("twilio_sms", "SM_redis_down");
+
+    expect(result.isDuplicate).toBe(false);
+    // Should still try to mark Redis (even if it might fail again)
+    expect(mocks.markIdempotency).toHaveBeenCalled();
+  });
+
+  it("handles DB being down gracefully (processes event)", async () => {
+    mocks.checkIdempotency.mockResolvedValue(false);
+    mocks.query.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const result = await deduplicateWebhook("twilio_sms", "SM_db_down");
+
+    // Should NOT mark as duplicate — better to double-process than drop
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  it("works for all webhook source types", async () => {
+    const sources = [
+      "twilio_sms",
+      "twilio_voice",
+      "twilio_voice_status",
+      "stripe",
+    ] as const;
+
+    for (const source of sources) {
+      vi.clearAllMocks();
+      mocks.checkIdempotency.mockResolvedValue(false);
+      mocks.query.mockResolvedValue([{ id: 1 }]);
+
+      const result = await deduplicateWebhook(source, `test-${source}`);
+      expect(result.isDuplicate).toBe(false);
+      expect(result.source).toBe(source);
+    }
+  });
+});

--- a/db/migrations/024_webhook_events.sql
+++ b/db/migrations/024_webhook_events.sql
@@ -1,0 +1,22 @@
+-- Persistent webhook idempotency table.
+-- Redis TTL-based idempotency expires after 24h; this table is the permanent
+-- source of truth to prevent duplicate processing on webhook replays.
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+  id            BIGSERIAL PRIMARY KEY,
+  source        TEXT NOT NULL,          -- 'twilio_sms' | 'twilio_voice' | 'twilio_voice_status' | 'stripe'
+  event_sid     TEXT NOT NULL,          -- MessageSid / CallSid / Stripe event.id
+  tenant_id     UUID,                   -- nullable (may not be known at dedup time)
+  processed     BOOLEAN NOT NULL DEFAULT TRUE,
+  received_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  processed_at  TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(source, event_sid)
+);
+
+-- Index for fast lookups during webhook handling
+CREATE INDEX IF NOT EXISTS idx_webhook_events_source_sid
+  ON webhook_events (source, event_sid);
+
+-- Index for monitoring/cleanup queries
+CREATE INDEX IF NOT EXISTS idx_webhook_events_received_at
+  ON webhook_events (received_at);


### PR DESCRIPTION
## Summary

- Adds persistent `webhook_events` PostgreSQL table as permanent idempotency source of truth (Migration 024)
- Implements two-tier dedup (Redis fast check + DB persistent check) for all webhooks: Twilio SMS, Voice, Voice-Status, and Stripe
- Adds Voice webhook idempotency (previously had **zero** dedup — critical gap)
- Adds outbound SMS dedup: blocks identical message re-send within 30s window
- Adds structured logging for all duplicate detection events (`webhook_duplicate_detected`, `booking_duplicate_blocked`, `sms_duplicate_blocked`)

## Why P0

Without persistent idempotency, Redis flush or 24h TTL expiry allows duplicate processing on webhook replays. Twilio retries webhooks on timeout. Queue retries re-process events. This causes: duplicate conversations, double bookings, SMS spam, incorrect billing counts — all trust-destroying for paying customers.

## What was changed

| File | Change |
|------|--------|
| `db/migrations/024_webhook_events.sql` | New table with `UNIQUE(source, event_sid)` |
| `apps/api/src/db/webhook-events.ts` | `deduplicateWebhook()` — two-tier check-and-mark |
| `apps/api/src/routes/webhooks/twilio-sms.ts` | Redis-only → two-tier dedup |
| `apps/api/src/routes/webhooks/twilio-voice.ts` | **Added** idempotency (was missing) |
| `apps/api/src/routes/webhooks/twilio-voice-status.ts` | Redis-only → two-tier dedup |
| `apps/api/src/routes/webhooks/stripe.ts` | Redis-only → two-tier dedup |
| `apps/api/src/services/process-sms.ts` | SMS send dedup (30s window) |
| `apps/api/src/services/appointments.ts` | Structured log on booking upsert |
| 5 test files | Updated mocks for new `deduplicateWebhook` API |
| `apps/api/src/tests/webhook-idempotency.test.ts` | 10 new tests for dedup module |

## Test plan

- [x] 548 tests passed, 0 failures
- [x] TypeScript compiles clean
- [x] Lint: 0 errors on changed files
- [x] New tests cover: first encounter, Redis hit, DB conflict, Redis down, DB down, all source types
- [ ] Run migration 024 on production database
- [ ] Monitor structured logs for `webhook_duplicate_detected` events after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)