### PR TITLE
fix(db): allow admin_cleared in conversations.close_reason CHECK

### DIFF
--- a/db/migrations/054_admin_cleared_close_reason.sql
+++ b/db/migrations/054_admin_cleared_close_reason.sql
@@ -1,0 +1,26 @@
+-- Migration 054: allow 'admin_cleared' as a conversations.close_reason value
+--
+-- The admin cooldown-clear endpoint (PR #520) closes any open
+-- conversations for a (tenant, customer) pair so the next inbound
+-- event opens a fresh thread. It writes close_reason='admin_cleared'
+-- for audit clarity, but the original CHECK constraint from
+-- 001_init.sql does not include that value, causing a 23514 error.
+--
+-- This migration drops the existing CHECK and re-adds it with
+-- 'admin_cleared' included.
+--
+-- Idempotent: drop-if-exists then add.
+
+ALTER TABLE conversations
+  DROP CONSTRAINT IF EXISTS conversations_close_reason_check;
+
+ALTER TABLE conversations
+  ADD CONSTRAINT conversations_close_reason_check
+  CHECK (close_reason IN (
+    'booking_completed',
+    'user_closed',
+    'inactivity_24h',
+    'system_blocked',
+    'turn_limit',
+    'admin_cleared'
+  ));


### PR DESCRIPTION
## Summary
PR #520's `POST /internal/admin/cooldowns/clear` writes `close_reason='admin_cleared'` when `closeOpen=true`. The CHECK constraint from `001_init.sql` doesn't allow that value → 500 (23514) on the closeOpen path. Migration 054 adds the value to the allow-list.

## Why tests didn't catch it
Tests mock `query()` and assert SQL strings, never hitting the real constraint.

## Verification
- [x] Migration is a simple constraint swap, idempotent (DROP IF EXISTS + ADD)
- [ ] Post-deploy: re-run `POST /internal/admin/cooldowns/clear` with `closeOpen: true` → expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)