### PR TITLE
chore: rotate admin password, document secure bootstrap flow

### DIFF
--- a/AI_STATUS.md
+++ b/AI_STATUS.md
@@ -9,6 +9,34 @@ missed call -> SMS -> AI conversation -> appointment booking -> Google Calendar
 
 ---
 
+## TASK: credential-hardening-cleanup — 2026-03-20
+
+**Status:** CLEANED AND SAFE — Static password hashes rotated, bootstrap flow documented as permanent access model
+
+### What Was Done
+1. Migration 026 rotates admin password to a random unknown hash, invalidating the static hashes from migrations 011 and 025
+2. Verification playbook updated to document the secure bootstrap flow (requires Render Dashboard access to obtain INTERNAL_API_KEY)
+3. No code changes to auth logic — existing bootstrap endpoint is the permanent access model
+
+### Security Risk Addressed
+- Migrations 011 and 025 contained static bcrypt hashes in committed files
+- The plaintext for migration 025 was used in a prior session's curl commands
+- After migration 026, neither hash is valid — admin must use the bootstrap endpoint with a server-side secret
+
+### Permanent Access Model
+1. Operator opens Render Dashboard → copies INTERNAL_API_KEY
+2. Calls `POST /auth/admin-bootstrap` with the key + new password + `force:true`
+3. Calls `POST /auth/login` to get JWT
+4. Uses JWT for all admin/verification endpoints
+
+### Verification Endpoints — Still Usable
+All 4 endpoints remain deployed and functional. Only the password changed — after bootstrap, the JWT flow works identically.
+
+### Action Required (Human)
+After deploy of migration 026, the operator must run the bootstrap endpoint to set a new password before admin access works again. See `docs/verification-playbook.md` for exact steps.
+
+---
+
 ## TASK: observability-access-hardening — 2026-03-20
 
 **Status:** ACTIVE AND USABLE — All 4 verification endpoints deployed, authenticated, and returning real production data

--- a/db/migrations/026_rotate_admin_password.sql
+++ b/db/migrations/026_rotate_admin_password.sql
@@ -1,0 +1,19 @@
+-- Rotate admin password to invalidate static hashes from migrations 011 and 025.
+--
+-- Migrations 011 and 025 set static bcrypt hashes in committed files, which is
+-- a credential artifact in git history. This migration replaces the hash with a
+-- random value that nobody knows the plaintext for.
+--
+-- After this migration runs, the admin must use the bootstrap endpoint to set
+-- a new password:
+--
+--   POST /auth/admin-bootstrap
+--   Header: x-internal-key: <ADMIN_BOOTSTRAP_KEY from Render Dashboard>
+--   Body: {"email":"mantas.gipiskis@gmail.com","password":"<new-password>","force":true}
+--
+-- The operator must first set ADMIN_BOOTSTRAP_KEY in Render Dashboard if not
+-- already configured.
+
+UPDATE tenants
+SET password_hash = '$2b$12$PyU8/.9z/csUpdP9vb9ZL.uSFFhuK4u7Ej2mTAkhM0DjNQle6fFVy'
+WHERE owner_email = 'mantas.gipiskis@gmail.com';

--- a/docs/verification-playbook.md
+++ b/docs/verification-playbook.md
@@ -28,17 +28,35 @@ Strict operator playbook for proving each duplicate-protection path works in pro
 
 ### Obtaining Admin JWT
 
-```bash
-# 1. If no admin account exists, bootstrap one (requires ADMIN_BOOTSTRAP_KEY):
-curl -X POST https://autoshopsmsai.com/auth/bootstrap \
-  -H "Content-Type: application/json" \
-  -d '{"email":"<admin-email>","password":"<password>","bootstrapKey":"<ADMIN_BOOTSTRAP_KEY>"}'
+**Step 1: Set admin password (one-time, requires Render Dashboard access)**
 
-# 2. Login to get JWT:
+The admin password is not stored in code or git. To set or reset it:
+
+1. Open Render Dashboard → `autoshop-api` → Environment
+2. Copy the value of `INTERNAL_API_KEY` (or set `ADMIN_BOOTSTRAP_KEY` if preferred)
+3. Run the bootstrap endpoint:
+
+```bash
+# Set/reset admin password via bootstrap (requires INTERNAL_API_KEY or ADMIN_BOOTSTRAP_KEY):
+curl -X POST https://autoshopsmsai.com/auth/admin-bootstrap \
+  -H "Content-Type: application/json" \
+  -H "x-internal-key: <KEY_FROM_RENDER_DASHBOARD>" \
+  -d '{"email":"mantas.gipiskis@gmail.com","password":"<choose-a-strong-password>","force":true}'
+```
+
+**Step 2: Login to get JWT**
+
+```bash
 TOKEN=$(curl -s -X POST https://autoshopsmsai.com/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"<admin-email>","password":"<password>"}' | jq -r '.token')
+  -d '{"email":"mantas.gipiskis@gmail.com","password":"<your-password>"}' | jq -r '.token')
 ```
+
+**Security notes:**
+- Never commit passwords or plaintext credentials to the repository
+- The bootstrap endpoint requires a server-side secret not available in git
+- Admin email must be in the `ADMIN_EMAILS` env var allowlist
+- JWTs expire after 24 hours
 
 ---
 


### PR DESCRIPTION
## Summary
- Migration 026 rotates admin password to random unknown hash, invalidating static hashes from migrations 011 and 025
- Updated verification playbook with secure bootstrap instructions (requires Render Dashboard access)
- No code changes to auth logic — existing bootstrap endpoint is the permanent model

## Security issue addressed
Migrations 011 and 025 contained static bcrypt hashes in committed files. The plaintext for migration 025 was used in a prior session. After migration 026 deploys, neither hash is valid.

## Action required after merge
The operator must run the bootstrap endpoint to set a new password:
1. Copy `INTERNAL_API_KEY` from Render Dashboard
2. `POST /auth/admin-bootstrap` with the key + new password + `force:true`
3. `POST /auth/login` to get JWT

## Test plan
- [x] tsc --noEmit passes
- [x] 548/548 tests pass
- [x] Migration is idempotent UPDATE
- [x] Verification endpoints unchanged
- [ ] After deploy: bootstrap new password via Render Dashboard key

🤖 Generated with [Claude Code](https://claude.com/claude-code)