### PR TITLE
fix(lt-pilot): add Lithuanian booking confirmation patterns to detectBookingIntent

### DIFF
--- a/apps/api/src/services/booking-intent.ts
+++ b/apps/api/src/services/booking-intent.ts
@@ -22,6 +22,7 @@ export interface BookingIntentResult {
 // ── Booking confirmation patterns (checked against AI response) ─────────────
 
 const HIGH_CONFIDENCE_PATTERNS = [
+  // English
   "appointment is confirmed",
   "appointment confirmed",
   "your appointment is set",
@@ -38,9 +39,19 @@ const HIGH_CONFIDENCE_PATTERNS = [
   "i have scheduled you",
   "appointment has been booked",
   "appointment has been scheduled",
+  // Lithuanian (LT pilot)
+  "vizitas patvirtintas",       // appointment confirmed
+  "vizitas rezervuotas",        // appointment reserved
+  "vizitas užregistruotas",     // appointment registered
+  "rezervacija patvirtinta",    // reservation confirmed
+  "užregistravau jus",          // I registered you (informal)
+  "užregistravau jūs",          // I registered you (formal)
+  "jūs užregistruotas",         // you are registered (masc)
+  "jūs užregistruota",          // you are registered (fem)
 ];
 
 const MEDIUM_CONFIDENCE_PATTERNS = [
+  // English
   "booked for",
   "scheduled for",
   "confirmed for",
@@ -51,6 +62,12 @@ const MEDIUM_CONFIDENCE_PATTERNS = [
   "we'll see you",
   "we will see you",
   "look forward to seeing you",
+  // Lithuanian (LT pilot)
+  "patvirtinu vizitą",          // I confirm the appointment
+  "patvirtinu rezervaciją",     // I confirm the reservation
+  "lauksime jūsų",             // we'll be waiting for you
+  "iki susitikimo",            // see you (until we meet)
+  "jūsų vizitas",              // your appointment (+ context)
 ];
 
 // ── Close/cancel patterns (checked against customer message) ────────────────
@@ -71,6 +88,10 @@ const CLOSE_KEYWORDS = [
   "do not text me",
   "don't contact me",
   "do not contact me",
+  // Lithuanian
+  "atšaukti",                   // cancel
+  "nebenoriu",                  // I don't want anymore
+  "nerašykite",                 // don't text me
 ];
 
 // ── Service types ───────────────────────────────────────────────────────────
@@ -125,7 +146,8 @@ const NATURAL_DATE_PATTERNS = [
 // ── Name extraction ─────────────────────────────────────────────────────────
 
 // Match patterns like "confirmed, John" or "Thank you, John" or "See you, John"
-const NAME_AFTER_COMMA = /(?:[Cc]onfirmed|[Tt]hank [Yy]ou|[Tt]hanks|[Ss]ee [Yy]ou),\s+([A-Z][a-z]+)/;
+// Also Lithuanian: "Ačiū, Manta" or "Patvirtinta, Manta"
+const NAME_AFTER_COMMA = /(?:[Cc]onfirmed|[Tt]hank [Yy]ou|[Tt]hanks|[Ss]ee [Yy]ou|[Aa]čiū|[Pp]atvirtint[ao]|[Ss]veiki),\s+([A-ZĄČĘĖĮŠŲŪŽa-ząčęėįšųūž][a-ząčęėįšųūž]+)/;
 // Match "for John" or "for John Smith"
 const NAME_AFTER_FOR =
   /(?:[Aa]ppointment|[Bb]ooking|[Ss]cheduled)\s+(?:is\s+)?(?:confirmed\s+)?for\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/;
@@ -198,7 +220,9 @@ function extractLicensePlate(customerMessage: string, aiResponse: string): strin
     !lower.includes("plate") &&
     !lower.includes("tag") &&
     !lower.includes("license") &&
-    !lower.includes("registration")
+    !lower.includes("registration") &&
+    !lower.includes("numerį") &&         // LT: registracijos numerį (registration number)
+    !lower.includes("registracij")
   ) {
     return null;
   }

--- a/apps/api/src/tests/booking-intent.test.ts
+++ b/apps/api/src/tests/booking-intent.test.ts
@@ -396,3 +396,83 @@ describe("POST /internal/booking-intent", () => {
     expect(res.json().userWantsClose).toBe(true);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Lithuanian (LT pilot) booking detection tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("detectBookingIntent — Lithuanian patterns", () => {
+  it("detects high-confidence 'vizitas patvirtintas' (appointment confirmed)", () => {
+    const r = detectBookingIntent(
+      "Vizitas patvirtintas! Jūsų Toyota Corolla bus apžiūrėta šiandien 10:00. Lauksime jūsų Proteros Servise!",
+      "Tinka"
+    );
+    expect(r.isBooked).toBe(true);
+    expect(r.confidence).toBe("high");
+    expect(r.matchedPatterns).toContain("vizitas patvirtintas");
+  });
+
+  it("detects high-confidence 'rezervacija patvirtinta' (reservation confirmed)", () => {
+    const r = detectBookingIntent(
+      "Rezervacija patvirtinta rytoj 14:00.",
+      "Gerai"
+    );
+    expect(r.isBooked).toBe(true);
+    expect(r.confidence).toBe("high");
+    expect(r.matchedPatterns).toContain("rezervacija patvirtinta");
+  });
+
+  it("detects medium-confidence 'lauksime jūsų' (we'll be waiting for you)", () => {
+    const r = detectBookingIntent(
+      "Lauksime jūsų rytoj 9:00!",
+      "Ačiū"
+    );
+    expect(r.isBooked).toBe(true);
+    expect(r.confidence).toBe("medium");
+    expect(r.matchedPatterns).toContain("lauksime jūsų");
+  });
+
+  it("does NOT detect booking from 'ačiū' alone (false positive guard)", () => {
+    const r = detectBookingIntent(
+      "Nėra už ką! Jei turėsite daugiau klausimų, drąsiai rašykite.",
+      "Ačiū"
+    );
+    expect(r.isBooked).toBe(false);
+    expect(r.confidence).toBe("none");
+  });
+
+  it("does NOT detect booking from general info response", () => {
+    const r = detectBookingIntent(
+      "Dirbame nuo 8:00 iki 18:00, pirmadienį–penktadienį.",
+      "Kokios darbo valandos?"
+    );
+    expect(r.isBooked).toBe(false);
+    expect(r.confidence).toBe("none");
+  });
+
+  it("extracts car model from Lithuanian conversation", () => {
+    const r = detectBookingIntent(
+      "Vizitas patvirtintas! Jūsų Toyota Corolla bus apžiūrėta šiandien 10:00.",
+      "Sveiki, mano Toyota Corolla nesikuria"
+    );
+    expect(r.isBooked).toBe(true);
+    expect(r.carModel).toContain("Toyota");
+    expect(r.carModel).toContain("Corolla");
+  });
+
+  it("extracts name from Lithuanian 'Ačiū, Manta' pattern", () => {
+    const r = detectBookingIntent(
+      "Ačiū, Manta. Ar galite nurodyti automobilio registracijos numerį?",
+      "Mantas šiandien 10 h ryto"
+    );
+    expect(r.customerName).toBe("Manta");
+  });
+
+  it("detects LT close keyword 'atšaukti'", () => {
+    const r = detectBookingIntent(
+      "Supratau, vizitas atšauktas.",
+      "atšaukti"
+    );
+    expect(r.userWantsClose).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug
AI confirmed appointments in Lithuanian ("Vizitas patvirtintas!") but no appointment row was created in DB. Customer received confirmation SMS but shop had no record.

## Root cause
`detectBookingIntent()` only matched English patterns like "appointment confirmed". Lithuanian AI responses were invisible to the booking detection regex.

## Fix
- Added 8 Lithuanian HIGH_CONFIDENCE patterns (vizitas patvirtintas, rezervacija patvirtinta, etc.)
- Added 5 Lithuanian MEDIUM_CONFIDENCE patterns (lauksime jūsų, patvirtinu vizitą, etc.)
- Added LT name extraction (Ačiū, Manta → extracts "Manta")
- Added LT close keywords (atšaukti, nebenoriu, nerašykite)
- Added LT license plate context keywords (numerį, registracij)

## Test coverage
8 new tests covering LT high/medium confidence, false positive guards, car model extraction, name extraction, and close keywords. 794/794 pass.

## No backfill needed
Only test traffic affected (owner testing with own phone +37067577829).

## Known limitation
Regex-based detection is brittle for multi-language. Long-term: migrate to OpenAI structured output.