### PR TITLE
LT pilot: backend Zadarma SMS sender + recent conversations read endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -41,6 +41,8 @@ import { configRoute } from "./routes/internal/config";
 import { githubIssuesRoute } from "./routes/internal/github-issues";
 import { dlqRoute } from "./routes/internal/dlq";
 import { ltLogConversationRoute } from "./routes/internal/lt-log-conversation";
+import { ltSendSmsRoute } from "./routes/internal/lt-send-sms";
+import { ltRecentConversationsRoute } from "./routes/internal/lt-recent-conversations";
 import { devLoopRoute } from "./routes/internal/dev-loop";
 import { devLoopExecuteRoute } from "./routes/internal/dev-loop-execute";
 import { leadsRoute } from "./routes/internal/leads";
@@ -160,6 +162,8 @@ async function bootstrap() {
   await app.register(githubIssuesRoute, { prefix: "/internal" });
   await app.register(dlqRoute, { prefix: "/internal" });
   await app.register(ltLogConversationRoute, { prefix: "/internal" });
+  await app.register(ltSendSmsRoute, { prefix: "/internal" });
+  await app.register(ltRecentConversationsRoute, { prefix: "/internal" });
   await app.register(devLoopRoute, { prefix: "/internal" });
   await app.register(devLoopExecuteRoute, { prefix: "/internal" });
   await app.register(leadsRoute, { prefix: "/internal" });

--- a/apps/api/src/routes/internal/lt-recent-conversations.ts
+++ b/apps/api/src/routes/internal/lt-recent-conversations.ts
@@ -1,0 +1,86 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+import { requireInternal } from "../../middleware/require-internal";
+import { resolveLtTenantId } from "../../utils/lt-tenant";
+
+/**
+ * GET /internal/lt-recent-conversations?tenant=<uuid|slug>&limit=<1..50>
+ *
+ * Read-side companion to /internal/lt-send-sms and /internal/lt-log-conversation.
+ * Returns the most recent messages (both directions) for the LT pilot tenant so
+ * smoke tests and the LT dashboard can verify writes end-to-end.
+ *
+ * Returns 200 with an empty array when no rows match (matches project convention).
+ * Internal only — requires x-internal-key header.
+ */
+
+const QuerySchema = z.object({
+  tenant: z.string().min(1),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+type Row = {
+  id: string;
+  customer_phone: string;
+  direction: string;
+  source: string | null;
+  body: string;
+  sent_at: string;
+};
+
+export async function ltRecentConversationsRoute(app: FastifyInstance) {
+  app.get(
+    "/lt-recent-conversations",
+    { preHandler: [requireInternal] },
+    async (request, reply) => {
+      const parsed = QuerySchema.safeParse(request.query);
+      if (!parsed.success) {
+        return reply.status(400).send({
+          ok: false,
+          error: "validation_failed",
+          details: parsed.error.issues.map(
+            (i) => `${i.path.join(".")}: ${i.message}`
+          ),
+        });
+      }
+
+      const { tenant, limit } = parsed.data;
+      const tenantUuid = resolveLtTenantId(tenant);
+      if (!tenantUuid) {
+        return reply.status(400).send({
+          ok: false,
+          error: "unknown_tenant",
+        });
+      }
+
+      const rows = await query<Row>(
+        `SELECT m.id,
+                c.customer_phone,
+                m.direction,
+                m.source,
+                m.body,
+                m.sent_at
+           FROM messages m
+           JOIN conversations c ON c.id = m.conversation_id
+          WHERE m.tenant_id = $1
+          ORDER BY m.sent_at DESC
+          LIMIT $2`,
+        [tenantUuid, limit]
+      );
+
+      return reply.status(200).send({
+        ok: true,
+        count: rows.length,
+        conversations: rows.map((r) => ({
+          id: r.id,
+          caller_number: r.customer_phone,
+          direction: r.direction,
+          source: r.source,
+          message_text: r.body,
+          created_at: r.sent_at,
+        })),
+      });
+    }
+  );
+}

--- a/apps/api/src/routes/internal/lt-send-sms.ts
+++ b/apps/api/src/routes/internal/lt-send-sms.ts
@@ -1,0 +1,220 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+import { requireInternal } from "../../middleware/require-internal";
+import { signZadarmaRequest } from "../../utils/zadarma";
+import { fetchWithTimeout } from "../../utils/fetch-with-timeout";
+import { resolveLtTenantId } from "../../utils/lt-tenant";
+
+/**
+ * POST /internal/lt-send-sms
+ *
+ * Backend wrapper around the Zadarma SMS API for the LT pilot. n8n cannot
+ * compute the HMAC-SHA1 signature Zadarma requires inside a stock HTTP
+ * Request node, and the free n8n tier has no env vars for API credentials —
+ * so the signing + credential management lives here on the backend instead.
+ *
+ * Flow:
+ *   1. Validate body (E.164 `to`, message length, tenant_id).
+ *   2. Resolve tenant slug/UUID → canonical tenant UUID.
+ *   3. Read ZADARMA_API_KEY / ZADARMA_API_SECRET from env. Return 503 if
+ *      either is missing (fail-closed — do not throw at startup).
+ *   4. Build a signed, form-urlencoded request and POST it to Zadarma.
+ *   5. On Zadarma success, persist an outbound message row (reusing the
+ *      existing conversations/messages pattern from lt-log-conversation).
+ *   6. Return 200 either way — success with { ok: true, ... } or logical
+ *      failure with { ok: false, error, zadarma_response } so n8n never
+ *      retries a 5xx (SMS would double-send).
+ *
+ * Internal only — requires x-internal-key header.
+ */
+
+const BodySchema = z.object({
+  to: z
+    .string()
+    .regex(/^\+\d{6,20}$/, "to must be E.164 starting with +"),
+  message: z.string().min(1).max(1600),
+  tenant_id: z.string().min(1),
+  source: z.string().min(1).max(64).optional().default("zadarma-missed-call"),
+});
+
+// LT Proteros Servisas DID — fixed sender for all outbound LT pilot SMS.
+const LT_SENDER_CALLER_ID = "+37045512300";
+
+// Full URL + signed path. The path (with trailing slash) is part of the signed
+// string, so it must NOT include the domain.
+const ZADARMA_URL = "https://api.zadarma.com/v1/sms/send/";
+const ZADARMA_PATH = "/v1/sms/send/";
+
+type ZadarmaResponseShape = {
+  status?: string;
+  [k: string]: unknown;
+};
+
+export async function ltSendSmsRoute(app: FastifyInstance) {
+  app.post(
+    "/lt-send-sms",
+    { preHandler: [requireInternal] },
+    async (request, reply) => {
+      const parsed = BodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({
+          ok: false,
+          error: "validation_failed",
+          details: parsed.error.issues.map(
+            (i) => `${i.path.join(".")}: ${i.message}`
+          ),
+        });
+      }
+
+      const { to, message, tenant_id, source } = parsed.data;
+
+      const tenantUuid = resolveLtTenantId(tenant_id);
+      if (!tenantUuid) {
+        return reply.status(400).send({
+          ok: false,
+          error: "unknown_tenant",
+          details: [
+            `tenant_id "${tenant_id}" is neither a UUID nor a known LT slug`,
+          ],
+        });
+      }
+
+      // Fail-closed: missing credentials → 503 at request time, not startup.
+      // This keeps the server bootable even if Zadarma creds are not yet set
+      // on the Render service (per CLAUDE.md: visibility of blockers).
+      const apiKey = process.env.ZADARMA_API_KEY;
+      const apiSecret = process.env.ZADARMA_API_SECRET;
+      if (!apiKey || !apiSecret) {
+        request.log.warn(
+          "ZADARMA_API_KEY/ZADARMA_API_SECRET not set — lt-send-sms unavailable"
+        );
+        return reply.status(503).send({
+          ok: false,
+          error: "zadarma_credentials_not_configured",
+        });
+      }
+
+      // Build signed Zadarma request (pure helper — see utils/zadarma.ts).
+      const signed = signZadarmaRequest(
+        ZADARMA_PATH,
+        { caller_id: LT_SENDER_CALLER_ID, message, number: to },
+        apiKey,
+        apiSecret
+      );
+
+      // Send — Zadarma expects form-urlencoded with the literal `apiKey:sig`
+      // Authorization header (no "Bearer " prefix).
+      let zadarmaResponse: ZadarmaResponseShape | { raw: string } | null = null;
+      let zadarmaOk = false;
+      try {
+        const res = await fetchWithTimeout(
+          ZADARMA_URL,
+          {
+            method: "POST",
+            headers: {
+              Authorization: signed.authHeader,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: signed.body.toString(),
+          },
+          15_000
+        );
+        const text = await res.text();
+        try {
+          zadarmaResponse = JSON.parse(text) as ZadarmaResponseShape;
+        } catch {
+          zadarmaResponse = { raw: text };
+        }
+        zadarmaOk =
+          res.ok &&
+          typeof zadarmaResponse === "object" &&
+          zadarmaResponse !== null &&
+          (zadarmaResponse as ZadarmaResponseShape).status === "success";
+      } catch (err) {
+        request.log.error(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Zadarma SMS request failed (network/timeout)"
+        );
+        return reply.status(200).send({
+          ok: false,
+          error: "zadarma_request_failed",
+          zadarma_response: {
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+      }
+
+      if (!zadarmaOk) {
+        request.log.warn(
+          { zadarmaResponse, to },
+          "Zadarma SMS send returned non-success"
+        );
+        return reply.status(200).send({
+          ok: false,
+          error: "zadarma_send_failed",
+          zadarma_response: zadarmaResponse,
+        });
+      }
+
+      // Success — persist to conversations/messages for dashboard visibility.
+      // DB failure must not fail the response: the SMS already went out.
+      let conversationId: string | null = null;
+      try {
+        const tenantRows = await query<{ id: string }>(
+          `SELECT id FROM tenants WHERE id = $1 LIMIT 1`,
+          [tenantUuid]
+        );
+        if (tenantRows.length === 0) {
+          request.log.warn(
+            { tenantUuid, to },
+            "Zadarma SMS sent but tenant row missing — skipping log"
+          );
+        } else {
+          const convRows = await query<{ id: string }>(
+            `SELECT id FROM conversations
+               WHERE tenant_id = $1 AND customer_phone = $2 AND status = 'open'
+               ORDER BY opened_at DESC
+               LIMIT 1`,
+            [tenantUuid, to]
+          );
+          if (convRows.length > 0) {
+            conversationId = convRows[0].id;
+            await query(
+              `UPDATE conversations
+                  SET last_message_at = NOW(), turn_count = turn_count + 1
+                WHERE id = $1`,
+              [conversationId]
+            );
+          } else {
+            const newConv = await query<{ id: string }>(
+              `INSERT INTO conversations
+                 (tenant_id, customer_phone, status, opened_at, last_message_at, turn_count)
+               VALUES ($1, $2, 'open', NOW(), NOW(), 1)
+               RETURNING id`,
+              [tenantUuid, to]
+            );
+            conversationId = newConv[0].id;
+          }
+          await query(
+            `INSERT INTO messages
+               (tenant_id, conversation_id, direction, body, source, sent_at)
+             VALUES ($1, $2, 'outbound', $3, $4, NOW())`,
+            [tenantUuid, conversationId, message, source]
+          );
+        }
+      } catch (err) {
+        request.log.error(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Failed to persist Zadarma SMS log (SMS already sent)"
+        );
+      }
+
+      return reply.status(200).send({
+        ok: true,
+        zadarma_status: zadarmaResponse,
+        conversation_id: conversationId,
+      });
+    }
+  );
+}

--- a/apps/api/src/tests/lt-recent-conversations.test.ts
+++ b/apps/api/src/tests/lt-recent-conversations.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+import { ltRecentConversationsRoute } from "../routes/internal/lt-recent-conversations";
+import { LT_PROTEROS_TENANT_UUID } from "../utils/lt-tenant";
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+  app.register(ltRecentConversationsRoute, { prefix: "/internal" });
+  return app;
+}
+
+function internalHeaders() {
+  return { "x-internal-key": "test-key" };
+}
+
+describe("GET /internal/lt-recent-conversations", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.INTERNAL_API_KEY = "test-key";
+  });
+
+  it("rejects missing x-internal-key with 403", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas",
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects missing tenant query param with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations",
+      headers: internalHeaders(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects unknown tenant slug with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-unknown",
+      headers: internalHeaders(),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("unknown_tenant");
+  });
+
+  it("rejects limit > 50 with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas&limit=999",
+      headers: internalHeaders(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 with empty array when no rows match", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas",
+      headers: internalHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toEqual({ ok: true, count: 0, conversations: [] });
+  });
+
+  it("maps DB columns to response shape (caller_number, message_text, created_at)", async () => {
+    mocks.query.mockResolvedValueOnce([
+      {
+        id: "msg-1",
+        customer_phone: "+37067577829",
+        direction: "outbound",
+        source: "zadarma-missed-call",
+        body: "Labas, parašykit kuo galim padėti.",
+        sent_at: "2026-04-11T16:30:00.000Z",
+      },
+      {
+        id: "msg-2",
+        customer_phone: "+37067577829",
+        direction: "inbound",
+        source: null,
+        body: "Noriu užsiregistruoti",
+        sent_at: "2026-04-11T16:31:00.000Z",
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas&limit=10",
+      headers: internalHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.count).toBe(2);
+    expect(body.conversations).toEqual([
+      {
+        id: "msg-1",
+        caller_number: "+37067577829",
+        direction: "outbound",
+        source: "zadarma-missed-call",
+        message_text: "Labas, parašykit kuo galim padėti.",
+        created_at: "2026-04-11T16:30:00.000Z",
+      },
+      {
+        id: "msg-2",
+        caller_number: "+37067577829",
+        direction: "inbound",
+        source: null,
+        message_text: "Noriu užsiregistruoti",
+        created_at: "2026-04-11T16:31:00.000Z",
+      },
+    ]);
+  });
+
+  it("scopes the SQL query by tenant_id (other tenants excluded)", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas",
+      headers: internalHeaders(),
+    });
+    const call = mocks.query.mock.calls[0];
+    const sql = call[0] as string;
+    const params = call[1] as unknown[];
+    expect(sql).toContain("WHERE m.tenant_id = $1");
+    expect(sql).toContain("ORDER BY m.sent_at DESC");
+    expect(params[0]).toBe(LT_PROTEROS_TENANT_UUID);
+  });
+
+  it("defaults limit to 10 and passes it to SQL", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas",
+      headers: internalHeaders(),
+    });
+    const params = mocks.query.mock.calls[0][1] as unknown[];
+    expect(params[1]).toBe(10);
+  });
+
+  it("honors custom limit up to 50", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+    const app = buildApp();
+    await app.inject({
+      method: "GET",
+      url: "/internal/lt-recent-conversations?tenant=lt-proteros-servisas&limit=25",
+      headers: internalHeaders(),
+    });
+    const params = mocks.query.mock.calls[0][1] as unknown[];
+    expect(params[1]).toBe(25);
+  });
+});

--- a/apps/api/src/tests/lt-send-sms.test.ts
+++ b/apps/api/src/tests/lt-send-sms.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+
+// ── Mocks (must be hoisted so vi.mock picks them up) ─────────────────────────
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+// fetchWithTimeout just delegates to global fetch — override globalThis.fetch.
+import { ltSendSmsRoute } from "../routes/internal/lt-send-sms";
+import { LT_PROTEROS_TENANT_UUID } from "../utils/lt-tenant";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function buildApp() {
+  const app = Fastify({ logger: false });
+  app.register(ltSendSmsRoute, { prefix: "/internal" });
+  return app;
+}
+
+function internalHeaders() {
+  return { "x-internal-key": "test-key" };
+}
+
+const VALID_BODY = {
+  to: "+37061234567",
+  message: "Labas, parašykit kuo galim padėti.",
+  tenant_id: "lt-proteros-servisas",
+  source: "zadarma-missed-call",
+};
+
+function mockZadarmaFetch(
+  response: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {}
+) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(JSON.stringify(response)),
+  }) as unknown as typeof fetch;
+}
+
+const originalFetch = globalThis.fetch;
+
+describe("POST /internal/lt-send-sms", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.INTERNAL_API_KEY = "test-key";
+    process.env.ZADARMA_API_KEY = "test_key";
+    process.env.ZADARMA_API_SECRET = "test_secret_12345";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.ZADARMA_API_KEY;
+    delete process.env.ZADARMA_API_SECRET;
+  });
+
+  it("rejects missing x-internal-key with 403", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects invalid E.164 `to` with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: { ...VALID_BODY, to: "37061234567" }, // no leading +
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("validation_failed");
+  });
+
+  it("rejects empty message with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: { ...VALID_BODY, message: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects unknown tenant slug with 400", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: { ...VALID_BODY, tenant_id: "lt-unknown-shop" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("unknown_tenant");
+  });
+
+  it("returns 503 when ZADARMA_API_KEY is missing", async () => {
+    delete process.env.ZADARMA_API_KEY;
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error).toBe("zadarma_credentials_not_configured");
+  });
+
+  it("returns 503 when ZADARMA_API_SECRET is missing", async () => {
+    delete process.env.ZADARMA_API_SECRET;
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("signs the request correctly and persists conversation on success", async () => {
+    const convId = "11111111-2222-3333-4444-555555555555";
+    mocks.query
+      .mockResolvedValueOnce([{ id: LT_PROTEROS_TENANT_UUID }]) // tenant exists
+      .mockResolvedValueOnce([])                                  // no open conv
+      .mockResolvedValueOnce([{ id: convId }])                    // INSERT conv
+      .mockResolvedValueOnce([]);                                  // INSERT outbound msg
+
+    const fetchSpy = mockZadarmaFetch({
+      status: "success",
+      messages: 1,
+      message_id: "zd-123",
+    });
+    globalThis.fetch = fetchSpy;
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.conversation_id).toBe(convId);
+    expect(body.zadarma_status).toMatchObject({ status: "success" });
+
+    // Verify the outbound fetch call to Zadarma:
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = (fetchSpy as unknown as {
+      mock: { calls: [string, RequestInit][] };
+    }).mock.calls[0];
+    expect(calledUrl).toBe("https://api.zadarma.com/v1/sms/send/");
+    expect((calledInit.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded"
+    );
+    const authHeader = (calledInit.headers as Record<string, string>)[
+      "Authorization"
+    ];
+    // Literal `apiKey:signature`, no "Bearer " prefix:
+    expect(authHeader.startsWith("test_key:")).toBe(true);
+    // Body is sorted alphabetically:
+    expect(typeof calledInit.body).toBe("string");
+    const bodyStr = calledInit.body as string;
+    const firstEq = bodyStr.indexOf("=");
+    expect(bodyStr.slice(0, firstEq)).toBe("caller_id");
+
+    // Verify the outbound message was persisted with source:
+    const insertCall = mocks.query.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" && (c[0] as string).includes("INSERT INTO messages")
+    );
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as unknown[];
+    expect(params[2]).toBe(VALID_BODY.message);
+    expect(params[3]).toBe("zadarma-missed-call");
+  });
+
+  it("reuses existing open conversation on success", async () => {
+    const existingConvId = "22222222-3333-4444-5555-666666666666";
+    mocks.query
+      .mockResolvedValueOnce([{ id: LT_PROTEROS_TENANT_UUID }])
+      .mockResolvedValueOnce([{ id: existingConvId }]) // open conv found
+      .mockResolvedValueOnce([])                        // UPDATE touch
+      .mockResolvedValueOnce([]);                       // INSERT outbound msg
+
+    globalThis.fetch = mockZadarmaFetch({ status: "success" });
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().conversation_id).toBe(existingConvId);
+  });
+
+  it("returns ok:false + 200 when Zadarma rejects the SMS", async () => {
+    globalThis.fetch = mockZadarmaFetch({
+      status: "error",
+      message: "wrong signature",
+    });
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+
+    expect(res.statusCode).toBe(200); // still 200 so n8n doesn't retry
+    const body = res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("zadarma_send_failed");
+    expect(body.zadarma_response).toMatchObject({ status: "error" });
+    // No DB writes should have happened:
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false + 200 on network error", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNRESET")) as unknown as typeof fetch;
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: VALID_BODY,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("zadarma_request_failed");
+  });
+
+  it("accepts a raw tenant UUID as well as a slug", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: LT_PROTEROS_TENANT_UUID }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "conv-uuid" }])
+      .mockResolvedValueOnce([]);
+    globalThis.fetch = mockZadarmaFetch({ status: "success" });
+
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/lt-send-sms",
+      headers: internalHeaders(),
+      payload: { ...VALID_BODY, tenant_id: LT_PROTEROS_TENANT_UUID },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+});

--- a/apps/api/src/tests/zadarma.test.ts
+++ b/apps/api/src/tests/zadarma.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import * as crypto from "node:crypto";
+import { signZadarmaRequest } from "../utils/zadarma";
+
+/**
+ * Pinned-signature regression test.
+ *
+ * The expected authHeader below is computed OFFLINE with identical inputs using
+ * Node's stock `crypto` module and hardcoded here. If anyone ever re-orders the
+ * concat, drops the trailing slash from apiPath, or swaps sha1 ↔ sha256, this
+ * test will fail before the change can reach Zadarma and produce a silent
+ * `wrong signature` error in production.
+ *
+ * Inputs are intentionally boring, non-secret values. Do not put real creds
+ * in this file.
+ */
+const FIXED = {
+  apiKey: "test_key",
+  apiSecret: "test_secret_12345",
+  apiPath: "/v1/sms/send/",
+  params: {
+    caller_id: "+37045512300",
+    message: "Labas",
+    number: "+37061234567",
+  },
+};
+
+// These three lines are the "source of truth" for the test. If the helper is
+// correct, they match exactly what it produces. If you regenerate them, you
+// must also run the helper against FIXED and confirm the new values match.
+const EXPECTED_QUERY_STRING =
+  "caller_id=%2B37045512300&message=Labas&number=%2B37061234567";
+const EXPECTED_MD5 = "734a00543ffe1d82b86a9b5c0f9c8ada";
+const EXPECTED_AUTH_HEADER = "test_key:hxo7RqQ8n5R5MaL2udTyZdzhnG0=";
+
+describe("signZadarmaRequest", () => {
+  it("produces the pinned Authorization header for known inputs", () => {
+    const { authHeader } = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    expect(authHeader).toBe(EXPECTED_AUTH_HEADER);
+  });
+
+  it("builds a form-urlencoded body in alphabetical key order", () => {
+    const { body } = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    // URLSearchParams preserves insertion order; the helper inserts sorted keys.
+    expect(body.toString()).toBe(EXPECTED_QUERY_STRING);
+  });
+
+  it("signature derivation matches the raw crypto primitives (algorithm pin)", () => {
+    // Recompute step-by-step with stock crypto and compare — catches any
+    // future drift where the helper diverges from the Zadarma formula.
+    const md5 = crypto
+      .createHash("md5")
+      .update(EXPECTED_QUERY_STRING)
+      .digest("hex");
+    expect(md5).toBe(EXPECTED_MD5);
+
+    const signData = FIXED.apiPath + EXPECTED_QUERY_STRING + md5;
+    const signature = crypto
+      .createHmac("sha1", FIXED.apiSecret)
+      .update(signData)
+      .digest("base64");
+
+    const { authHeader } = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    expect(authHeader).toBe(`${FIXED.apiKey}:${signature}`);
+  });
+
+  it("key order in input is irrelevant (sort happens inside)", () => {
+    const a = signZadarmaRequest(
+      FIXED.apiPath,
+      {
+        number: FIXED.params.number,
+        message: FIXED.params.message,
+        caller_id: FIXED.params.caller_id,
+      },
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    const b = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    expect(a.authHeader).toBe(b.authHeader);
+    expect(a.body.toString()).toBe(b.body.toString());
+  });
+
+  it("changing any input produces a different signature", () => {
+    const base = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    const diffMessage = signZadarmaRequest(
+      FIXED.apiPath,
+      { ...FIXED.params, message: "Labass" },
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    const diffSecret = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      "different_secret"
+    );
+    const diffPath = signZadarmaRequest(
+      "/v1/sms/send", // missing trailing slash
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+
+    expect(diffMessage.authHeader).not.toBe(base.authHeader);
+    expect(diffSecret.authHeader).not.toBe(base.authHeader);
+    expect(diffPath.authHeader).not.toBe(base.authHeader);
+  });
+
+  it("url-encodes values containing '+' and spaces", () => {
+    const { body } = signZadarmaRequest(
+      FIXED.apiPath,
+      { number: "+37061234567", message: "hi there" },
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    // URLSearchParams encodes spaces as '+' — same as Zadarma's example.
+    const str = body.toString();
+    expect(str).toContain("message=hi+there");
+    expect(str).toContain("number=%2B37061234567");
+  });
+});

--- a/apps/api/src/utils/lt-tenant.ts
+++ b/apps/api/src/utils/lt-tenant.ts
@@ -1,0 +1,29 @@
+/**
+ * LT pilot tenant identifier resolution.
+ *
+ * The tenants table has no `slug` column (see db/migrations/001_init.sql),
+ * so internal routes called from n8n/Zadarma workflows receive either the raw
+ * tenant UUID or a well-known slug like `lt-proteros-servisas`. This helper
+ * normalizes both to the canonical UUID, and rejects anything unknown.
+ *
+ * When a `slug` column eventually gets added to `tenants`, replace the map
+ * with a DB lookup — the call sites will not need to change.
+ */
+
+export const LT_PROTEROS_TENANT_UUID = "7d82ab25-e991-4d13-b4ac-846865f8b85a";
+
+const SLUG_TO_UUID: Record<string, string> = {
+  "lt-proteros-servisas": LT_PROTEROS_TENANT_UUID,
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Returns the canonical tenant UUID for an incoming identifier, or null if the
+ * identifier is neither a UUID nor a known LT slug.
+ */
+export function resolveLtTenantId(input: string): string | null {
+  if (UUID_RE.test(input)) return input;
+  return SLUG_TO_UUID[input] ?? null;
+}

--- a/apps/api/src/utils/zadarma.ts
+++ b/apps/api/src/utils/zadarma.ts
@@ -1,0 +1,68 @@
+import * as crypto from "node:crypto";
+
+export interface ZadarmaSignedRequest {
+  /**
+   * Value for the Authorization header: `${apiKey}:${signature}` (literal colon,
+   * no "Bearer " prefix).
+   */
+  authHeader: string;
+  /** Form-urlencoded body with params in alphabetical key order. */
+  body: URLSearchParams;
+}
+
+/**
+ * Sign a Zadarma API request using HMAC-SHA1.
+ *
+ * Formula (verbatim from Zadarma docs + proven in n8n sandbox
+ * `n8n/workflows/TEST/wf002-lt-sandbox-send-sms.json`):
+ *
+ *   1. Sort params alphabetically by key
+ *   2. queryString = RFC1738 form-urlencoded `k=v` pairs joined with `&`
+ *                    (same encoding as PHP's `http_build_query` with
+ *                    PHP_QUERY_RFC1738 — space becomes `+`, `+` becomes `%2B`)
+ *   3. md5Hash     = md5(queryString) as hex
+ *   4. signData    = apiPath + queryString + md5Hash
+ *   5. signature   = base64(hmac-sha1(signData, apiSecret))
+ *   6. authHeader  = `${apiKey}:${signature}`
+ *
+ * IMPORTANT: the wire body and the signed string MUST use byte-for-byte
+ * identical encoding. We use `URLSearchParams` for both so they cannot drift.
+ * (An earlier draft used `encodeURIComponent` for the signature and
+ * `URLSearchParams` for the body — those encode spaces differently (`%20` vs
+ * `+`) and produce a silent `wrong signature` error for any message
+ * containing a space.)
+ *
+ * `apiPath` MUST include the trailing slash (e.g. "/v1/sms/send/") and MUST
+ * NOT include the domain — it is part of the signed string and a mismatch
+ * produces a `wrong signature` error from Zadarma.
+ *
+ * This helper is pure — no I/O, no env access — so it is trivially unit-
+ * testable and safe to call from any context.
+ */
+export function signZadarmaRequest(
+  apiPath: string,
+  params: Record<string, string>,
+  apiKey: string,
+  apiSecret: string
+): ZadarmaSignedRequest {
+  // Build a URLSearchParams with keys in alphabetical order. URLSearchParams
+  // preserves insertion order, so sort → append gives us a deterministic,
+  // sorted, RFC1738-encoded serialization that is identical between the
+  // signed string and the wire body.
+  const sortedKeys = Object.keys(params).sort();
+  const body = new URLSearchParams();
+  for (const k of sortedKeys) body.append(k, params[k]);
+
+  const queryString = body.toString();
+  const md5Hash = crypto.createHash("md5").update(queryString).digest("hex");
+  const signData = apiPath + queryString + md5Hash;
+  const signature = crypto
+    .createHmac("sha1", apiSecret)
+    .update(signData)
+    .digest("base64");
+
+  return {
+    authHeader: `${apiKey}:${signature}`,
+    body,
+  };
+}

--- a/db/migrations/051_messages_source.sql
+++ b/db/migrations/051_messages_source.sql
@@ -1,0 +1,20 @@
+-- 051_messages_source.sql
+-- Add an optional `source` tag to messages so the LT pilot can distinguish
+-- zadarma-missed-call outbound SMS from the main SMS AI conversation flow,
+-- and so the /internal/lt-recent-conversations read endpoint can surface it.
+--
+-- Small additive change — nullable, no backfill needed. Existing inserts
+-- continue to work unchanged.
+
+BEGIN;
+
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS source TEXT;
+
+-- Partial index: only rows that actually carry a source tag.
+-- Keeps the index small since most messages will stay NULL for now.
+CREATE INDEX IF NOT EXISTS idx_messages_source
+  ON messages (source)
+  WHERE source IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds two new `/internal/*` endpoints for the LT Zadarma pilot plus the HMAC-SHA1 signing helper they share.

- **POST `/internal/lt-send-sms`** — backend wrapper for Zadarma's SMS API. Signs the request, POSTs to `https://api.zadarma.com/v1/sms/send/`, and on success persists an outbound row in `conversations`/`messages`. Returns `ok: true` on success or `ok: false, error, zadarma_response` on logical failure (always 200, so n8n never retries a 5xx and double-sends an SMS).
- **GET `/internal/lt-recent-conversations?tenant=<uuid|slug>&limit=<1..50>`** — read-side companion so smoke tests can verify writes end-to-end. Returns 200 with an empty array when no rows match (project convention).
- **`apps/api/src/utils/zadarma.ts`** — pure `signZadarmaRequest(apiPath, params, apiKey, apiSecret)` helper.
- **`apps/api/src/utils/lt-tenant.ts`** — small resolver for `"lt-proteros-servisas"` slug ⇆ canonical tenant UUID (`tenants` table has no `slug` column yet).
- **`db/migrations/051_messages_source.sql`** — additive nullable `source` column on `messages` (+ partial index) so the read endpoint can surface which message came from which pipeline.

## Why backend wraps Zadarma instead of an n8n Code node

- **HMAC-SHA1 is not inlineable in n8n's stock HTTP Request node** — every working integration in the repo (`wf002`, `wf006`) already uses a pre-node to compute the signature, so the complexity lives somewhere either way.
- **Free n8n tier has no env vars** — credentials would have to live in an n8n credential object per workflow, duplicated across every LT workflow that needs to send SMS. Rotating becomes a multi-workflow edit.
- **CLAUDE.md: SMS critical path belongs on the backend** — keeps the missed-call → SMS reply core flow on code we actually version, test, and monitor in Render logs rather than in n8n's UI.
- **Single source of truth for Zadarma creds** — `ZADARMA_API_KEY` / `ZADARMA_API_SECRET` live only on Render and are read at request time. Rotation is a one-place env var flip.
- **Read endpoint needed a backing column anyway** — adding `messages.source` unblocks the `/lt-recent-conversations` endpoint in the same PR.

## Files changed (9)

| File | Change |
|---|---|
| `db/migrations/051_messages_source.sql` | new — nullable `source` col + partial index |
| `apps/api/src/utils/zadarma.ts` | new — pure signing helper |
| `apps/api/src/utils/lt-tenant.ts` | new — slug/UUID resolver + `LT_PROTEROS_TENANT_UUID` constant |
| `apps/api/src/routes/internal/lt-send-sms.ts` | new — POST route (Zod validation, 503 on missing creds, fetchWithTimeout, reuses existing conv/msg pattern from `lt-log-conversation.ts`) |
| `apps/api/src/routes/internal/lt-recent-conversations.ts` | new — GET route (Zod query validation, scoped by tenant_id) |
| `apps/api/src/index.ts` | +2 imports, +2 `app.register` calls (mirroring `ltLogConversationRoute` convention) |
| `apps/api/src/tests/zadarma.test.ts` | new — 6 tests; pinned authHeader for known inputs, algorithm invariants, space-encoding check |
| `apps/api/src/tests/lt-send-sms.test.ts` | new — 11 tests; auth, validation, 503 on missing creds, happy path with conversation reuse, Zadarma error, network error, raw UUID acceptance |
| `apps/api/src/tests/lt-recent-conversations.test.ts` | new — 9 tests; auth, validation, empty array, column mapping, tenant scoping, limit handling |

## Notable implementation detail — **encoding bug caught in draft**

First draft used `encodeURIComponent` to build the signed query string and `URLSearchParams` to build the wire body. These encode spaces differently (`%20` vs `+`). For the test's no-space inputs they happened to match, but **any real LT SMS containing a space would have produced a silent `wrong signature` error from Zadarma.** Fixed before commit: both the signed string and the body now come from the same `URLSearchParams` instance, so they cannot drift. See the extended comment in `apps/api/src/utils/zadarma.ts` for details.

## Verification (local)

```
VERIFICATION
EXIT_CODE=0
TEST_FILES=54
TESTS_TOTAL=771
TESTS_FAILED=0
DURATION=10.19s
```

- `npm run typecheck` — clean, 0 errors
- `npx vitest run src/tests/zadarma.test.ts src/tests/lt-send-sms.test.ts src/tests/lt-recent-conversations.test.ts` — **26/26 pass** (new tests)
- `npm test` — **771/771 pass** full suite, no regressions

## Known open blocker (flagged for reviewer to handle next)

⚠ **`ZADARMA_API_KEY` and `ZADARMA_API_SECRET` are NOT yet set on the Render service `autoshop-api-7ek9`.** Confirmed by listing env vars via the Render API — 28 keys total, 0 matching `/zadarma/i`. Until they're added, `/internal/lt-send-sms` will return `503 zadarma_credentials_not_configured` in production. This is intentional (fail-closed at request time, not at startup, so the service still boots) but must be resolved before the live n8n workflow can be switched from the httpbin placeholder to this endpoint in Step 3.

## Test plan

- [x] Full local `npm test` green (771/771)
- [x] Typecheck green
- [x] Algorithm pinned against known-good signature (offline-computed)
- [x] Encoding bug caught pre-commit
- [ ] Reviewer reads the diff and confirms the approach (you asked me not to merge)
- [ ] Set `ZADARMA_API_KEY` / `ZADARMA_API_SECRET` on Render
- [ ] After merge + Render env vars set: run migration `051`, hit `/internal/lt-send-sms` with a real LT number, verify row appears via `/internal/lt-recent-conversations`
- [ ] Step 3: update `WF-LT-ZADARMA-MISSED-CALL.json` in n8n to call `/internal/lt-send-sms` instead of `httpbin.org/post`, re-import, re-run the 4-case smoke test — Test 1 should now actually deliver

🤖 Generated with [Claude Code](https://claude.com/claude-code)