### PR TITLE
feat(dashboard): auto-refresh conversations and dashboard views

### DIFF
--- a/apps/web/app.html
+++ b/apps/web/app.html
@@ -5454,6 +5454,9 @@ function switchView(view, opts) {
       history.pushState({ view: view }, '', newPath + window.location.search);
     }
   }
+
+  // Start/stop auto-refresh polling for the new view (no-op if already armed)
+  applyPollingForView(view);
 }
 
 // Handle browser back/forward
@@ -5461,6 +5464,122 @@ window.addEventListener('popstate', function(e) {
   var view = (e.state && e.state.view) ? e.state.view : getViewFromPath();
   switchView(view, { skipPush: true });
 });
+
+// ════════════════════════════════════════════
+// AUTO-REFRESH POLLING
+// ════════════════════════════════════════════
+// Re-fetches data on the active view so new SMS messages and KPI
+// changes appear without a page reload. Uses the same authenticated
+// endpoints as the initial loads — pure-frontend addition with zero
+// backend impact and no LT/US tenant divergence.
+//
+// Ticks are gated on document.visibilityState (paused when tab hidden)
+// and on JWT presence (paused when logged out). Intervals stay armed;
+// each tick decides whether to fire.
+var _convPollInterval = null;
+var _dashPollInterval = null;
+var POLL_CONV_MS = 15000;
+var POLL_DASH_MS = 30000;
+
+function _shouldPoll() {
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return false;
+  if (!localStorage.getItem('autoshop_jwt')) return false;
+  return true;
+}
+
+async function _refreshOpenThread() {
+  if (!selectedConversationId) return;
+  var id = selectedConversationId;
+  try {
+    var token = localStorage.getItem('autoshop_jwt');
+    var res = await fetch('/tenant/conversations/' + id, {
+      headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+    });
+    if (!res.ok) return;
+    var json = await res.json();
+    if (!json.messages) return;
+    var existing = (convThreads[id] && convThreads[id].thread) || [];
+    if (json.messages.length === existing.length) return;
+
+    var _total = json.messages.length;
+    var _capped = _total > CONV_THREAD_MESSAGE_CAP;
+    var _slice = _capped ? json.messages.slice(-CONV_THREAD_MESSAGE_CAP) : json.messages;
+    var conv = conversationsData.find(function(c) { return c.id === id; });
+    var prev = convThreads[id] || {};
+    convThreads[id] = {
+      title: prev.title || (conv ? (conv.customerName || conv.phone) : 'Conversation'),
+      meta: prev.meta || (conv ? conv.phone : ''),
+      thread: _slice.map(function(m) {
+        return {
+          d: m.direction === 'outbound' ? 'ai' : 'customer',
+          t: m.body,
+          ts: m.sent_at ? fmtDate(m.sent_at) : ''
+        };
+      }),
+      _truncatedTotal: _capped ? _total : 0,
+      result: prev.result || null,
+      info: prev.info || []
+    };
+    var body = document.getElementById('convThreadBody');
+    if (body && selectedConversationId === id) {
+      renderConvThread(body, convThreads[id]);
+      // Keep the latest message visible after auto-refresh
+      body.scrollTop = body.scrollHeight;
+    }
+  } catch (e) { /* swallow — next tick retries */ }
+}
+
+function startConversationPolling() {
+  if (_convPollInterval) return;
+  _convPollInterval = setInterval(async function() {
+    if (!_shouldPoll()) return;
+    try {
+      await loadConversationsData(); // re-renders inbox via renderConvInbox()
+      await _refreshOpenThread();
+    } catch (e) { console.warn('Conversation poll failed:', e); }
+  }, POLL_CONV_MS);
+}
+
+function stopConversationPolling() {
+  if (_convPollInterval) { clearInterval(_convPollInterval); _convPollInterval = null; }
+}
+
+function startDashboardPolling() {
+  if (_dashPollInterval) return;
+  _dashPollInterval = setInterval(async function() {
+    if (!_shouldPoll()) return;
+    try {
+      var ok = await loadDashboardData();
+      if (!ok) return;
+      // Mirror the initial-load render set so new live conversations,
+      // KPIs, revenue, and pipeline rows appear after each tick.
+      renderBanners();
+      renderLiveKPIs();
+      renderDashConvTable(liveConversationsData);
+      renderLiveRevenueBlocks();
+      renderLivePipeline();
+      renderSidebarStatus();
+      renderSystemHero();
+    } catch (e) { console.warn('Dashboard poll failed:', e); }
+  }, POLL_DASH_MS);
+}
+
+function stopDashboardPolling() {
+  if (_dashPollInterval) { clearInterval(_dashPollInterval); _dashPollInterval = null; }
+}
+
+function applyPollingForView(view) {
+  if (view === 'conversations') {
+    stopDashboardPolling();
+    startConversationPolling();
+  } else if (view === 'dashboard') {
+    stopConversationPolling();
+    startDashboardPolling();
+  } else {
+    stopConversationPolling();
+    stopDashboardPolling();
+  }
+}
 
 // ════════════════════════════════════════════
 // SETTINGS TABS


### PR DESCRIPTION
## Summary
- New SMS messages now appear in the dashboard within 15s without a page refresh
- Conversations view polls `/tenant/conversations` every 15s; open thread polled on the same tick
- Dashboard view polls `/tenant/dashboard` every 30s and re-renders KPIs, live conversations, revenue, pipeline, etc.
- Frontend-only — no backend changes, no LT/US divergence

## Behavior
- Polling is gated on `document.visibilityState !== 'hidden'` and JWT presence (no traffic when tab is backgrounded or logged out)
- `applyPollingForView(view)` wired into `switchView` — navigating away stops the poller, switching back resumes
- Open-thread refresh: re-fetches `/tenant/conversations/:id`, only mutates DOM when `messages.length` grew, then auto-scrolls to the latest message

## Test plan
- [x] Full vitest suite still passes (824/824, 17.95s)
- [ ] Manual: open conversations view, send test SMS to LT pilot number, new message appears within 15s without page refresh
- [ ] Manual: open dashboard, send test SMS, KPIs/live-conv table refresh within 30s
- [ ] Manual: hide tab → poll stops; un-hide → poll resumes
- [ ] Manual: logout → poll stops

## USA safety
- Frontend-only, no backend code touched
- Uses same authenticated endpoints as initial loads
- Identical behavior across all tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)