### PR TITLE
fix: Groovy BigDecimal cast in version format

### DIFF
--- a/android-app/app/build.gradle
+++ b/android-app/app/build.gradle
@@ -24,7 +24,7 @@ android {
         targetSdk 34
         versionCode Integer.parseInt(System.getenv('BUILD_NUMBER') ?: '1')
         def buildNum = Integer.parseInt(System.getenv('BUILD_NUMBER') ?: '1')
-        versionName String.format("%d.%02d", buildNum / 100, buildNum % 100)
+        versionName String.format("%d.%02d", (int)(buildNum / 100), (int)(buildNum % 100))
 
         buildConfigField "String", "DEFAULT_API_KEY", "\"${System.getenv('DEFAULT_API_KEY') ?: ''}\""
         buildConfigField "String", "DEFAULT_CALENDAR_ID", "\"${System.getenv('DEFAULT_CALENDAR_ID') ?: ''}\""


### PR DESCRIPTION
Build #111 failed: Groovy integer division returns BigDecimal, String.format(\"%d\") needs int. Added explicit cast.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_