### PR TITLE
feat(tenants): add isPilotTenant and isUsTenant helpers (unused)

### DIFF
--- a/apps/api/src/tests/tenant-region.test.ts
+++ b/apps/api/src/tests/tenant-region.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { isPilotTenant, isUsTenant } from "../utils/tenant-region";
+
+describe("tenant-region helpers", () => {
+  it("isPilotTenant returns true when is_pilot_tenant is true", () => {
+    expect(isPilotTenant({ is_pilot_tenant: true })).toBe(true);
+  });
+
+  it("isPilotTenant returns false when is_pilot_tenant is false", () => {
+    expect(isPilotTenant({ is_pilot_tenant: false })).toBe(false);
+  });
+
+  it("isUsTenant returns false when is_pilot_tenant is true", () => {
+    expect(isUsTenant({ is_pilot_tenant: true })).toBe(false);
+  });
+
+  it("isUsTenant returns true when is_pilot_tenant is false", () => {
+    expect(isUsTenant({ is_pilot_tenant: false })).toBe(true);
+  });
+
+  it.each([
+    { is_pilot_tenant: true },
+    { is_pilot_tenant: false },
+  ])("isPilotTenant and isUsTenant are pure inverses for %o", (t) => {
+    expect(isPilotTenant(t)).toBe(!isUsTenant(t));
+  });
+});

--- a/apps/api/src/utils/tenant-region.ts
+++ b/apps/api/src/utils/tenant-region.ts
@@ -1,0 +1,21 @@
+import type { Tenant } from "../db/tenants";
+
+/**
+ * Returns true if the tenant is a free pilot (non-US) tenant, e.g. LT Proteros Servisas.
+ * Use this to guard US-specific logic (Stripe area code extraction, Texas number provisioning, A2P checks).
+ * TODO: when multi-region launch is planned, replace this with proper region logic (country_code column, etc).
+ * See LT/US strategy docs.
+ */
+export function isPilotTenant(tenant: Pick<Tenant, "is_pilot_tenant">): boolean {
+  return tenant.is_pilot_tenant === true;
+}
+
+/**
+ * Returns true if the tenant is a standard US production tenant (not a pilot).
+ * Inverse of isPilotTenant. Prefer using this in positive guards (e.g. "if (isUsTenant(t)) runStripe...")
+ * for readability where the US path is the main branch.
+ * TODO: when multi-region launch is planned, replace with proper region check.
+ */
+export function isUsTenant(tenant: Pick<Tenant, "is_pilot_tenant">): boolean {
+  return tenant.is_pilot_tenant !== true;
+}


### PR DESCRIPTION
## Why
Step 2 of the LT/US pilot isolation plan. PR #491 added the `is_pilot_tenant` column; this PR introduces the read-side helpers that future guard PRs will use in `stripe.ts:241`, `twilio-provisioning.ts`, etc. **Nothing in production code calls these yet.**

## What
- `apps/api/src/utils/tenant-region.ts` (new) — two pure functions:
  - `isPilotTenant(tenant)` — `tenant.is_pilot_tenant === true`
  - `isUsTenant(tenant)` — `tenant.is_pilot_tenant !== true`
  - Both accept `Pick<Tenant, 'is_pilot_tenant'>` so callers/tests can pass lightweight objects without constructing a full `Tenant`.
  - Both have JSDoc with TODO notes for the future region-column refactor.
- `apps/api/src/tests/tenant-region.test.ts` (new) — 6 unit tests covering all 4 truth-table cases plus a parameterized inverse-symmetry check.

**Files:** 2 new files, +48 lines, 0 modifications to existing code.

## Verification
- `npm run build` (apps/api): exit 0
- `npm test` (apps/api): **741/741 passing, 50 files, exit 0** (was 735 before; +6 new tests, no regressions)

```
VERIFICATION
EXIT_CODE=0
TEST_FILES=50
TESTS_TOTAL=741
TESTS_FAILED=0
DURATION=20.47s
```

## Explicit
**These helpers are NOT USED anywhere in production code yet.** This PR is purely additive — imports are only from tests. A future PR will introduce them as guards in `stripe.ts:241` and `twilio-provisioning.ts`.

Follow-up to #491, #492.