### PR TITLE
fix(lt-pilot): add 'numeris' to LT plate context with telefono-numeris guard

### DIFF
--- a/apps/api/src/services/booking-intent.ts
+++ b/apps/api/src/services/booking-intent.ts
@@ -212,6 +212,17 @@ const PLATE_PATTERNS = [
   /\b([A-Z]{1,3}\d{1,2}[\s-]?[A-Z]{1,3})\b/, // vanity-style
 ];
 
+/**
+ * Lithuanian context check for "numeris" (number) — must be plate context,
+ * not phone context. "telefono numeris" → phone, skip. Bare "numeris ABC123" → plate.
+ */
+function hasPlateContextLt(lower: string): boolean {
+  if (!lower.includes("numeris")) return false;
+  // Exclude phone-number context
+  if (/telefono\s+numeris|tel\.?\s*numeris|tel\s+nr/i.test(lower)) return false;
+  return true;
+}
+
 function extractLicensePlate(customerMessage: string, aiResponse: string): string | null {
   const combined = customerMessage + " " + aiResponse;
   // Only look for plates if contextual keywords are nearby
@@ -222,7 +233,8 @@ function extractLicensePlate(customerMessage: string, aiResponse: string): strin
     !lower.includes("license") &&
     !lower.includes("registration") &&
     !lower.includes("numerį") &&         // LT: registracijos numerį (registration number)
-    !lower.includes("registracij")
+    !lower.includes("registracij") &&
+    !hasPlateContextLt(lower)
   ) {
     return null;
   }

--- a/apps/api/src/tests/booking-intent.test.ts
+++ b/apps/api/src/tests/booking-intent.test.ts
@@ -475,4 +475,20 @@ describe("detectBookingIntent — Lithuanian patterns", () => {
     );
     expect(r.userWantsClose).toBe(true);
   });
+
+  it("extracts license plate when 'numeris' precedes plate (LT context)", () => {
+    const r = detectBookingIntent(
+      "Ačiū, registruoju jūsų vizitą.",
+      "Mano automobilio numeris ABC123, atvyksiu rytoj."
+    );
+    expect(r.licensePlate).toBe("ABC123");
+  });
+
+  it("does NOT extract plate from 'telefono numeris' (phone context, false positive guard)", () => {
+    const r = detectBookingIntent(
+      "Ačiū už informaciją.",
+      "Mano telefono numeris yra +37067577829, skambinkit."
+    );
+    expect(r.licensePlate).toBeNull();
+  });
 });


### PR DESCRIPTION
Fixes plate extraction failure for LT customers using bare 'numeris' (was only matching 'numerį' accusative). Guards against phone-number false positives. 796/796 tests pass.