### PR TITLE
feat: dynamic business hours from Google Sheet

### DIFF
--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -291,8 +291,11 @@ class AppRepository(
         conversationDao.closeOldBooked(cutoff)
     }
 
-    private fun isBusinessHours(): Boolean =
-        BusinessCalendar.isBusinessHours(java.time.LocalDateTime.now(BusinessCalendar.ZONE))
+    private suspend fun isBusinessHours(): Boolean {
+        val kb = sheetsClient.getKnowledge()
+        val (start, end) = BusinessCalendar.parseWorkingHours(kb.workingHours)
+        return BusinessCalendar.isBusinessHours(java.time.LocalDateTime.now(BusinessCalendar.ZONE), start, end)
+    }
 
     suspend fun setTakeover(phone: String, takeover: Boolean) {
         conversationDao.setTakeover(phone, takeover)

--- a/android-app/app/src/main/java/com/proteros/smsai/util/BusinessCalendar.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/BusinessCalendar.kt
@@ -54,10 +54,23 @@ object BusinessCalendar {
         }
     }
 
-    fun isBusinessHours(now: LocalDateTime): Boolean {
+    fun isBusinessHours(now: LocalDateTime, startHour: Int = 8, endHour: Int = 17): Boolean {
         val dow = now.dayOfWeek
         if (dow == DayOfWeek.SUNDAY || dow == DayOfWeek.SATURDAY) return false
         if (isLithuanianHoliday(now.toLocalDate())) return false
-        return now.hour in 8..16
+        return now.hour in startHour until endHour
+    }
+
+    fun parseWorkingHours(hoursStr: String): Pair<Int, Int> {
+        try {
+            val timePart = hoursStr.substringAfter(" ").trim()
+            val parts = timePart.split("-")
+            if (parts.size == 2) {
+                val start = parts[0].trim().substringBefore(":").toIntOrNull() ?: 8
+                val end = parts[1].trim().substringBefore(":").toIntOrNull() ?: 17
+                return start to end
+            }
+        } catch (_: Exception) {}
+        return 8 to 17
     }
 }

--- a/android-app/app/src/test/java/com/proteros/smsai/util/BusinessCalendarTest.kt
+++ b/android-app/app/src/test/java/com/proteros/smsai/util/BusinessCalendarTest.kt
@@ -120,6 +120,24 @@ class BusinessCalendarTest {
         assertEquals(LocalDateTime.of(2025, 12, 29, 8, 0, 0), slot)
     }
 
+    // --- parseWorkingHours ---
+
+    @Test
+    fun `parseWorkingHours standard format`() {
+        assertEquals(8 to 17, BusinessCalendar.parseWorkingHours("I-V 8:00-17:00"))
+    }
+
+    @Test
+    fun `parseWorkingHours extended hours`() {
+        assertEquals(7 to 20, BusinessCalendar.parseWorkingHours("I-V 7:00-20:00"))
+    }
+
+    @Test
+    fun `parseWorkingHours custom business hours`() {
+        assertTrue(BusinessCalendar.isBusinessHours(LocalDateTime.of(2025, 6, 16, 19, 0), 8, 20))
+        assertFalse(BusinessCalendar.isBusinessHours(LocalDateTime.of(2025, 6, 16, 19, 0), 8, 17))
+    }
+
     @Test
     fun `Friday 4pm returns Monday 8am`() {
         val slot = BusinessCalendar.findNextSlot(LocalDateTime.of(2025, 6, 20, 16, 0))


### PR DESCRIPTION
Business hours now read from Google Sheet instead of hardcoded.\nChange \"I-V 8:00-20:00\" in Sheet → AI replies until 20:00.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_