### PR TITLE
LT pilot: CRITICAL Zadarma signing fix (base64 of hex, not raw)

### DIFF
--- a/apps/api/src/tests/zadarma.test.ts
+++ b/apps/api/src/tests/zadarma.test.ts
@@ -31,7 +31,11 @@ const FIXED = {
 const EXPECTED_QUERY_STRING =
   "caller_id=%2B37045512300&message=Labas&number=%2B37061234567";
 const EXPECTED_MD5 = "734a00543ffe1d82b86a9b5c0f9c8ada";
-const EXPECTED_AUTH_HEADER = "test_key:hxo7RqQ8n5R5MaL2udTyZdzhnG0=";
+// Signature is base64(hex(hmac)) → 56 chars, NOT base64(raw_hmac) → 28 chars.
+// Confirmed by Zadarma support (2026-04-11) and their GAS reference code.
+const EXPECTED_HMAC_HEX = "871a3b46a43c9f947931a2f6b9d4f265dce19c6d";
+const EXPECTED_AUTH_HEADER =
+  "test_key:ODcxYTNiNDZhNDNjOWY5NDc5MzFhMmY2YjlkNGYyNjVkY2UxOWM2ZA==";
 
 describe("signZadarmaRequest", () => {
   it("produces the pinned Authorization header for known inputs", () => {
@@ -56,8 +60,9 @@ describe("signZadarmaRequest", () => {
   });
 
   it("signature derivation matches the raw crypto primitives (algorithm pin)", () => {
-    // Recompute step-by-step with stock crypto and compare — catches any
-    // future drift where the helper diverges from the Zadarma formula.
+    // Recompute step-by-step with stock crypto, mirroring PHP's
+    // base64_encode(hash_hmac('sha1', $data, $key)) where hash_hmac
+    // returns hex by default (raw_output=false).
     const md5 = crypto
       .createHash("md5")
       .update(EXPECTED_QUERY_STRING)
@@ -65,10 +70,13 @@ describe("signZadarmaRequest", () => {
     expect(md5).toBe(EXPECTED_MD5);
 
     const signData = FIXED.apiPath + EXPECTED_QUERY_STRING + md5;
-    const signature = crypto
+    const hmacHex = crypto
       .createHmac("sha1", FIXED.apiSecret)
       .update(signData)
-      .digest("base64");
+      .digest("hex");
+    expect(hmacHex).toBe(EXPECTED_HMAC_HEX);
+
+    const signature = Buffer.from(hmacHex, "utf8").toString("base64");
 
     const { authHeader } = signZadarmaRequest(
       FIXED.apiPath,
@@ -129,6 +137,21 @@ describe("signZadarmaRequest", () => {
     expect(diffMessage.authHeader).not.toBe(base.authHeader);
     expect(diffSecret.authHeader).not.toBe(base.authHeader);
     expect(diffPath.authHeader).not.toBe(base.authHeader);
+  });
+
+  it("base64-encodes HEX string, not raw bytes (56 chars, not 28)", () => {
+    // SHA-1 raw = 20 bytes → base64 = 28 chars (WRONG for Zadarma)
+    // SHA-1 hex = 40 chars → base64 = 56 chars (CORRECT for Zadarma)
+    // This test catches the exact bug that caused every API call to return
+    // 401 Not authorized before the 2026-04-12 fix.
+    const { authHeader } = signZadarmaRequest(
+      FIXED.apiPath,
+      FIXED.params,
+      FIXED.apiKey,
+      FIXED.apiSecret
+    );
+    const sigPart = authHeader.split(":").slice(1).join(":");
+    expect(sigPart.length).toBe(56);
   });
 
   it("url-encodes values containing '+' and spaces", () => {

--- a/apps/api/src/utils/zadarma.ts
+++ b/apps/api/src/utils/zadarma.ts
@@ -22,8 +22,20 @@ export interface ZadarmaSignedRequest {
  *                    PHP_QUERY_RFC1738 — space becomes `+`, `+` becomes `%2B`)
  *   3. md5Hash     = md5(queryString) as hex
  *   4. signData    = apiPath + queryString + md5Hash
- *   5. signature   = base64(hmac-sha1(signData, apiSecret))
- *   6. authHeader  = `${apiKey}:${signature}`
+ *   5. hmacHex     = hmac-sha1(signData, apiSecret) as **hex string** (40 chars)
+ *   6. signature   = base64(hmacHex)   ← base64 of the hex STRING, not raw bytes
+ *   7. authHeader  = `${apiKey}:${signature}`
+ *
+ * Step 5–6 is critical: PHP's `hash_hmac('sha1', ..., $secret)` returns hex by
+ * default (`raw_output = false`), and the PHP SDK passes that hex string straight
+ * into `base64_encode()`. Node's `crypto.createHmac().digest('base64')` encodes
+ * the raw 20-byte HMAC — a shorter, different value. The correct Node equivalent
+ * of PHP's `base64_encode(hash_hmac('sha1', $data, $key))` is:
+ *
+ *     const hex = crypto.createHmac('sha1', key).update(data).digest('hex');
+ *     const sig = Buffer.from(hex, 'utf8').toString('base64');
+ *
+ * Confirmed by Zadarma support (2026-04-11) and their GAS reference code.
  *
  * IMPORTANT: the wire body and the signed string MUST use byte-for-byte
  * identical encoding. We use `URLSearchParams` for both so they cannot drift.
@@ -56,10 +68,17 @@ export function signZadarmaRequest(
   const queryString = body.toString();
   const md5Hash = crypto.createHash("md5").update(queryString).digest("hex");
   const signData = apiPath + queryString + md5Hash;
-  const signature = crypto
+
+  // Two-step encoding: HMAC → hex string → base64.
+  // PHP's hash_hmac returns hex by default; Zadarma's server base64-decodes our
+  // signature back to hex and compares against its own hex HMAC. If we base64
+  // the raw 20-byte digest instead, the signature is shorter (28 vs 56 chars)
+  // and Zadarma rejects with "Not authorized".
+  const hmacHex = crypto
     .createHmac("sha1", apiSecret)
     .update(signData)
-    .digest("base64");
+    .digest("hex");
+  const signature = Buffer.from(hmacHex, "utf8").toString("base64");
 
   return {
     authHeader: `${apiKey}:${signature}`,


### PR DESCRIPTION
## Summary

**Root cause of every 401 Not authorized from Zadarma since the LT pilot began.**

Our signing helper (`apps/api/src/utils/zadarma.ts`) was calling:
```js
crypto.createHmac("sha1", secret).update(data).digest("base64")
```
This base64-encodes the **raw 20-byte** HMAC output → 28-char signature.

Zadarma expects:
```js
const hex = crypto.createHmac("sha1", secret).update(data).digest("hex");
Buffer.from(hex, "utf8").toString("base64")
```
This base64-encodes the **40-char hex string** representation → 56-char signature.

The difference exists because PHP's `hash_hmac('sha1', $data, $key)` returns hex by default (`raw_output = false`), and Zadarma's server-side verification expects the base64 of that hex string — not the base64 of raw bytes. Confirmed by Zadarma support in their 2026-04-11 ticket reply and their Google Apps Script reference code.

## What changed

| File | Change |
|---|---|
| `apps/api/src/utils/zadarma.ts` | Two-step encoding: `.digest("hex")` then `Buffer.from(hex).toString("base64")`. Updated header comment explaining why, with reference to PHP `hash_hmac` default behavior. |
| `apps/api/src/tests/zadarma.test.ts` | Recomputed pinned signature (28 chars → 56 chars). Added new test asserting signature length = 56 (catches this exact regression). Updated algorithm-pin test to verify hex intermediate. Now 7 tests (was 6). |

## Verification

```
EXIT_CODE=0
TEST_FILES=54
TESTS_TOTAL=772
TESTS_FAILED=0
```

## Impact

Every Zadarma API call from this codebase was returning `401 Not authorized` because the signature was the wrong length and encoding. After this fix, the backend `/internal/lt-send-sms` endpoint should successfully authenticate against `api.zadarma.com` and deliver SMS for the LT pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)