### PR TITLE
feat(admin): POST /internal/admin/cooldowns/clear for pilot debugging

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -47,6 +47,7 @@ import { devLoopRoute } from "./routes/internal/dev-loop";
 import { devLoopExecuteRoute } from "./routes/internal/dev-loop-execute";
 import { leadsRoute } from "./routes/internal/leads";
 import { zadarmaWebhookRoute } from "./routes/internal/zadarma-webhook";
+import { adminCooldownsRoute } from "./routes/internal/admin-cooldowns";
 import { db } from "./db/client";
 import { redis } from "./queues/redis";
 import { deadLetterQueue } from "./queues/dead-letter";
@@ -172,6 +173,7 @@ async function bootstrap() {
   // Zadarma's Notifications URL cannot send custom auth headers, so this
   // endpoint must be publicly reachable. See zadarma-webhook.ts for details.
   await app.register(zadarmaWebhookRoute, { prefix: "/internal" });
+  await app.register(adminCooldownsRoute, { prefix: "/internal" });
   await app.register(googleAuthRoute, { prefix: "/auth/google" });
   await app.register(loginRoute, { prefix: "/auth" });
   await app.register(signupRoute, { prefix: "/auth" });

--- a/apps/api/src/routes/internal/admin-cooldowns.ts
+++ b/apps/api/src/routes/internal/admin-cooldowns.ts
@@ -1,0 +1,80 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { query } from "../../db/client";
+import { requireInternal } from "../../middleware/require-internal";
+
+const E164 = z.string().regex(/^\+\d{7,15}$/, "Must be E.164 phone format");
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid(),
+  customerPhone: E164,
+  closeOpen: z.boolean().optional(),
+});
+
+/**
+ * POST /internal/admin/cooldowns/clear
+ *
+ * Operational tool for pilot debugging: removes the
+ * conversation_cooldowns row that blocks a customer phone from being
+ * re-engaged within 1 hour of a previous conversation closing.
+ *
+ * Optional `closeOpen: true` also closes any currently-open
+ * conversation rows for that (tenant, customerPhone) pair so the next
+ * inbound call/SMS opens a fresh thread instead of resuming.
+ *
+ * Internal-only — guarded by requireInternal (x-internal-key header).
+ */
+export async function adminCooldownsRoute(app: FastifyInstance) {
+  app.post(
+    "/admin/cooldowns/clear",
+    { preHandler: [requireInternal] },
+    async (request, reply) => {
+      const parsed = BodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({
+          error: "Validation failed",
+          details: parsed.error.issues.map(
+            (i) => `${i.path.join(".")}: ${i.message}`
+          ),
+        });
+      }
+
+      const { tenantId, customerPhone, closeOpen } = parsed.data;
+
+      const cooldownRows = await query<{ id: string }>(
+        `DELETE FROM conversation_cooldowns
+          WHERE tenant_id = $1 AND customer_phone = $2
+          RETURNING tenant_id AS id`,
+        [tenantId, customerPhone]
+      );
+      const deleted = cooldownRows.length;
+
+      let closed: number | undefined;
+      if (closeOpen) {
+        const closedRows = await query<{ id: string }>(
+          `UPDATE conversations
+              SET status = 'closed',
+                  close_reason = 'admin_cleared',
+                  closed_at = NOW()
+            WHERE tenant_id = $1
+              AND customer_phone = $2
+              AND status = 'open'
+            RETURNING id`,
+          [tenantId, customerPhone]
+        );
+        closed = closedRows.length;
+      }
+
+      request.log.info(
+        { tenantId, customerPhone, deleted, closed: closed ?? null },
+        "admin/cooldowns/clear"
+      );
+
+      return reply.status(200).send(
+        closeOpen
+          ? { ok: true, deleted, closed }
+          : { ok: true, deleted }
+      );
+    }
+  );
+}

--- a/apps/api/src/tests/admin-cooldowns.test.ts
+++ b/apps/api/src/tests/admin-cooldowns.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../db/client", () => ({
+  db: { end: vi.fn() },
+  query: mocks.query,
+}));
+
+import { adminCooldownsRoute } from "../routes/internal/admin-cooldowns";
+
+const TENANT_ID = "7d82ab25-e991-4d13-b4ac-846865f8b85a";
+const PHONE = "+37067577829";
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminCooldownsRoute, { prefix: "/internal" });
+  return app;
+}
+
+describe("POST /internal/admin/cooldowns/clear", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_API_KEY = "test-internal-key";
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_API_KEY;
+  });
+
+  it("clears cooldown row and returns deleted count", async () => {
+    mocks.query.mockResolvedValueOnce([{ id: TENANT_ID }]); // DELETE returns 1 row
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      headers: { "x-internal-key": "test-internal-key" },
+      payload: { tenantId: TENANT_ID, customerPhone: PHONE },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, deleted: 1 });
+
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("DELETE FROM conversation_cooldowns");
+    expect(sql).toContain("RETURNING");
+    expect(params).toEqual([TENANT_ID, PHONE]);
+  });
+
+  it("returns deleted:0 when no cooldown row exists (not an error)", async () => {
+    mocks.query.mockResolvedValueOnce([]);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      headers: { "x-internal-key": "test-internal-key" },
+      payload: { tenantId: TENANT_ID, customerPhone: PHONE },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("with closeOpen=true also closes any open conversation rows", async () => {
+    mocks.query
+      .mockResolvedValueOnce([{ id: TENANT_ID }]) // cooldown DELETE
+      .mockResolvedValueOnce([{ id: "conv-1" }, { id: "conv-2" }]); // conversations UPDATE
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      headers: { "x-internal-key": "test-internal-key" },
+      payload: { tenantId: TENANT_ID, customerPhone: PHONE, closeOpen: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, deleted: 1, closed: 2 });
+
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+    const [sql2, params2] = mocks.query.mock.calls[1] as [string, unknown[]];
+    expect(sql2).toContain("UPDATE conversations");
+    expect(sql2).toContain("status = 'closed'");
+    expect(sql2).toContain("close_reason = 'admin_cleared'");
+    expect(sql2).toContain("WHERE tenant_id");
+    expect(sql2).toContain("status = 'open'");
+    expect(params2).toEqual([TENANT_ID, PHONE]);
+  });
+
+  it("returns 400 on missing tenantId", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      headers: { "x-internal-key": "test-internal-key" },
+      payload: { customerPhone: PHONE },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("Validation failed");
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid E.164 phone", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      headers: { "x-internal-key": "test-internal-key" },
+      payload: { tenantId: TENANT_ID, customerPhone: "not-a-phone" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects 403 without x-internal-key", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/admin/cooldowns/clear",
+      payload: { tenantId: TENANT_ID, customerPhone: PHONE },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Pilot debugging tool to clear the 1h anti-abuse `conversation_cooldowns` row that blocks `handleMissedCallSms` after a conversation closes
- Optional `closeOpen: true` also closes any currently-open conversation rows for the same (tenant, customerPhone)
- Internal-only — guarded by `requireInternal` (`x-internal-key` header)

## Background
Real-call test on the LT pilot returned `service_error: "Conversation blocked: cooldown"` (Render logs at 13:17 UTC). The previous test conversation had closed cleanly at 13:02:56 UTC, but the 1h cooldown in `apps/api/src/services/conversation.ts:108-126` blocked all further missed-call SMS to the same phone. Without this endpoint the only options were ad-hoc Render Shell SQL or the full-tenant reset (too destructive).

## Behavior
- `POST /internal/admin/cooldowns/clear`
- Body (zod-validated): `{ tenantId: UUID, customerPhone: E.164, closeOpen?: boolean }`
- Default response: `{ ok: true, deleted: <count> }`
- With `closeOpen: true`: `{ ok: true, deleted: <count>, closed: <count> }`
- Closed conversations get `close_reason='admin_cleared'` for audit clarity

## Test plan
- [x] 6 new tests cover: happy-path delete, no-match returns `deleted:0`, closeOpen path, missing-field 400, bad-phone 400, missing-internal-key 403
- [x] Full vitest suite passes (830/830, 18.61s)
- [ ] Post-deploy: clear cooldown for LT pilot, then real-call test to verify SMS arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)