### PR TITLE
feat(lt-pilot): expand Proteros services + system prompt v3

### DIFF
--- a/db/migrations/046_lt_services_expanded.sql
+++ b/db/migrations/046_lt_services_expanded.sql
@@ -1,0 +1,21 @@
+-- Migration 046 (LT pilot): expanded services_description for Proteros Servisas
+--
+-- Apr 2026 user feedback: AI refused to book a tire-change appointment
+-- citing "tik remonto paslaugas" (only repair services). The previous
+-- services_description (set in 043_lt_tenant_context.sql) listed core
+-- services but did not explicitly include common pilot-shop work like
+-- tire mounting/balancing, transmission, clutch, exhaust, or pre-TÜV
+-- preparation. The AI prompt injects this string verbatim, so a narrow
+-- list directly causes scope rejections.
+--
+-- This migration broadens the canonical services list. Companion
+-- migration 047_lt_system_prompt_v3.sql also adjusts the prompt to
+-- explicitly accept all car repair / maintenance requests.
+--
+-- Idempotent: targeted UPDATE keyed on the LT pilot tenant email.
+-- Safe to re-run; safe for non-LT tenants (filter is exact-match).
+
+UPDATE tenants
+   SET services_description = 'Bendrieji remonto darbai, variklio diagnostika, stabdžių sistema, pakaba ir vairo mechanizmas, ratų geometrija, padangų keitimas ir montavimas, ratų keitimas ir balansavimas, alyvos ir filtrų keitimas, kondicionieriaus pildymas ir remontas, akumuliatoriaus patikra ir keitimas, prieš-techninės apžiūros patikrinimas, elektros sistemos diagnostika, greičių dėžės remontas, sankabos keitimas, išmetimo sistemos remontas, automobilio paruošimas techninei apžiūrai.',
+       updated_at = NOW()
+ WHERE owner_email = 'mantas.gipiskis+lt@gmail.com';

--- a/db/migrations/047_lt_system_prompt_v3.sql
+++ b/db/migrations/047_lt_system_prompt_v3.sql
@@ -1,0 +1,52 @@
+-- Migration 047 (LT pilot): Lithuanian system prompt v3 for Proteros Servisas
+--
+-- Iteration on v2 (migration 044). Apr 2026 user feedback: AI refused
+-- to book a tire/wheel change citing "teikiame tik remonto paslaugas"
+-- (we only offer repair services). v2 rule was too narrow.
+--
+-- v3 changes vs v2:
+-- 1. New explicit "PRIIMAMOS PASLAUGOS:" scope block stating that all
+--    car repair / maintenance requests must be accepted, with concrete
+--    examples (tires, diagnostics, brakes, oil) so the model does not
+--    pattern-match "tire" as out-of-scope.
+-- 2. STILIUS rule about non-repair services rewritten to target only
+--    truly out-of-scope work (car wash, interior valeting) instead of
+--    any non-"repair" word, and uses "remonto IR priežiūros" so it is
+--    consistent with the new scope block.
+--
+-- All other v2 directives are preserved verbatim (no-repeat, multi-field
+-- extraction, business-hours discipline, "Vizitas patvirtintas!"
+-- confirmation phrase).
+--
+-- Idempotent: deactivates v2 if present, upserts v3 active.
+
+DO $$
+DECLARE
+  v_tid UUID;
+BEGIN
+  SELECT id INTO v_tid
+    FROM tenants
+   WHERE owner_email = 'mantas.gipiskis+lt@gmail.com'
+   LIMIT 1;
+
+  IF v_tid IS NULL THEN
+    RAISE NOTICE 'LT pilot tenant not found — skipping prompt v3';
+    RETURN;
+  END IF;
+
+  -- Deactivate v1, v2 (and any other older versions)
+  UPDATE system_prompts SET is_active = FALSE WHERE tenant_id = v_tid AND version < 3;
+
+  INSERT INTO system_prompts (tenant_id, version, prompt_text, is_active)
+  VALUES (
+    v_tid,
+    3,
+    E'Jūs esate autoserviso „Proteros Servisas" (Panevėžys) dirbtinio intelekto asistentas, bendraujantis su klientais SMS žinutėmis.\n\nUŽDUOTIS:\nPadėti klientui užsiregistruoti vizitui. Surinkti: vardas, automobilio markė/modelis, gedimo aprašymas, pageidaujamas laikas. Numerį (valstybinį) — nebūtinas, bet jei klientas pamini, įsidėmėk.\n\nPRIIMAMOS PASLAUGOS:\nPriimk visas užklausas susijusias su automobilių remontu ir priežiūra, įskaitant bet neapsiribojant: ratų/padangų keitimą, variklio diagnostiką, stabdžių remontą, alyvos keitimą ir kitus serviso darbus.\n\nPAGRINDINĖS TAISYKLĖS:\n1. NIEKADA nekartok klausimo apie informaciją, kuri jau pateikta pokalbyje. Sek pokalbio istoriją ir užfiksuok visus jau gautus laukus.\n2. Jei vienoje kliento žinutėje pateikti keli laukai (pvz. „Mantas, BMW X5, numeris ABC123, 15 val."), išgauk VISUS laukus iš karto. Neklausk po vieną, jei jie jau yra.\n3. Nesugalvok darbo valandų ar prieinamų laikų. Jei klientas siūlo laiką darbo valandomis (Pr–Pn 08:00–18:00, Št 09:00–14:00) — priimk. Jei ne darbo valandomis — pasiūlyk artimiausią darbo laiką.\n4. Kai surinkai vardą, automobilį, gedimą IR laiką, AIŠKIAI patvirtink fraze: „Vizitas patvirtintas!" ir nurodyk pilnas detales (klientas, automobilis, data ir laikas). Ši frazė YRA būtina sistemos atpažinimui.\n5. Jei klientas tiesiog patvirtina („taip", „tinka", „patvirtinu") ir visi duomenys surinkti — IŠ KARTO užbaik fraze „Vizitas patvirtintas!" su detalėmis.\n\nSTILIUS:\n- Visada kreipkitės „jūs" forma (formaliai).\n- Atsakymai trumpi: maksimum 2 sakiniai. SMS, ne email.\n- Atsakykite tik lietuviškai.\n- Nesiūlykite papildomų paslaugų, jei klientas neprašo.\n- Jei klausia apie ne-automobilio paslaugas (pvz. plovimas, vidaus valymas) — mandagiai paaiškinkite, kad teikiame tik automobilių remonto ir priežiūros paslaugas.\n- Jei negalite padėti — pasakykite, kad servisas susisieks tiesiogiai.\n\nNiekada nesakykite „palaukite" ar „tikrinu sistemoje" — atsakykite iškart pagal turimą informaciją.',
+    TRUE
+  )
+  ON CONFLICT (tenant_id, version) DO UPDATE
+    SET prompt_text = EXCLUDED.prompt_text,
+        is_active = TRUE;
+
+  RAISE NOTICE 'LT system prompt v3 applied for tenant %', v_tid;
+END $$;


### PR DESCRIPTION
## Summary
- User feedback: AI refused a tire-change booking citing "tik remonto paslaugas" (only repair services)
- Broaden canonical services list AND rewrite the prompt rule that caused the rejection
- LT-only — US tenants untouched (both migrations filter on `owner_email='mantas.gipiskis+lt@gmail.com'`)

## Changes
- `db/migrations/046_lt_services_expanded.sql` — adds tires (mounting/balancing), alignment, AC, electrical diagnostics, transmission, clutch, exhaust, and TÜV preparation to `services_description`
- `db/migrations/047_lt_system_prompt_v3.sql`:
  - New `PRIIMAMOS PASLAUGOS` scope block explicitly accepting all car repair / maintenance requests with concrete examples (tires, diagnostics, brakes, oil)
  - STILIUS rule about non-repair work rewritten to target only genuinely out-of-scope services (car wash, interior valeting); uses "remonto IR priežiūros" so it's consistent with the new scope block
  - All other v2 directives preserved verbatim (no-repeat, multi-field extraction, business-hours discipline, "Vizitas patvirtintas!" trigger phrase)
  - Inserts as `version=3, is_active=true`; deactivates v1/v2

## Test plan
- [x] Both migrations idempotent (DO block + ON CONFLICT upsert)
- [ ] Render auto-applies migrations on deploy; check `/admin/tenants/<lt-id>/settings` reflects new services_description and v3 prompt
- [ ] Real LT pilot test: customer SMS asks about tire change → AI accepts and proceeds with booking flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)