### PR TITLE
LT pilot: n8n workflow uses backend Zadarma sender (real SMS path)

### DIFF
--- a/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
+++ b/n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json
@@ -163,10 +163,12 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "https://httpbin.org/post",
+        "url": "https://autoshop-api-7ek9.onrender.com/internal/lt-send-sms",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ to: $json.to, from: $json.from, text: $json.text, tenant_id: $json.tenant_id, source: $json.source }) }}",
+        "jsonBody": "={{ JSON.stringify({ to: $('Build SMS payload').item.json.to, message: $('Build SMS payload').item.json.text, tenant_id: $('Build SMS payload').item.json.tenant_id, source: $('Build SMS payload').item.json.source }) }}",
         "options": {
           "timeout": 15000
         }
@@ -177,7 +179,12 @@
       "typeVersion": 4.2,
       "position": [1120, 200],
       "continueOnFail": true,
-      "notes": "PLACEHOLDER: posts to httpbin.org/post until Step 2 swaps in the real Zadarma SMS API endpoint."
+      "credentials": {
+        "httpHeaderAuth": {
+          "name": "internal-api-key"
+        }
+      },
+      "notes": "Posts to backend /internal/lt-send-sms. Backend wraps Zadarma HMAC-SHA1 signing, sends via api.zadarma.com, persists the outbound message to the LT conversations table, and returns { ok:true } on success or { ok:false, error, zadarma_response } on failure (always HTTP 200 so n8n never retries a 5xx and double-sends). Reuses the same 'internal-api-key' Header Auth credential (header: x-internal-key) as the Log to internal API node."
     },
     {
       "parameters": {


### PR DESCRIPTION
## Summary

Completes Step 2 of the LT pilot missed-call handler. The \`Send SMS via Zadarma\` node in \`n8n-workflows/WF-LT-ZADARMA-MISSED-CALL.json\` now POSTs to the backend \`/internal/lt-send-sms\` endpoint (PR GitHubProgramming/autoshop-sms-ai#501, live in production) instead of the \`httpbin.org/post\` placeholder shipped in Step 1.

## What changed (1 file, 1 node)

| Field | Before | After |
|---|---|---|
| URL | \`https://httpbin.org/post\` | \`https://autoshop-api-7ek9.onrender.com/internal/lt-send-sms\` |
| Authentication | (none) | \`genericCredentialType\` → \`httpHeaderAuth\` → credential \`internal-api-key\` (reused from the Log node — same header \`x-internal-key\`) |
| Body field | \`text\` (matched the old placeholder's field name) | \`message\` (matches backend Zod schema) |
| Body references | \`$json.X\` (direct from upstream item) | \`$('Build SMS payload').item.json.X\` (explicit named reference, same pattern already used by the Log to internal API node) |
| \`continueOnFail\` | true | true (unchanged — preserved so a backend hiccup doesn't break the log path) |
| Notes | placeholder-marker text | documents the new responsibility boundary |

All other 7 nodes untouched. Connections unchanged. 8 nodes / 6 connections confirmed via JSON.parse + structural check.

## Responsibility split after this change

| Layer | Owns |
|---|---|
| **n8n workflow** | receive Zadarma missed-call webhook, parse fields, gate on missed-call semantics, build SMS payload, call backend, respond to webhook with \`{ok:true}\` / \`{ok:true,skipped:true}\` |
| **Backend \`/internal/lt-send-sms\`** | Zadarma HMAC-SHA1 signing, credential management (\`ZADARMA_API_KEY\` / \`ZADARMA_API_SECRET\` as Render env vars — single source of truth), \`conversations\`/\`messages\` persistence, always-200 response shape so n8n never retries a 5xx and double-sends |

## Blockers before this actually delivers an SMS

1. **Live n8n workflow must be re-imported via the UI.** Editing the JSON in the repo does not propagate to \`bandomasis.app.n8n.cloud\`. After merge, open the workflow in n8n, re-import this file, confirm the \`Send SMS via Zadarma\` node shows the new URL and the \`internal-api-key\` credential is attached. (Separate Chrome step — not in this PR.)
2. **Zadarma credentials still rejected with \`Not authorized\`.** The deep-debug audit from the previous session concluded our signing is byte-identical to Zadarma's official PHP SDK, rate-limit headers decrement correctly, but every endpoint (including zero-param \`/v1/info/balance/\`) returns the same catchall \`401 Not authorized\`. Either the credentials copied into Render/.secrets are from a non-API dashboard page, or the Zadarma account needs an activation step. Until that's resolved, this node will deliver \`200 { ok:false, error:"zadarma_send_failed" }\` for every invocation — which is fine for the workflow (it won't crash or retry) but means no SMS reaches customers yet.
3. **Smoke test after re-import** must use \`call_status: "no answer"\` (or \`"busy"\` / \`"cancel"\`) — not \`"answered"\` — or the IF node will take the skipped branch.

## Test plan

- [x] JSON parses locally (8 nodes, 6 connections, diff isolated to one node)
- [ ] Re-import into \`bandomasis.app.n8n.cloud\` via n8n UI
- [ ] Run the 4-case smoke test (Test 1 should now return \`{ok:true}\` from the webhook AND trigger a backend call — check Render logs for the POST)
- [ ] Confirm backend rejection path: while Zadarma creds are still broken, Test 1 should surface \`{ok:true}\` from the webhook itself (n8n's response to Zadarma is always 200 OK on missed-call branch) but the backend internal log will show \`zadarma_send_failed: Not authorized\`
- [ ] Once Zadarma creds are fixed: Test 1 should deliver a real SMS to \`+37067577829\` AND write an outbound row visible via \`/internal/lt-recent-conversations\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)