### PR TITLE
LT pilot: Zadarma missed-call → n8n webhook (Step 1/3)

### DIFF
--- a/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
+++ b/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
@@ -1,0 +1,324 @@
+{
+  "name": "WF-LT-ZADARMA-MISSED-CALL",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lt-zadarma-missed-call",
+        "authentication": "headerAuth",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "lt-zd-webhook",
+      "name": "Webhook: Zadarma Missed Call",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "lt-zadarma-missed-call",
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "zadarma-webhook-secret"
+        }
+      },
+      "notes": "Header Auth credential must be created manually in n8n as 'zadarma-webhook-secret' with header name 'x-zadarma-secret'."
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "caller-number",
+              "name": "caller_number",
+              "type": "string",
+              "value": "={{ $json.body?.caller_id || $json.body?.from || $json.caller_id || $json.from || '' }}"
+            },
+            {
+              "id": "called-number",
+              "name": "called_number",
+              "type": "string",
+              "value": "={{ $json.body?.called_did || $json.body?.destination || $json.called_did || $json.destination || '+37045512300' }}"
+            },
+            {
+              "id": "event-type",
+              "name": "event_type",
+              "type": "string",
+              "value": "={{ $json.body?.event || $json.event || '' }}"
+            },
+            {
+              "id": "call-status",
+              "name": "call_status",
+              "type": "string",
+              "value": "={{ ($json.body?.disposition || $json.body?.status || $json.disposition || $json.status || '').toString().toLowerCase() }}"
+            },
+            {
+              "id": "call-start",
+              "name": "call_start",
+              "type": "string",
+              "value": "={{ $json.body?.call_start || $json.body?.start || $json.call_start || $json.start || new Date().toISOString() }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "lt-zd-parse",
+      "name": "Parse Zadarma payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": false,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "cond-status-missed",
+              "leftValue": "={{ ['no answer','busy','cancel'].includes($json.call_status) }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "cond-caller-not-empty",
+              "leftValue": "={{ $json.caller_number }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "cond-not-self-call",
+              "leftValue": "={{ $json.caller_number !== $json.called_number }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "lt-zd-if-missed",
+      "name": "Is missed call?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "sms-to",
+              "name": "to",
+              "type": "string",
+              "value": "={{ $json.caller_number }}"
+            },
+            {
+              "id": "sms-from",
+              "name": "from",
+              "type": "string",
+              "value": "+37045512300"
+            },
+            {
+              "id": "sms-text",
+              "name": "text",
+              "type": "string",
+              "value": "Labas, čia Proteros Servisas. Negalėjau atsiliepti — parašykit kokia problema su automobiliu, ir aš jums padėsiu suplanuoti vizitą. Ačiū!"
+            },
+            {
+              "id": "sms-tenant",
+              "name": "tenant_id",
+              "type": "string",
+              "value": "lt-proteros-servisas"
+            },
+            {
+              "id": "sms-source",
+              "name": "source",
+              "type": "string",
+              "value": "zadarma-missed-call"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "lt-zd-build-sms",
+      "name": "Build SMS payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://httpbin.org/post",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ to: $json.to, from: $json.from, text: $json.text, tenant_id: $json.tenant_id, source: $json.source }) }}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "lt-zd-send-sms",
+      "name": "Send SMS via Zadarma",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "continueOnFail": true,
+      "notes": "PLACEHOLDER: posts to httpbin.org/post until Step 2 swaps in the real Zadarma SMS API endpoint."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://autoshop-api-7ek9.onrender.com/internal/lt-log-conversation",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ tenant_id: $('Build SMS payload').item.json.tenant_id, caller_number: $('Build SMS payload').item.json.to, direction: 'outbound', message_text: $('Build SMS payload').item.json.text, source: 'zadarma-missed-call' }) }}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "lt-zd-log-api",
+      "name": "Log to internal API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 200],
+      "continueOnFail": true,
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "internal-api-key"
+        }
+      },
+      "notes": "Header Auth credential must be created manually in n8n as 'internal-api-key' with header name 'x-internal-key'."
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"ok\": true } }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "lt-zd-respond-ok",
+      "name": "Respond: OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [1560, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"ok\": true, \"skipped\": true, \"reason\": \"not a missed call\" } }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "lt-zd-respond-skip",
+      "name": "Respond: Skipped",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.4,
+      "position": [900, 440]
+    }
+  ],
+  "connections": {
+    "Webhook: Zadarma Missed Call": {
+      "main": [
+        [
+          {
+            "node": "Parse Zadarma payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Zadarma payload": {
+      "main": [
+        [
+          {
+            "node": "Is missed call?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is missed call?": {
+      "main": [
+        [
+          {
+            "node": "Build SMS payload",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond: Skipped",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build SMS payload": {
+      "main": [
+        [
+          {
+            "node": "Send SMS via Zadarma",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send SMS via Zadarma": {
+      "main": [
+        [
+          {
+            "node": "Log to internal API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log to internal API": {
+      "main": [
+        [
+          {
+            "node": "Respond: OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "errorWorkflow": ""
+  },
+  "active": false,
+  "tags": [
+    { "name": "LT_Proteros" },
+    { "name": "zadarma" },
+    { "name": "missed-call" },
+    { "name": "step-1-of-3" }
+  ]
+}

--- a/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.md
+++ b/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.md
@@ -1,0 +1,83 @@
+# WF-LT-ZADARMA-MISSED-CALL
+
+LT pilot missed-call handler: Zadarma → n8n webhook → SMS reply → internal log.
+
+**Status:** Step 1 of 3 — SMS sender is a placeholder (httpbin.org/post). Step 2 replaces it with the real Zadarma SMS API.
+
+## Webhook URL
+
+```
+https://bandomasis.app.n8n.cloud/webhook/lt-zadarma-missed-call
+```
+
+Configure this URL in the Zadarma PBX notification settings for the LT DID `+37045512300`.
+
+## Required n8n credentials (create manually before import)
+
+Both credentials use the **Header Auth** type. Create them in n8n before importing this workflow, otherwise the webhook and logging nodes will fail on first execution.
+
+| Credential name          | Header name        | Header value                                         |
+|--------------------------|--------------------|------------------------------------------------------|
+| `zadarma-webhook-secret` | `x-zadarma-secret` | Shared secret agreed with Zadarma (inbound guard)    |
+| `internal-api-key`       | `x-internal-key`   | Internal API key for `autoshop-api-7ek9.onrender.com`|
+
+## Flow
+
+1. **Webhook: Zadarma Missed Call** — POST `/webhook/lt-zadarma-missed-call`, gated by `x-zadarma-secret` Header Auth.
+2. **Parse Zadarma payload** — extracts `caller_number`, `called_number`, `event_type`, `call_status`, `call_start`.
+3. **Is missed call?** — requires `call_status ∈ {"no answer","busy","cancel"}`, non-empty `caller_number`, and `caller_number != called_number`.
+4. **Build SMS payload** — LT-language reply from `+37045512300` for tenant `lt-proteros-servisas`.
+5. **Send SMS via Zadarma** — **PLACEHOLDER** → `https://httpbin.org/post`. Replaced in Step 2.
+6. **Log to internal API** → `POST /internal/lt-log-conversation` with `x-internal-key` header.
+7. **Respond: OK** → `200 { "ok": true }`.
+8. **Respond: Skipped** (false branch) → `200 { "ok": true, "skipped": true, "reason": "not a missed call" }`.
+
+## Test curl — sample Zadarma NOTIFY_END payload
+
+```bash
+curl -X POST "https://bandomasis.app.n8n.cloud/webhook/lt-zadarma-missed-call" \
+  -H "Content-Type: application/json" \
+  -H "x-zadarma-secret: REPLACE_WITH_SHARED_SECRET" \
+  -d '{
+    "event": "NOTIFY_END",
+    "caller_id": "+37067577829",
+    "called_did": "+37045512300",
+    "disposition": "no answer",
+    "call_start": "2026-04-11T10:15:00+03:00",
+    "call_id": "zd-test-0001"
+  }'
+```
+
+Expected response:
+
+```json
+{ "ok": true }
+```
+
+### Negative test (should take false branch)
+
+```bash
+curl -X POST "https://bandomasis.app.n8n.cloud/webhook/lt-zadarma-missed-call" \
+  -H "Content-Type: application/json" \
+  -H "x-zadarma-secret: REPLACE_WITH_SHARED_SECRET" \
+  -d '{
+    "event": "NOTIFY_END",
+    "caller_id": "+37067577829",
+    "called_did": "+37045512300",
+    "disposition": "answered",
+    "call_start": "2026-04-11T10:15:00+03:00"
+  }'
+```
+
+Expected response:
+
+```json
+{ "ok": true, "skipped": true, "reason": "not a missed call" }
+```
+
+## Notes
+
+- The `Send SMS via Zadarma` node is intentionally `continueOnFail: true` so the logging node still runs even if the placeholder endpoint is unreachable.
+- Workflow ships with `active: false` — activate manually in n8n after credentials are created and a dry-run test passes.
+- Step 2 will swap the httpbin URL for the real Zadarma SMS API and move the shared secret out of the curl example into an env reference.
+- Step 3 will wire the inbound SMS side (customer replies) back into the SMS AI conversation loop.


### PR DESCRIPTION
## Summary

- Adds `n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json` — Step 1 of 3 for the LT pilot missed-call handler: Zadarma webhook → parse → missed-call gate → LT SMS reply → internal log → 200.
- SMS sender is intentionally a **placeholder** posting to `https://httpbin.org/post`; Step 2 will swap in the real Zadarma SMS API endpoint.
- Adds `n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.md` with webhook URL, required manual credentials (`zadarma-webhook-secret`, `internal-api-key`), and test curl for both the missed-call and answered-call branches.

## Flow

`Webhook (Header Auth x-zadarma-secret)` → `Parse Zadarma payload` → `Is missed call?` → (true) `Build SMS payload` → `Send SMS via Zadarma [PLACEHOLDER httpbin]` → `Log to internal API (x-internal-key)` → `200 {ok:true}` / (false) `200 {ok:true, skipped:true, reason:"not a missed call"}`.

Missed-call gate: `call_status ∈ {"no answer","busy","cancel"}` AND `caller_number` non-empty AND `caller_number != called_number`.

## Required manual setup in n8n (before activation)

1. Create Header Auth credential `zadarma-webhook-secret` — header `x-zadarma-secret`.
2. Create Header Auth credential `internal-api-key` — header `x-internal-key`.
3. Import `WF-LT-ZADARMA-MISSED-CALL.json`.
4. Dry-run with the curl in the README.
5. Activate the workflow and register the webhook URL in Zadarma PBX for `+37045512300`.

## Test plan

- [ ] JSON parses (verified locally: 8 nodes, 6 connections).
- [ ] Import workflow into n8n sandbox and confirm all nodes resolve credentials.
- [ ] Send the positive test curl — expect `{"ok":true}` and a row in the internal log API.
- [ ] Send the negative test curl (`disposition: "answered"`) — expect `{"ok":true,"skipped":true,"reason":"not a missed call"}`.
- [ ] Verify placeholder httpbin request body contains `to/from/text/tenant_id/source`.
- [ ] (Step 2 PR) Replace httpbin with real Zadarma SMS API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)