### PR TITLE
docs(twilio-provisioning): document LT/US isolation invariant for future callers

### DIFF
--- a/apps/api/src/services/twilio-provisioning.ts
+++ b/apps/api/src/services/twilio-provisioning.ts
@@ -15,6 +15,35 @@
 
 import { createLogger } from "../utils/logger";
 
+/**
+ * ⚠️ LT/US ISOLATION INVARIANT — READ BEFORE ADDING CALLERS
+ *
+ * This file contains US-specific Twilio provisioning logic. It assumes all tenants
+ * are US tenants. It hardcodes Texas area codes (see TEXAS_AREA_CODES below), uses
+ * +1 phone parsing, and will silently fall back to Austin 512 for any non-US phone
+ * number.
+ *
+ * Callers MUST guard against pilot tenants BEFORE calling any function in this file.
+ * Existing guards:
+ *   - apps/api/src/routes/webhooks/stripe.ts (PR #494)
+ *   - apps/api/src/workers/provision-number.worker.ts (PR #495)
+ *
+ * If you add a new caller, you MUST add an isPilotTenant() check before the call.
+ * See apps/api/src/utils/tenant-region.ts for the helper.
+ *
+ * Why this is a documentation invariant rather than an in-file code guard:
+ * provisionNumberForTenant returns a non-optional ProvisionResult { sid, phoneNumber,
+ * areaCodeUsed, attemptedAreaCodes }. Any "benign no-op" return for a pilot tenant
+ * would either (a) populate required fields with undefined and crash the caller's
+ * INSERT, (b) require widening ProvisionResult to a union with a `skipped` discriminator
+ * and updating dead-code paths in the already-guarded worker, or (c) throw an error
+ * that would trigger BullMQ retries and DLQ. None are cleaner than enforcing the
+ * invariant at every caller. See PR #496 for the full reasoning.
+ *
+ * TODO: when multi-region launch is planned, refactor this file to accept a region
+ * parameter and remove the invariant.
+ */
+
 const log = createLogger("twilio-provisioning");
 
 const TWILIO_API_BASE = "https://api.twilio.com/2010-04-01";


### PR DESCRIPTION
## Why
Final defense layer for the LT/US pilot isolation plan after caller-side guards in #494 (Stripe webhook) and #495 (BullMQ worker). Goal: prevent any *future* caller of `twilio-provisioning.ts` from forgetting that this file is US-only and Texas-area-code-hardcoded.

**Audit reference:** Final guard layer for P0 bug (b) from LT Proteros audit Apr 8 2026. Also documents the `TEXAS_AREA_CODES` hardcode at `twilio-provisioning.ts:28-30` mentioned in audit findings part 2.

## What — Variant chosen: C (documentation invariant)

Added a prominent doc-block at the top of `apps/api/src/services/twilio-provisioning.ts` (after the existing imports) that:
- Warns the file is US-only and Texas-fallback-hardcoded
- Lists the existing caller-side guards (#494, #495)
- Tells new callers they MUST add `isPilotTenant()` before calling in
- Points at `apps/api/src/utils/tenant-region.ts` for the helper
- Records the Variant decision and reasoning so future maintainers don't re-litigate it

**Diff:** 1 file, +29 lines, **0 code changes**.

## Why Variant C and not Variant A

Variant A (in-helper code guard) is technically possible — there's only **1 production caller** (`provision-number.worker.ts`, already guarded in #495), and `is_pilot_tenant` is already in scope there. But the **return-shape stop condition** is met: `provisionNumberForTenant` returns `ProvisionResult { sid, phoneNumber, areaCodeUsed, attemptedAreaCodes }` — all fields non-optional. Any "benign no-op" return for a pilot tenant would force one of:

1. Populate the required fields with `undefined` → caller's `INSERT INTO tenant_phone_numbers (..., result.sid, result.phoneNumber)` crashes. **Worse than today.**
2. Widen `ProvisionResult` to a union with a `skipped: true` discriminator → forces updating consumption logic in the worker (lines 153-179) for a code path that **cannot fire** because PR #495 already guards above it. Speculative complexity testing dead paths.
3. Throw `Error("pilot_tenant_provisioning_blocked")` → BullMQ marks job failed → 5 retries → DLQ. Fails loudly but for a path that's already guarded one layer up.

None are cleaner than enforcing the invariant at every caller, which is exactly what we already do. Variant C codifies that contract in the file itself.

## Callers found (production code only)
- `apps/api/src/workers/provision-number.worker.ts:6-9` — imports `provisionNumberForTenant`, `verifyNumberInMessagingService`. Already guarded (#495).

(Test files: `tests/twilio-provisioning.test.ts`, `tests/provision-worker-pilot-guard.test.ts` — not production callers.)

## Verification
- `npm run build` (apps/api): exit 0
- `npm test` (apps/api): **745/745 passing, 51 files, exit 0** (unchanged from #495 — Variant C adds no tests)

```
VERIFICATION
EXIT_CODE=0
TEST_FILES=51
TESTS_TOTAL=745
TESTS_FAILED=0
DURATION=8.72s
```

## US regression
No code changes anywhere. US behavior is byte-identical.

## Verification plan post-merge
After merge, watch Render Events for a successful deploy. Container should boot healthy — comment-only change, no migration, no env var changes.

Follow-up to #494, #495.