### PR TITLE
feat(stripe): guard pilot tenants from Texas number provisioning

### DIFF
--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -6,6 +6,7 @@ import { billingQueue, provisionNumberQueue } from "../../queues/redis";
 import { deduplicateWebhook } from "../../db/webhook-events";
 import { getSharedTestNumber } from "../../utils/test-tenant";
 import { createLogger } from "../../utils/logger";
+import { isPilotTenant } from "../../utils/tenant-region";
 
 const log = createLogger("stripe-webhook");
 
@@ -228,14 +229,20 @@ async function routeStripeEvent(event: Stripe.Event, tenantId: string) {
           [tenantId]
         );
         if (existing.length === 0) {
-          const tenantRows = await query<{ shop_name: string; owner_phone: string | null; is_test: boolean }>(
-            `SELECT shop_name, owner_phone, is_test FROM tenants WHERE id = $1`,
+          const tenantRows = await query<{ shop_name: string; owner_phone: string | null; is_test: boolean; is_pilot_tenant: boolean }>(
+            `SELECT shop_name, owner_phone, is_test, is_pilot_tenant FROM tenants WHERE id = $1`,
             [tenantId]
           );
 
           // Test tenants: skip Twilio purchase entirely — dashboard shows shared number via fallback
           if (tenantRows[0]?.is_test) {
             log.info({ tenantId }, "Test tenant — skipping Twilio purchase (shared test number)");
+          // LT/US pilot isolation guard — skip US-specific Twilio provisioning for pilot tenants (e.g. LT Proteros). See LT/US strategy docs. TODO: replace with proper region logic when multi-region launch is planned.
+          } else if (tenantRows[0] && isPilotTenant(tenantRows[0])) {
+            log.info(
+              { tenantId, eventType: event.type, reason: "skipped Twilio provisioning: pilot tenant" },
+              "Pilot tenant — skipping Twilio purchase (LT/US isolation guard)"
+            );
           } else {
             const areaCode =
               tenantRows[0]?.owner_phone?.replace(/\D/g, "").slice(1, 4) || "512";

--- a/apps/api/src/tests/stripe-webhook.test.ts
+++ b/apps/api/src/tests/stripe-webhook.test.ts
@@ -262,6 +262,52 @@ describe("POST /webhooks/stripe", () => {
     await app.close();
   });
 
+  it("US tenant baseline — provisions Twilio number when is_pilot_tenant=false (regression)", async () => {
+    const sub = subscriptionObject();
+    const evt = makeEvent("customer.subscription.created", sub);
+    mocks.constructEvent.mockReturnValue(evt);
+
+    mocks.query
+      .mockResolvedValueOnce([]) // billing_events INSERT
+      .mockResolvedValueOnce([{ billing_status: "trial" }]) // SELECT billing_status
+      .mockResolvedValueOnce([]) // UPDATE tenants
+      .mockResolvedValueOnce([]) // SELECT tenant_phone_numbers (none)
+      .mockResolvedValueOnce([
+        { shop_name: "Joe's Auto", owner_phone: "+15125551234", is_test: false, is_pilot_tenant: false },
+      ]); // SELECT tenant
+
+    const app = await buildApp();
+    await postStripe(app);
+
+    expect(mocks.provisionQueueAdd).toHaveBeenCalledWith(
+      "provision-twilio-number",
+      expect.objectContaining({ tenantId: TEST_TENANT_ID, areaCode: "512", shopName: "Joe's Auto" }),
+      expect.any(Object)
+    );
+    await app.close();
+  });
+
+  it("LT pilot tenant — does NOT provision Twilio number when is_pilot_tenant=true", async () => {
+    const sub = subscriptionObject();
+    const evt = makeEvent("customer.subscription.created", sub);
+    mocks.constructEvent.mockReturnValue(evt);
+
+    mocks.query
+      .mockResolvedValueOnce([]) // billing_events INSERT
+      .mockResolvedValueOnce([{ billing_status: "trial" }]) // SELECT billing_status
+      .mockResolvedValueOnce([]) // UPDATE tenants
+      .mockResolvedValueOnce([]) // SELECT tenant_phone_numbers (none)
+      .mockResolvedValueOnce([
+        { shop_name: "Proteros Servisas", owner_phone: "+37067577829", is_test: false, is_pilot_tenant: true },
+      ]); // SELECT tenant
+
+    const app = await buildApp();
+    await postStripe(app);
+
+    expect(mocks.provisionQueueAdd).not.toHaveBeenCalled();
+    await app.close();
+  });
+
   it("does NOT provision number if tenant already has an active number", async () => {
     const sub = subscriptionObject();
     const evt = makeEvent("customer.subscription.created", sub);


### PR DESCRIPTION
## Why
First real guard PR in the LT/US pilot isolation plan (PRs #491/#492/#493 were schema + helpers + fixture fix). Addresses **P0 bug (b) from LT Proteros audit Apr 8 2026** — `apps/api/src/routes/webhooks/stripe.ts:241` extracts a Texas area code via `owner_phone.replace(/\D/g, "").slice(1, 4) || "512"`. For a `+370` Lithuanian phone this falls back to `"512"` (Austin), and on a paid upgrade would auto-provision a Texas Twilio number and silently overwrite LT Proteros' existing Zadarma number.

## What
Added an early-return guard in the `customer.subscription.created` branch, mirroring the existing `is_test` short-circuit shape.

**`apps/api/src/routes/webhooks/stripe.ts`** (+9, -2):
- New import: `import { isPilotTenant } from "../../utils/tenant-region";`
- Extended the inline tenant SELECT row type with `is_pilot_tenant: boolean` and added the column to the SELECT statement
- Added `else if (tenantRows[0] && isPilotTenant(tenantRows[0]))` branch right after the `is_test` skip, with the required TODO comment and a structured log: `{ tenantId, eventType, reason }`
- The US `else` block (area code derivation + `provisionNumberQueue.add`) is **byte-identical** to before this PR

**`apps/api/src/tests/stripe-webhook.test.ts`** (+46):
- New test: **US baseline regression** — `is_pilot_tenant=false` still provisions (areaCode `"512"`, shopName, jobId — all unchanged)
- New test: **LT pilot** — `is_pilot_tenant=true` → `provisionQueueAdd` not called

## Verification
- `npm run build` (apps/api): exit 0
- `npm test` (apps/api): **743/743 passing, 50 files, exit 0** (was 741; +2 new tests, no regressions)

```
VERIFICATION
EXIT_CODE=0
TEST_FILES=50
TESTS_TOTAL=743
TESTS_FAILED=0
DURATION=19.75s
```

## Diff review (manual)
```
 apps/api/src/routes/webhooks/stripe.ts    | 11 ++++++--
 apps/api/src/tests/stripe-webhook.test.ts | 46 ++++++++++++++++++++++++++++
 2 files changed, 55 insertions(+), 2 deletions(-)
```
Only insertions plus the SELECT/row-type extension. No reformatting, no moved lines, no semantic changes to the US path.

## US regression
The new "US baseline" test asserts that for `is_pilot_tenant=false`, `provisionQueueAdd` is still called with `areaCode: "512"` and `shopName: "Joe's Auto"` — identical to the pre-existing test. Existing US tests continue to pass.

## Verification plan post-merge
After merge, watch Render Events for a successful deploy. No manual prod test required — there are no prod scenarios that currently upgrade an LT tenant via Stripe.

Follow-up to #491, #492, #493.