### PR TITLE
feat: readonly verification endpoints + operator playbook

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -29,6 +29,10 @@ import { getAlerts, acknowledgeAlert, countUnacknowledgedAlerts } from "../../se
  *   GET /internal/admin/audit
  *   GET /internal/admin/metrics/conversation-health
  *   GET /internal/admin/tenants/:id/health
+ *   GET /internal/admin/verification/webhook-events
+ *   GET /internal/admin/verification/duplicate-evidence
+ *   GET /internal/admin/verification/booking-dedup
+ *   GET /internal/admin/verification/sms-dedup
  */
 export async function adminRoute(app: FastifyInstance) {
   // ── No-cache headers for all admin responses ──────────────────────────────
@@ -1349,5 +1353,114 @@ export async function adminRoute(app: FastifyInstance) {
     const updated = await acknowledgeAlert(id, adminEmail);
     if (!updated) return reply.status(404).send({ error: "Alert not found or already acknowledged" });
     return reply.send({ acknowledged: true });
+  });
+
+  // ── GET /internal/admin/verification/webhook-events ──────────────────────
+  // Readonly view of webhook_events table for duplicate-block verification.
+  app.get("/admin/verification/webhook-events", { preHandler: [adminGuard] }, async (req, reply) => {
+    const q = req.query as { source?: string; event_sid?: string; limit?: string };
+    const limit = Math.min(parseInt(q.limit || "50", 10) || 50, 200);
+
+    let sql = `SELECT id, source, event_sid, tenant_id, processed, received_at, processed_at
+               FROM webhook_events`;
+    const params: (string | number)[] = [];
+    const conditions: string[] = [];
+
+    if (q.source) {
+      conditions.push(`source = $${params.length + 1}`);
+      params.push(q.source);
+    }
+    if (q.event_sid) {
+      conditions.push(`event_sid = $${params.length + 1}`);
+      params.push(q.event_sid);
+    }
+
+    if (conditions.length > 0) {
+      sql += ` WHERE ${conditions.join(" AND ")}`;
+    }
+    sql += ` ORDER BY received_at DESC LIMIT $${params.length + 1}`;
+    params.push(limit);
+
+    const rows = await query(sql, params);
+    return reply.send({ webhook_events: rows, count: (rows as any[]).length });
+  });
+
+  // ── GET /internal/admin/verification/duplicate-evidence ──────────────────
+  // Summary: webhook event counts by source within a time window.
+  app.get("/admin/verification/duplicate-evidence", { preHandler: [adminGuard] }, async (req, reply) => {
+    const q = req.query as { hours?: string };
+    const hours = Math.min(parseInt(q.hours || "24", 10) || 24, 168);
+
+    const summary = await query(
+      `SELECT source, COUNT(*)::int AS total_events,
+              COUNT(DISTINCT event_sid)::int AS unique_sids
+       FROM webhook_events
+       WHERE received_at >= NOW() - ($1 || ' hours')::interval
+       GROUP BY source
+       ORDER BY source`,
+      [hours.toString()]
+    );
+
+    const recentEvents = await query(
+      `SELECT source, event_sid, tenant_id, received_at
+       FROM webhook_events
+       WHERE received_at >= NOW() - ($1 || ' hours')::interval
+       ORDER BY received_at DESC
+       LIMIT 100`,
+      [hours.toString()]
+    );
+
+    return reply.send({
+      window_hours: hours,
+      by_source: summary,
+      recent_events: recentEvents,
+    });
+  });
+
+  // ── GET /internal/admin/verification/booking-dedup ────────────────────────
+  // Check for booking dedup evidence via appointments table.
+  app.get("/admin/verification/booking-dedup", { preHandler: [adminGuard] }, async (req, reply) => {
+    const q = req.query as { tenant_id?: string; limit?: string };
+    const limit = Math.min(parseInt(q.limit || "20", 10) || 20, 100);
+
+    let sql = `SELECT a.id, a.tenant_id, a.conversation_id, a.customer_name,
+                      a.service_type, a.status, a.created_at, a.updated_at,
+                      (a.updated_at > a.created_at + interval '1 second') AS was_updated
+               FROM appointments a`;
+    const params: (string | number)[] = [];
+
+    if (q.tenant_id) {
+      sql += ` WHERE a.tenant_id = $1`;
+      params.push(q.tenant_id);
+    }
+
+    sql += ` ORDER BY a.created_at DESC LIMIT $${params.length + 1}`;
+    params.push(limit);
+
+    const rows = await query(sql, params);
+    return reply.send({ appointments: rows, count: (rows as any[]).length });
+  });
+
+  // ── GET /internal/admin/verification/sms-dedup ────────────────────────────
+  // Check for SMS send dedup evidence via messages table.
+  app.get("/admin/verification/sms-dedup", { preHandler: [adminGuard] }, async (req, reply) => {
+    const q = req.query as { conversation_id?: string; limit?: string };
+    const limit = Math.min(parseInt(q.limit || "30", 10) || 30, 100);
+
+    let sql = `SELECT m.id, m.conversation_id, m.direction, m.body,
+                      m.twilio_sid, m.sent_at, m.created_at
+               FROM messages m`;
+    const params: (string | number)[] = [];
+
+    if (q.conversation_id) {
+      sql += ` WHERE m.conversation_id = $1`;
+      params.push(q.conversation_id);
+    }
+
+    sql += ` ORDER BY m.created_at DESC LIMIT $${params.length + 1}`;
+    params.push(limit);
+
+    const rows = await query(sql, params);
+    return reply.send({ messages: rows, count: (rows as any[]).length });
   });
 }

--- a/docs/verification-playbook.md
+++ b/docs/verification-playbook.md
@@ -1,0 +1,246 @@
+# Production Duplicate-Protection Verification Playbook
+
+Strict operator playbook for proving each duplicate-protection path works in production.
+
+---
+
+## Prerequisites
+
+### Required Credentials
+
+| Credential | How to Obtain | Where Used |
+|------------|--------------|------------|
+| Admin JWT | `POST /auth/login` with admin email/password (email must be in `ADMIN_EMAILS` env) | All verification endpoints |
+| Render Dashboard | https://dashboard.render.com — service owner access | Log inspection, log drain setup |
+| Production API URL | `https://autoshopsmsai.com` | API calls |
+
+### Log Drain Setup (One-Time)
+
+1. Open Render Dashboard → `autoshop-api` service → **Logs** tab
+2. Click **Add Log Drain**
+3. Choose provider (Papertrail recommended for simplicity, Datadog for dashboards)
+4. Once active, all structured JSON logs are forwarded and searchable
+
+**Structured log events to search for:**
+- `webhook_duplicate_detected` — webhook replay blocked
+- `booking_duplicate_blocked` — duplicate appointment creation blocked
+- `sms_duplicate_blocked` — duplicate SMS send blocked
+
+### Obtaining Admin JWT
+
+```bash
+# 1. If no admin account exists, bootstrap one (requires ADMIN_BOOTSTRAP_KEY):
+curl -X POST https://autoshopsmsai.com/auth/bootstrap \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<admin-email>","password":"<password>","bootstrapKey":"<ADMIN_BOOTSTRAP_KEY>"}'
+
+# 2. Login to get JWT:
+TOKEN=$(curl -s -X POST https://autoshopsmsai.com/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<admin-email>","password":"<password>"}' | jq -r '.token')
+```
+
+---
+
+## Proof 1: SMS Webhook Replay Blocked
+
+**What it proves:** Sending the same `MessageSid` twice does not trigger duplicate processing.
+
+### Evidence Source
+Admin API: `GET /internal/admin/verification/webhook-events?source=twilio_sms`
+
+### Procedure
+
+```bash
+# 1. Check current webhook events for twilio_sms
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?source=twilio_sms&limit=10" | jq .
+
+# 2. Send a test replay (same MessageSid twice):
+DEDUP_SID="SM_VERIFY_$(date +%s)"
+
+curl -X POST https://autoshopsmsai.com/webhooks/twilio/sms \
+  -d "MessageSid=$DEDUP_SID&From=%2B15551234567&To=%2B13257523890&Body=test"
+
+curl -X POST https://autoshopsmsai.com/webhooks/twilio/sms \
+  -d "MessageSid=$DEDUP_SID&From=%2B15551234567&To=%2B13257523890&Body=test"
+
+# 3. Check that only ONE row exists for this event_sid:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?event_sid=$DEDUP_SID" | jq .
+
+# 4. Check logs (Render Dashboard or log drain) for:
+#    event: "webhook_duplicate_detected", source: "twilio_sms", MessageSid: $DEDUP_SID
+```
+
+### Pass Condition
+- `webhook_events` table contains exactly **1 row** for the test `event_sid`
+- Second request returns HTTP 200 with `<Response/>` (same as first — by design)
+- Log drain shows `webhook_duplicate_detected` for the second request
+- **OR** Render Dashboard logs show the structured log entry
+
+### Fail Condition
+- Two rows appear for the same `event_sid` (UNIQUE constraint violation would prevent this, but check)
+- No `webhook_duplicate_detected` log for the replay
+
+---
+
+## Proof 2: Stripe Webhook Replay Blocked
+
+**What it proves:** Sending the same Stripe `event.id` twice does not trigger duplicate billing processing.
+
+### Evidence Source
+Admin API: `GET /internal/admin/verification/webhook-events?source=stripe`
+
+### Procedure
+
+```bash
+# Note: Stripe webhooks require valid signature (STRIPE_WEBHOOK_SECRET).
+# Use Stripe CLI for replay testing:
+
+# 1. Install Stripe CLI and login
+stripe login
+
+# 2. Trigger a test event (creates unique event.id):
+stripe trigger checkout.session.completed
+
+# 3. Re-send the same event via Stripe Dashboard > Webhooks > Resend
+# Or use stripe events resend <event_id>
+
+# 4. Check webhook_events for stripe source:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?source=stripe&limit=10" | jq .
+
+# 5. Check logs for webhook_duplicate_detected with source: "stripe"
+```
+
+### Pass Condition
+- Only **1 row** per Stripe `event.id` in `webhook_events`
+- Replay log shows `webhook_duplicate_detected` for stripe source
+
+### Fail Condition
+- Multiple rows for same event ID
+- No duplicate detection log on replay
+
+---
+
+## Proof 3: Booking Duplicate Blocked
+
+**What it proves:** Creating two appointments for the same `conversation_id` does not create duplicate records (uses `ON CONFLICT` upsert).
+
+### Evidence Source
+Admin API: `GET /internal/admin/verification/booking-dedup`
+
+### Procedure
+
+```bash
+# 1. List recent appointments to find a conversation_id:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/booking-dedup?limit=10" | jq .
+
+# 2. Check for any appointment where was_updated=true
+#    (indicates ON CONFLICT triggered — the row was updated, not duplicated)
+
+# 3. Check log drain for "booking_duplicate_blocked" events:
+#    Search: event:"booking_duplicate_blocked"
+
+# 4. Verify UNIQUE constraint exists on appointments table:
+#    (already proven by migration 024 and unit tests — 548 passing)
+```
+
+### Pass Condition
+- No two appointments share the same `conversation_id`
+- Any `was_updated=true` appointment confirms the upsert path worked
+- Log drain shows `booking_duplicate_blocked` if a real duplicate was attempted
+- **OR** unit test suite confirms dedup logic (548 tests passing)
+
+### Fail Condition
+- Two appointments with identical `conversation_id`
+- Upsert silently drops data without logging
+
+---
+
+## Proof 4: SMS Duplicate-Send Blocked
+
+**What it proves:** The same outbound SMS is not sent twice within a 30-second window for the same conversation.
+
+### Evidence Source
+Admin API: `GET /internal/admin/verification/sms-dedup`
+
+### Procedure
+
+```bash
+# 1. List recent messages for a known conversation:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/sms-dedup?limit=30" | jq .
+
+# 2. For a specific conversation, check outbound messages:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/sms-dedup?conversation_id=<uuid>&limit=30" | jq .
+
+# 3. Check that no two outbound messages with identical body
+#    have sent_at timestamps within 30 seconds of each other
+
+# 4. Check log drain for "sms_duplicate_blocked" events:
+#    Search: event:"sms_duplicate_blocked"
+```
+
+### Pass Condition
+- No identical outbound messages within 30s in the same conversation
+- Log drain shows `sms_duplicate_blocked` if a real duplicate send was attempted
+- **OR** timing analysis of messages table shows no sub-30s identical sends
+
+### Fail Condition
+- Two identical outbound messages within 30s for the same conversation
+- `sms_duplicate_blocked` never fires despite queue retries
+
+---
+
+## Quick Verification Summary
+
+Run after obtaining `$TOKEN`:
+
+```bash
+# Full duplicate evidence summary (last 24 hours):
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/duplicate-evidence?hours=24" | jq .
+
+# Webhook events by source:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?source=twilio_sms&limit=5" | jq .
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?source=twilio_voice&limit=5" | jq .
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/webhook-events?source=stripe&limit=5" | jq .
+
+# Booking dedup:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/booking-dedup?limit=10" | jq .
+
+# SMS dedup:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://autoshopsmsai.com/internal/admin/verification/sms-dedup?limit=10" | jq .
+```
+
+---
+
+## Access Methods (Priority Order)
+
+| Method | Setup Effort | Evidence Quality | Status |
+|--------|-------------|-----------------|--------|
+| Admin verification endpoints | Zero (deployed with API) | Direct DB evidence | **Available after deploy** |
+| Render Dashboard logs | Zero | Structured log text search | **Available now** |
+| Log drain (Papertrail/Datadog) | 5 min Render config | Searchable, alertable, persistent | **Requires one-time setup** |
+| Production DB readonly | Render Dashboard > Database > External Access | Full SQL access | **Available via Render** |
+
+## Render Log Drain Setup (Recommended)
+
+1. Go to https://dashboard.render.com
+2. Select `autoshop-api` service
+3. Click **Logs** in sidebar
+4. Click **Add Log Drain** (top right)
+5. For Papertrail: enter syslog endpoint from Papertrail account
+6. For Datadog: enter Datadog log intake URL with API key
+7. Once active, search for structured events by `event` field
+
+This makes all `webhook_duplicate_detected`, `booking_duplicate_blocked`, and `sms_duplicate_blocked` events permanently searchable and alertable.

--- a/render.yaml
+++ b/render.yaml
@@ -78,6 +78,14 @@ services:
       - key: ADMIN_BOOTSTRAP_KEY
         sync: false
 
+      # ── Log drain (set in Render Dashboard) ───────────────────────────
+      # Configure via Render Dashboard > Service > Logs > Add Log Drain
+      # Supported: Papertrail, Datadog, Logflare, syslog endpoint
+      # Once active, structured logs (webhook_duplicate_detected,
+      # booking_duplicate_blocked, sms_duplicate_blocked) become searchable.
+      - key: LOG_LEVEL
+        value: "info"
+
   # ── Redis ───────────────────────────────────────────────────────────────────
   - type: redis
     name: autoshop-redis


### PR DESCRIPTION
## Summary
- Add 4 admin-protected readonly verification endpoints for production duplicate-block evidence
- Add operator verification playbook with exact procedures for all 4 proof types
- Document log drain setup path in render.yaml

## New Endpoints (all require admin JWT)
- `GET /internal/admin/verification/webhook-events` — query webhook_events by source/event_sid
- `GET /internal/admin/verification/duplicate-evidence` — summary counts by source within time window
- `GET /internal/admin/verification/booking-dedup` — appointment dedup evidence with was_updated flag
- `GET /internal/admin/verification/sms-dedup` — message table for send-dedup evidence

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 548 tests pass (0 failures)
- [x] All endpoints protected by existing adminGuard (JWT + ADMIN_EMAILS)
- [x] No new dependencies
- [ ] After deploy: obtain admin JWT and run playbook quick verification commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)