### PR TITLE
fix(build): add locale fields to Google OAuth + signup JWT signs

### DIFF
--- a/apps/api/src/routes/auth/google.ts
+++ b/apps/api/src/routes/auth/google.ts
@@ -443,8 +443,11 @@ export async function googleAuthRoute(app: FastifyInstance) {
         id: string;
         shop_name: string;
         owner_email: string;
+        locale: string;
+        currency: string;
+        timezone: string;
       }>(
-        `SELECT id, shop_name, owner_email FROM tenants WHERE owner_email = $1 LIMIT 1`,
+        `SELECT id, shop_name, owner_email, locale, currency, timezone FROM tenants WHERE owner_email = $1 LIMIT 1`,
         [normalizedEmail]
       );
 
@@ -491,7 +494,7 @@ export async function googleAuthRoute(app: FastifyInstance) {
             "New tenant created via Google signup — demo mode"
           );
 
-          tenant = { id: tenantId, shop_name: "My Shop", owner_email: normalizedEmail };
+          tenant = { id: tenantId, shop_name: "My Shop", owner_email: normalizedEmail, locale: "en-US", currency: "USD", timezone: "America/Chicago" };
           isNewAccount = true;
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : "unknown";
@@ -513,7 +516,13 @@ export async function googleAuthRoute(app: FastifyInstance) {
 
       // Issue JWT — same format as email/password login
       const jwt = app.jwt.sign(
-        { tenantId: tenant.id, email: tenant.owner_email },
+        {
+          tenantId: tenant.id,
+          email: tenant.owner_email,
+          locale: tenant.locale || "en-US",
+          currency: tenant.currency || "USD",
+          timezone: tenant.timezone || "America/Chicago",
+        },
         { expiresIn: "24h" }
       );
 

--- a/apps/api/src/routes/auth/signup.ts
+++ b/apps/api/src/routes/auth/signup.ts
@@ -160,7 +160,13 @@ export async function signupRoute(app: FastifyInstance) {
 
     // ── Issue JWT ────────────────────────────────────────────────────────────
     const token = app.jwt.sign(
-      { tenantId, email: normalizedEmail },
+      {
+        tenantId,
+        email: normalizedEmail,
+        locale: "en-US",
+        currency: "USD",
+        timezone: "America/Chicago",
+      },
       { expiresIn: "24h" }
     );
 

--- a/apps/api/src/tests/tenants.test.ts
+++ b/apps/api/src/tests/tenants.test.ts
@@ -32,6 +32,9 @@ function makeTenant(overrides: Partial<Tenant> = {}): Tenant {
     provisioning_state: "ready",
     provisioning_error_reason: null,
     is_pilot_tenant: false,
+    locale: "en-US",
+    currency: "USD",
+    timezone: "America/Chicago",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
Fixes Render build failure caused by TypeScript compile error.

PR #511 extended the JWT payload type with `locale`/`currency`/`timezone` but `google.ts` and `signup.ts` still signed JWTs without those fields, causing `tsc` to fail during Docker build.

- `google.ts`: query now includes locale/currency/timezone, JWT sign includes them
- `signup.ts`: new signups default to en-US/USD/America/Chicago
- `tenants.test.ts`: mock Tenant factory includes new fields

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Full suite: 819/819 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)