### PR TITLE
Use real Google Calendar availability for slot suggestions

### DIFF
--- a/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
@@ -3,7 +3,6 @@ package com.proteros.smsai.api
 import android.content.Context
 import com.proteros.smsai.data.Message
 import com.proteros.smsai.util.AppLog
-import com.proteros.smsai.util.BusinessCalendar
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -29,12 +28,6 @@ class ClaudeApiClient(private val context: Context) {
         val kb = knowledgeBase
         val now = java.time.LocalDateTime.now()
         val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-        val dayFormatter = java.time.format.DateTimeFormatter.ofPattern("EEEE", java.util.Locale("lt"))
-        val slot1 = BusinessCalendar.findNextSlot(now)
-        val slot2 = BusinessCalendar.findNextSlot(slot1.plusHours(1))
-        val slot1Str = "${slot1.format(dayFormatter)} ${slot1.format(formatter)}"
-        val slot2Str = "${slot2.format(dayFormatter)} ${slot2.format(formatter)}"
-
         val servicesList = kb.services.joinToString("\n") { s ->
             val priceInfo = if (s.price.isNotBlank() && s.price != "Pagal apžiūrą") " (${s.price})" else ""
             val descInfo = if (s.description.isNotBlank()) " — ${s.description}" else ""
@@ -71,7 +64,7 @@ SVARBIOS TAISYKLĖS:
 $rulesBlock
 - Priimk BET KOKIĄ su automobiliu susijusią užklausą. Jei klientas aprašo paslaugą kitais žodžiais nei sąraše (pvz "padangos" = "Ratų montavimas", "alyvos keitimas" = "Tepalų keitimas") — suprask ką turi omenyje ir registruok. NIEKADA nesakyk kad paslaugos neteikiame.
 - Kiekvienas vizitas trunka ${kb.visitDuration} min.
-- Kai klientas parašo problemą — iškart pasiūlyk 2 artimiausius laisvus laikus: $slot1Str arba $slot2Str.
+- Kai klientas parašo problemą — iškart pasiūlyk 2 artimiausius laisvus laikus iš pateiktų laisvų laikų sąrašo.
 - Jei klientas nurodo pageidaujamą dieną (pvz "penktadienį") — pasiūlyk 2 laisvus laikus tą dieną arba artimiausią darbo dieną.
 - Jei klientas sutinka su vienu iš pasiūlytų laikų — iškart registruok.
 - Registracijos patvirtinime NERAŠYK adreso — sistema automatiškai pridės adresą ir žemėlapio nuorodą.

--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -156,9 +156,27 @@ class AppRepository(
         val rescheduleContext = if (convo.rescheduleCount > 0 && !convo.bookingDateTime.isNullOrBlank()) {
             "\nKlientas nori PAKEISTI vizito laiką. Senas laikas: ${convo.bookingDateTime}. Paslauga: ${convo.bookingService ?: "ta pati"}. Pasiūlyk 2 naujus laikus ir kai sutiks — registruok su [BOOKING:...] formatu."
         } else null
+
+        val availableSlots = try {
+            val now = java.time.LocalDateTime.now()
+            val fmt = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+            val start = BusinessCalendar.findNextSlot(now).format(fmt)
+            val slot1 = calendarClient.findNextFreeSlot(start)
+            val slot2 = slot1?.let { calendarClient.findNextFreeSlot(it) }
+            val slot3 = slot2?.let { calendarClient.findNextFreeSlot(it) }
+            listOfNotNull(slot1, slot2, slot3)
+        } catch (e: Exception) {
+            AppLog.e("AppRepo", "Failed to fetch calendar slots", e)
+            emptyList()
+        }
+        val slotsContext = if (availableSlots.isNotEmpty()) {
+            "\nArtimiausi LAISVI laikai kalendoriuje: ${availableSlots.joinToString(", ")}. Siūlyk TIK šiuos laikus."
+        } else null
+
+        val extraInfo = listOfNotNull(rescheduleContext, slotsContext).joinToString("").ifEmpty { null }
         sheetsClient.logEvent("SMS", phone, body)
 
-        val aiResponse = claudeClient.generateReply(phone, historyWithoutLatest, body, convo.contactName, rescheduleContext)
+        val aiResponse = claudeClient.generateReply(phone, historyWithoutLatest, body, convo.contactName, extraInfo)
         lastAiCallTime[phone] = System.currentTimeMillis()
         AppLog.i("AppRepo", "AI reply for $phone: ${aiResponse.text}")
 


### PR DESCRIPTION
## Summary
- Query GoogleCalendarClient.findNextFreeSlot() for 2-3 real free slots before each AI reply
- Inject actual availability into system prompt so AI only suggests free times
- Remove hardcoded BusinessCalendar slots that didn't check calendar occupancy
- Graceful fallback if calendar is unreachable

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_