### PR TITLE
LT pilot: fix Parse node field extraction (smoke-test fix)

### DIFF
--- a/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
+++ b/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
@@ -30,25 +30,25 @@
               "id": "caller-number",
               "name": "caller_number",
               "type": "string",
-              "value": "={{ $json.body?.caller_id || $json.body?.from || $json.caller_id || $json.from || '' }}"
+              "value": "={{ ($json.body?.caller_id || $json.body?.from || $json.caller_id || $json.from || '').toString() }}"
             },
             {
               "id": "called-number",
               "name": "called_number",
               "type": "string",
-              "value": "={{ $json.body?.called_did || $json.body?.destination || $json.called_did || $json.destination || '+37045512300' }}"
+              "value": "={{ ($json.body?.called_did || $json.body?.called_number || $json.body?.to || $json.called_did || $json.called_number || $json.to || '').toString() }}"
             },
             {
               "id": "event-type",
               "name": "event_type",
               "type": "string",
-              "value": "={{ $json.body?.event || $json.event || '' }}"
+              "value": "={{ ($json.body?.event || $json.body?.event_type || $json.event || $json.event_type || '').toString() }}"
             },
             {
               "id": "call-status",
               "name": "call_status",
               "type": "string",
-              "value": "={{ ($json.body?.disposition || $json.body?.status || $json.disposition || $json.status || '').toString().toLowerCase() }}"
+              "value": "={{ ($json.body?.call_status || $json.body?.disposition || $json.body?.status || $json.call_status || $json.disposition || $json.status || '').toString().toLowerCase() }}"
             },
             {
               "id": "call-start",


### PR DESCRIPTION
## Summary

Smoke-testing the LT Zadarma webhook (see recent chat thread) revealed that the **Parse Zadarma payload** Set node only read `disposition` / `status` from `$json.body` — it never looked at `call_status`, and it only had partial fallbacks to direct `$json` keys. Result: a correctly-formed test payload (`call_status: "no answer"`) fell into the false branch and got `{"ok":true,"skipped":true,"reason":"not a missed call"}` instead of firing the SMS + log path.

## Fix

In `n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json`, updated all four extracted fields in `lt-zd-parse` to use symmetric `$json.body?.X || $json.X` fallback chains and added the missing source keys:

| Field          | New fallback chain                                                                                                                                          |
|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `caller_number`| `$json.body?.caller_id \|\| $json.body?.from \|\| $json.caller_id \|\| $json.from`                                                                          |
| `called_number`| `$json.body?.called_did \|\| $json.body?.called_number \|\| $json.body?.to \|\| $json.called_did \|\| $json.called_number \|\| $json.to`                    |
| `event_type`   | `$json.body?.event \|\| $json.body?.event_type \|\| $json.event \|\| $json.event_type`                                                                      |
| `call_status`  | `$json.body?.call_status \|\| $json.body?.disposition \|\| $json.body?.status \|\| $json.call_status \|\| $json.disposition \|\| $json.status` (lowercased) |

All four also wrapped in `.toString()` for type safety.

## Smoke test results that motivated this (before fix)

| # | Case                  | Expected             | Actual                                                      | Result |
|---|-----------------------|----------------------|-------------------------------------------------------------|--------|
| 1 | Valid missed call     | `ok:true`, not skip  | `{"ok":true,"skipped":true,"reason":"not a missed call"}`   | FAIL   |
| 2 | Answered call         | `skipped:true`       | `{"ok":true,"skipped":true,"reason":"not a missed call"}`   | pass\* |
| 3 | Self-call             | `skipped:true`       | `{"ok":true,"skipped":true,"reason":"not a missed call"}`   | pass\* |
| 4 | Missing auth header   | 401 or 403           | `403 Authorization data is wrong!`                          | PASS   |

\* Tests 2 and 3 passed for the wrong reason — they were falling into the same empty-`call_status` skip path as Test 1, not their intended condition branches. With this fix they'll exercise the genuine answered-call and self-call conditions.

## Required follow-up

**Re-import** `n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json` into the live n8n instance at `bandomasis.app.n8n.cloud` after merge — editing the file in the repo does not propagate to the running workflow. After re-import, re-run the 4-case smoke test and expect Test 1 to return `{"ok":true}` and fire the `Log to internal API` node.

## Test plan

- [x] JSON parses locally (8 nodes, 6 connections, all 5 Parse assignments present)
- [ ] Re-import workflow into n8n
- [ ] Re-run 4-case smoke test from chat — Test 1 must flip from FAIL to PASS
- [ ] Confirm `Log to internal API` call body contains `tenant_id: lt-proteros-servisas` and `direction: outbound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)