### PR TITLE
Fix: stop app from responding to private SMS

### DIFF
--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -81,15 +81,8 @@ class AppRepository(
 
         var convo = conversationDao.getByPhone(phone)
         if (convo == null) {
-            AppLog.i("AppRepo", "No conversation for $phone, creating new one")
-            val contactName = ContactLookup.findName(context, phone)
-            conversationDao.insertIgnore(
-                Conversation(phoneNumber = phone, status = Conversation.STATUS_ACTIVE, contactName = contactName)
-            )
-            convo = conversationDao.getByPhone(phone) ?: run {
-                AppLog.e("AppRepo", "Failed to create conversation for $phone")
-                return
-            }
+            AppLog.i("AppRepo", "No app-initiated conversation for $phone, ignoring private SMS")
+            return
         }
         if (convo.contactName == null) {
             val contactName = ContactLookup.findName(context, phone)


### PR DESCRIPTION
## Summary
- App was creating conversations for ANY incoming SMS, including private owner-client messages
- Now only responds to SMS from numbers with existing app-initiated conversation (created by missed call)
- Private SMS not logged to Sheet, not saved to DB, not responded to

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_