### PR TITLE
feat(worker): guard pilot tenants from Texas number provisioning (defense in depth)

### DIFF
--- a/apps/api/src/tests/provision-worker-pilot-guard.test.ts
+++ b/apps/api/src/tests/provision-worker-pilot-guard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockQuery = vi.fn();
+const mockProvision = vi.fn();
+const mockVerify = vi.fn();
+const mockWelcome = vi.fn();
+
+vi.mock("../db/client", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+vi.mock("../queues/redis", () => ({
+  bullmqConnection: {},
+}));
+
+vi.mock("../queues/dead-letter", () => ({
+  moveToDeadLetter: vi.fn(),
+}));
+
+vi.mock("../services/twilio-provisioning", () => ({
+  provisionNumberForTenant: (...args: unknown[]) => mockProvision(...args),
+  verifyNumberInMessagingService: (...args: unknown[]) => mockVerify(...args),
+}));
+
+vi.mock("../services/welcome-email", () => ({
+  sendWelcomeEmailForProvisionedTenant: (...args: unknown[]) => mockWelcome(...args),
+}));
+
+import { __test__ } from "../workers/provision-number.worker";
+const { processProvisionJob } = __test__;
+
+const TENANT_ID = "00000000-0000-0000-0000-000000000abc";
+
+function makeJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job-1",
+    data: { tenantId: TENANT_ID, ...overrides },
+  } as any;
+}
+
+describe("provision-number worker — pilot tenant guard", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockProvision.mockReset();
+    mockVerify.mockReset();
+    mockWelcome.mockReset();
+  });
+
+  it("US tenant baseline — runs full provisioning when is_pilot_tenant=false (regression)", async () => {
+    mockQuery
+      .mockResolvedValueOnce(undefined) // setProvisioningState 'provisioning'
+      .mockResolvedValueOnce([
+        { shop_name: "Joe's Auto", owner_phone: "+15125551234", is_pilot_tenant: false },
+      ]) // SELECT tenant
+      .mockResolvedValueOnce([]) // SELECT existing tenant_phone_numbers (none)
+      .mockResolvedValueOnce(undefined) // INSERT tenant_phone_numbers
+      .mockResolvedValueOnce(undefined); // setProvisioningState 'ready'
+
+    mockProvision.mockResolvedValueOnce({
+      sid: "PN123",
+      phoneNumber: "+15125559999",
+      areaCodeUsed: "512",
+      attemptedAreaCodes: ["512"],
+    });
+
+    const result = await processProvisionJob(makeJob());
+
+    expect(mockProvision).toHaveBeenCalledTimes(1);
+    expect(mockProvision).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredAreaCode: "512", shopName: "Joe's Auto" }),
+    );
+    expect(result).toEqual({ success: true, phoneNumber: "+15125559999", sid: "PN123" });
+  });
+
+  it("LT pilot tenant — skips Twilio provisioning when is_pilot_tenant=true", async () => {
+    mockQuery
+      .mockResolvedValueOnce(undefined) // setProvisioningState 'provisioning'
+      .mockResolvedValueOnce([
+        { shop_name: "Proteros Servisas", owner_phone: "+37067577829", is_pilot_tenant: true },
+      ]) // SELECT tenant
+      .mockResolvedValueOnce(undefined); // setProvisioningState 'ready' (from guard)
+
+    const result = await processProvisionJob(makeJob());
+
+    expect(mockProvision).not.toHaveBeenCalled();
+    expect(mockVerify).not.toHaveBeenCalled();
+    expect(mockWelcome).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/api/src/workers/provision-number.worker.ts
+++ b/apps/api/src/workers/provision-number.worker.ts
@@ -8,6 +8,7 @@ import {
   verifyNumberInMessagingService,
 } from "../services/twilio-provisioning";
 import { sendWelcomeEmailForProvisionedTenant } from "../services/welcome-email";
+import { isPilotTenant } from "../utils/tenant-region";
 
 const log = createLogger("provision-worker");
 
@@ -72,14 +73,25 @@ async function processProvisionJob(job: Job): Promise<{
     const tenantRows = await query<{
       shop_name: string;
       owner_phone: string | null;
+      is_pilot_tenant: boolean;
     }>(
-      `SELECT shop_name, owner_phone FROM tenants WHERE id = $1 LIMIT 1`,
+      `SELECT shop_name, owner_phone, is_pilot_tenant FROM tenants WHERE id = $1 LIMIT 1`,
       [tenantId],
     );
     if (tenantRows.length === 0) {
       throw new Error(`tenant_not_found: ${tenantId}`);
     }
     const tenant = tenantRows[0]!;
+
+    // LT/US pilot isolation guard — second layer of defense. stripe.ts:241 is the first layer (PR #494). This guard protects against any code path that enqueues this job without going through the Stripe webhook. TODO: replace with proper region logic when multi-region launch is planned.
+    if (isPilotTenant(tenant)) {
+      log.info(
+        { tenantId, jobId: job.id, reason: "skipped Twilio provisioning: pilot tenant (worker layer)" },
+        "Pilot tenant — skipping Twilio purchase (LT/US isolation guard)",
+      );
+      await setProvisioningState(tenantId, "ready", null);
+      return { success: true };
+    }
 
     // Idempotency: if this tenant already has an active phone number
     // (e.g., a previous attempt purchased + service-added but the worker


### PR DESCRIPTION
## Why
Defense in depth for the LT/US pilot isolation plan. PR #494 added a guard at the Stripe webhook entry point (`stripe.ts:241`). This PR adds the same guard inside the BullMQ worker that actually purchases the Twilio number, so **any** future code path that enqueues `provision-twilio-number` (manual admin trigger, retry, internal automation) will refuse to provision a Texas number for a pilot tenant.

**Audit reference:** Second layer of defense for P0 bug (b) from LT Proteros audit Apr 8 2026.

## What
**`apps/api/src/workers/provision-number.worker.ts:84-93`** (+13, -1):
- New import: `import { isPilotTenant } from "../utils/tenant-region";`
- Extended the inline tenant SELECT row type and SELECT statement with `is_pilot_tenant: boolean`
- Added the guard right after `const tenant = tenantRows[0]!;` — runs **before** the idempotent existing-number check, so pilot tenants never touch any Twilio call inside this worker (not even the verify path).
- On guard hit: structured info log with `{ tenantId, jobId, reason }`, then `setProvisioningState(tenantId, "ready", null)` (so the row doesn't get stuck in `provisioning`), then `return { success: true }`. Returning resolves the BullMQ job as **completed** — no retry, no DLQ.
- The US code path below the guard is byte-identical to before this PR.

**`apps/api/src/tests/provision-worker-pilot-guard.test.ts`** (new, +90):
- **US baseline regression** — `is_pilot_tenant=false` → `provisionNumberForTenant` called once with `{ preferredAreaCode: "512", shopName: "Joe's Auto" }`, full success payload returned. Proves existing US worker behavior is unchanged.
- **LT pilot** — `is_pilot_tenant=true` → `provisionNumberForTenant` NOT called, `verifyNumberInMessagingService` NOT called, `sendWelcomeEmailForProvisionedTenant` NOT called, returns `{ success: true }`.
- Worker is exercised via the existing `__test__.processProvisionJob` export. Twilio/welcome-email/redis/dead-letter modules are mocked — no real API calls.

## Diff review
```
 apps/api/src/workers/provision-number.worker.ts | 14 +++++++++++++-
 1 file changed, 13 insertions(+), 1 deletion(-)
```
Production diff is purely additive (1 import, 1 row-type field, 1 SELECT field, 1 guard block). No reformatting, no moved lines, no changes to function signatures, return types, or queue options.

## Verification
- `npm run build` (apps/api): exit 0
- `npm test` (apps/api): **745/745 passing, 51 files, exit 0** (was 743; +2 new tests, no regressions)

```
VERIFICATION
EXIT_CODE=0
TEST_FILES=51
TESTS_TOTAL=745
TESTS_FAILED=0
DURATION=22.29s
```

## US regression
The new "US baseline" test asserts that for `is_pilot_tenant=false`, the worker still calls `provisionNumberForTenant({ preferredAreaCode: "512", shopName: "Joe's Auto" })` and returns the same `{ success, phoneNumber, sid }` shape. All 743 pre-existing tests continue to pass.

## Verification plan post-merge
After merge, watch Render Events for a successful deploy. Container should boot healthy — no new migration, no env var changes, no schema changes.

Follow-up to #494.