### PR TITLE
fix: correct column names in verification endpoints

### DIFF
--- a/apps/api/src/routes/internal/admin.ts
+++ b/apps/api/src/routes/internal/admin.ts
@@ -1424,8 +1424,8 @@ export async function adminRoute(app: FastifyInstance) {
     const limit = Math.min(parseInt(q.limit || "20", 10) || 20, 100);
 
     let sql = `SELECT a.id, a.tenant_id, a.conversation_id, a.customer_name,
-                      a.service_type, a.status, a.created_at, a.updated_at,
-                      (a.updated_at > a.created_at + interval '1 second') AS was_updated
+                      a.service_type, a.booking_state, a.calendar_synced,
+                      a.created_at, a.scheduled_at
                FROM appointments a`;
     const params: (string | number)[] = [];
 
@@ -1448,7 +1448,7 @@ export async function adminRoute(app: FastifyInstance) {
     const limit = Math.min(parseInt(q.limit || "30", 10) || 30, 100);
 
     let sql = `SELECT m.id, m.conversation_id, m.direction, m.body,
-                      m.twilio_sid, m.sent_at, m.created_at
+                      m.twilio_sid, m.sent_at
                FROM messages m`;
     const params: (string | number)[] = [];
 
@@ -1457,7 +1457,7 @@ export async function adminRoute(app: FastifyInstance) {
       params.push(q.conversation_id);
     }
 
-    sql += ` ORDER BY m.created_at DESC LIMIT $${params.length + 1}`;
+    sql += ` ORDER BY m.sent_at DESC LIMIT $${params.length + 1}`;
     params.push(limit);
 
     const rows = await query(sql, params);

--- a/docs/verification-playbook.md
+++ b/docs/verification-playbook.md
@@ -138,19 +138,18 @@ Admin API: `GET /internal/admin/verification/booking-dedup`
 curl -s -H "Authorization: Bearer $TOKEN" \
   "https://autoshopsmsai.com/internal/admin/verification/booking-dedup?limit=10" | jq .
 
-# 2. Check for any appointment where was_updated=true
-#    (indicates ON CONFLICT triggered — the row was updated, not duplicated)
+# 2. Check that no two appointments share the same conversation_id
+#    (UNIQUE constraint prevents duplicates — ON CONFLICT upsert)
 
 # 3. Check log drain for "booking_duplicate_blocked" events:
 #    Search: event:"booking_duplicate_blocked"
 
 # 4. Verify UNIQUE constraint exists on appointments table:
-#    (already proven by migration 024 and unit tests — 548 passing)
+#    (already proven by migration and unit tests — 548 passing)
 ```
 
 ### Pass Condition
 - No two appointments share the same `conversation_id`
-- Any `was_updated=true` appointment confirms the upsert path worked
 - Log drain shows `booking_duplicate_blocked` if a real duplicate was attempted
 - **OR** unit test suite confirms dedup logic (548 tests passing)
 


### PR DESCRIPTION
## Summary
- Fix booking-dedup endpoint: use actual columns (booking_state, calendar_synced) instead of nonexistent (status, updated_at)
- Fix sms-dedup endpoint: use sent_at instead of nonexistent created_at
- Discovered via live production testing

## Test plan
- [x] tsc --noEmit passes
- [ ] After deploy: verify all 4 endpoints return 200 with valid data

🤖 Generated with [Claude Code](https://claude.com/claude-code)