### PR TITLE
Anonymize private data in debug logs

### DIFF
--- a/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.api
 import android.content.Context
 import com.proteros.smsai.data.Message
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -97,7 +98,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
     }
 
     fun generateGreeting(phone: String): String {
-        AppLog.i(TAG, "generateGreeting for $phone")
+        AppLog.i(TAG, "generateGreeting for ${maskPhone(phone)}")
         return knowledgeBase.greeting
     }
 
@@ -115,7 +116,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
     suspend fun generateReply(phone: String, history: List<Message>, latestMessage: String, contactName: String? = null, extraInfo: String? = null): AiReply = withContext(Dispatchers.IO) {
         refreshKnowledge()
         val apiKey = SecurePrefs.getApiKey(context)
-        AppLog.i(TAG, "generateReply for $phone, hasApiKey=${!apiKey.isNullOrBlank()}, historySize=${history.size}")
+        AppLog.i(TAG, "generateReply for ${maskPhone(phone)}, hasApiKey=${!apiKey.isNullOrBlank()}, historySize=${history.size}")
         if (apiKey.isNullOrBlank()) return@withContext AiReply("Atsiprašome, šiuo metu negalime atsakyti.${if (knowledgeBase.phone.isNotBlank()) " Paskambinkite ${knowledgeBase.phone}." else ""}")
 
         try {
@@ -142,7 +143,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
             val nameContext = if (!contactName.isNullOrBlank()) "\nKliento vardas: $contactName. Kreipkis vardu." else "\nKliento vardas nežinomas. Neskreipk vardu."
             val fullContext = nameContext + (extraInfo ?: "")
             val responseText = callClaude(apiKey, (0 until messages.length()).map { messages.getJSONObject(it) }, fullContext)
-            AppLog.i(TAG, "Reply for $phone (${responseText.length} chars)")
+            AppLog.i(TAG, "Reply for ${maskPhone(phone)} (${responseText.length} chars)")
 
             val bookingRegex = """\[BOOKING:([^|]+)\|(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})]""".toRegex()
             val match = bookingRegex.find(responseText)
@@ -158,7 +159,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
                 AiReply(text = responseText)
             }
         } catch (e: Exception) {
-            AppLog.e(TAG, "generateReply failed for $phone", e)
+            AppLog.e(TAG, "generateReply failed for ${maskPhone(phone)}", e)
             AiReply("Atsiprašome, įvyko klaida. Pabandykite vėliau arba skambinkite tiesiogiai.")
         }
     }

--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.data
 import android.content.Context
 import com.proteros.smsai.util.AgentNotification
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.BusinessCalendar
 import com.proteros.smsai.api.ClaudeApiClient
 import com.proteros.smsai.api.GoogleCalendarClient
@@ -32,16 +33,16 @@ class AppRepository(
     suspend fun handleMissedCall(rawPhone: String) {
         archiveOldConversations()
         val phone = PhoneUtils.normalize(rawPhone)
-        AppLog.i("AppRepo", "handleMissedCall: $phone")
+        AppLog.i("AppRepo", "handleMissedCall: ${maskPhone(phone)}")
 
         val existing = conversationDao.getByPhone(phone)
         if (existing != null && (existing.status == Conversation.STATUS_ACTIVE || existing.status == Conversation.STATUS_BOOKED)) {
-            AppLog.i("AppRepo", "Conversation already exists for $phone (${existing.status}), skipping")
+            AppLog.i("AppRepo", "Conversation already exists for ${maskPhone(phone)} (${existing.status}), skipping")
             return
         }
 
         val contactName = ContactLookup.findName(context, phone)
-        AppLog.i("AppRepo", "Contact name for $phone: ${contactName ?: "unknown"}")
+        AppLog.i("AppRepo", "Contact lookup for ${maskPhone(phone)}")
 
         conversationDao.insertIgnore(
             Conversation(phoneNumber = phone, status = Conversation.STATUS_ACTIVE, contactName = contactName)
@@ -53,7 +54,7 @@ class AppRepository(
 
         claudeClient.refreshKnowledge()
         val greeting = claudeClient.generateGreeting(phone)
-        AppLog.i("AppRepo", "Generated greeting for $phone: $greeting")
+        AppLog.i("AppRepo", "Greeting generated for ${maskPhone(phone)}")
 
         messageDao.insert(
             Message(conversationPhone = phone, sender = Message.SENDER_AI, body = greeting)
@@ -65,7 +66,7 @@ class AppRepository(
         val result = smsSender.sendWithRetry(phone, greeting)
         if (result.isFailure) {
             val error = result.exceptionOrNull()?.message ?: "Nežinoma klaida"
-            AppLog.e("AppRepo", "SMS send exception for $phone: $error")
+            AppLog.e("AppRepo", "SMS send exception for ${maskPhone(phone)}: $error")
             messageDao.insert(
                 Message(conversationPhone = phone, sender = Message.SENDER_SYSTEM, body = "SMS klaida: $error")
             )
@@ -77,11 +78,11 @@ class AppRepository(
     suspend fun handleIncomingSms(rawPhone: String, body: String) {
         archiveOldConversations()
         val phone = PhoneUtils.normalize(rawPhone)
-        AppLog.i("AppRepo", "handleIncomingSms from $phone: $body")
+        AppLog.i("AppRepo", "handleIncomingSms from ${maskPhone(phone)} (${body.length} chars)")
 
         var convo = conversationDao.getByPhone(phone)
         if (convo == null) {
-            AppLog.i("AppRepo", "No app-initiated conversation for $phone, ignoring private SMS")
+            AppLog.i("AppRepo", "No app-initiated conversation for ${maskPhone(phone)}, ignoring private SMS")
             return
         }
         if (convo.contactName == null) {
@@ -97,13 +98,13 @@ class AppRepository(
         )
 
         if (convo.ownerTakeover) {
-            AppLog.i("AppRepo", "Owner takeover active for $phone, skipping AI reply")
+            AppLog.i("AppRepo", "Owner takeover active for ${maskPhone(phone)}, skipping AI reply")
             return
         }
 
         if (convo.status == Conversation.STATUS_BOOKED) {
             if (convo.rescheduleCount >= 1) {
-                AppLog.i("AppRepo", "Reschedule limit reached for $phone, sending final confirmation")
+                AppLog.i("AppRepo", "Reschedule limit reached for ${maskPhone(phone)}")
                 val confirmMsg = "Jūsų vizitas: ${convo.bookingDateTime ?: "užregistruotas"}. Dėl pakeitimų skambinkite."
                 messageDao.insert(
                     Message(conversationPhone = phone, sender = Message.SENDER_AI, body = confirmMsg)
@@ -117,7 +118,7 @@ class AppRepository(
                 return
             }
 
-            AppLog.i("AppRepo", "Allowing reschedule for $phone (count=${convo.rescheduleCount})")
+            AppLog.i("AppRepo", "Allowing reschedule for ${maskPhone(phone)} (count=${convo.rescheduleCount})")
             conversationDao.updateStatus(phone, Conversation.STATUS_ACTIVE)
             conversationDao.incrementReschedule(phone)
             messageDao.insert(
@@ -128,14 +129,14 @@ class AppRepository(
         val now = System.currentTimeMillis()
         val lastCall = lastAiCallTime[phone]
         if (lastCall != null && now - lastCall < AI_COOLDOWN_MS) {
-            AppLog.i("AppRepo", "Rate limit: skipping AI call for $phone (cooldown ${AI_COOLDOWN_MS}ms)")
+            AppLog.i("AppRepo", "Rate limit: skipping AI call for ${maskPhone(phone)}")
             return
         }
 
         val history = messageDao.getForConversation(phone)
         val aiTurns = history.count { it.sender == Message.SENDER_AI }
         if (aiTurns >= maxAiTurns) {
-            AppLog.i("AppRepo", "Max AI turns ($maxAiTurns) reached for $phone, handing over to owner")
+            AppLog.i("AppRepo", "Max AI turns ($maxAiTurns) reached for ${maskPhone(phone)}, handing over")
             conversationDao.setTakeover(phone, true)
             AgentNotification.handoverToOwner(context, phone)
             messageDao.insert(
@@ -170,7 +171,7 @@ class AppRepository(
 
         val aiResponse = claudeClient.generateReply(phone, historyWithoutLatest, body, convo.contactName, extraInfo)
         lastAiCallTime[phone] = System.currentTimeMillis()
-        AppLog.i("AppRepo", "AI reply for $phone: ${aiResponse.text}")
+        AppLog.i("AppRepo", "AI reply for ${maskPhone(phone)} (${aiResponse.text.length} chars)")
 
         if (aiResponse.bookingDetected) {
             AppLog.i("AppRepo", "Booking detected: ${aiResponse.service} at ${aiResponse.dateTime}")
@@ -180,7 +181,7 @@ class AppRepository(
             } catch (_: Exception) { true }
 
             if (!slotFree) {
-                AppLog.i("AppRepo", "Time slot conflict for $phone at ${aiResponse.dateTime}")
+                AppLog.i("AppRepo", "Time slot conflict for ${maskPhone(phone)}")
                 val nextFree = try {
                     aiResponse.dateTime?.let { calendarClient.findNextFreeSlot(it) }
                 } catch (_: Exception) { null }

--- a/android-app/app/src/main/java/com/proteros/smsai/receiver/MissedCallReceiver.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/receiver/MissedCallReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.telephony.TelephonyManager
 import com.proteros.smsai.AutoShopApp
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,7 @@ class MissedCallReceiver : BroadcastReceiver() {
             TelephonyManager.EXTRA_STATE_RINGING -> {
                 @Suppress("DEPRECATION")
                 val number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)
-                AppLog.i(TAG, "RINGING from: $number")
+                AppLog.i(TAG, "RINGING from: ${number?.let { maskPhone(it) }}")
                 prefs.edit()
                     .putString("last_state", "RINGING")
                     .putString("incoming_number", number)
@@ -45,20 +46,20 @@ class MissedCallReceiver : BroadcastReceiver() {
             TelephonyManager.EXTRA_STATE_IDLE -> {
                 val lastState = prefs.getString("last_state", null)
                 val number = prefs.getString("incoming_number", null)
-                AppLog.i(TAG, "IDLE - lastState=$lastState, number=$number")
+                AppLog.i(TAG, "IDLE - lastState=$lastState")
 
                 prefs.edit().putString("last_state", "IDLE").apply()
 
                 if (lastState == "RINGING" && !number.isNullOrBlank()) {
-                    AppLog.i(TAG, "MISSED CALL DETECTED from $number")
+                    AppLog.i(TAG, "MISSED CALL DETECTED from ${maskPhone(number)}")
                     val app = context.applicationContext as AutoShopApp
                     val pending = goAsync()
                     CoroutineScope(Dispatchers.IO).launch {
                         try {
                             app.repository.handleMissedCall(number)
-                            AppLog.i(TAG, "handleMissedCall completed for $number")
+                            AppLog.i(TAG, "handleMissedCall completed for ${maskPhone(number)}")
                         } catch (e: Exception) {
-                            AppLog.e(TAG, "handleMissedCall failed for $number", e)
+                            AppLog.e(TAG, "handleMissedCall failed for ${maskPhone(number)}", e)
                         } finally {
                             pending.finish()
                         }

--- a/android-app/app/src/main/java/com/proteros/smsai/receiver/SmsReceiver.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/receiver/SmsReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.provider.Telephony
 import com.proteros.smsai.AutoShopApp
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,7 +37,7 @@ class SmsReceiver : BroadcastReceiver() {
             return
         }
         val grouped = messages.groupBy { it.displayOriginatingAddress }
-        AppLog.i("SmsReceiver", "Received SMS from ${grouped.keys}")
+        AppLog.i("SmsReceiver", "Received SMS from ${grouped.keys.map { it?.let { maskPhone(it) } }}")
 
         val app = context.applicationContext as AutoShopApp
 
@@ -45,18 +46,18 @@ class SmsReceiver : BroadcastReceiver() {
             val body = parts.joinToString("") { it.displayMessageBody ?: "" }
 
             if (isDuplicate("$sender|$body")) {
-                AppLog.i("SmsReceiver", "Duplicate SMS from $sender, skipping")
+                AppLog.i("SmsReceiver", "Duplicate SMS from ${maskPhone(sender)}, skipping")
                 continue
             }
 
-            AppLog.i("SmsReceiver", "Processing SMS from $sender (${body.length} chars)")
+            AppLog.i("SmsReceiver", "Processing SMS from ${maskPhone(sender)} (${body.length} chars)")
 
             val pending = goAsync()
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     app.repository.handleIncomingSms(sender, body)
                 } catch (e: Exception) {
-                    AppLog.e("SmsReceiver", "Error handling SMS from $sender", e)
+                    AppLog.e("SmsReceiver", "Error handling SMS from ${maskPhone(sender)}", e)
                 } finally {
                     pending.finish()
                 }

--- a/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.ui
 import androidx.lifecycle.*
 import com.proteros.smsai.data.AppRepository
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
@@ -33,7 +34,7 @@ class ConversationViewModel(
     val error: LiveData<String?> = _error
 
     init {
-        AppLog.i(TAG, "Init for phone: '$phone' (len=${phone.length}, bytes=${phone.toByteArray().joinToString(",") { it.toString() }})")
+        AppLog.i(TAG, "Init for phone: ${maskPhone(phone)}")
         viewModelScope.launch {
             try {
                 val convo = repo.conversationDao.getByPhone(phone)
@@ -43,8 +44,7 @@ class ConversationViewModel(
                 _status.postValue(convo?.status)
 
                 if (convo == null) {
-                    val all = repo.conversationDao.getAllOnce()
-                    AppLog.e(TAG, "No conversation for '$phone'. All phones in DB: ${all.map { "'${it.phoneNumber}'" }}")
+                    AppLog.e(TAG, "No conversation found for ${maskPhone(phone)}")
                 }
             } catch (e: Exception) {
                 AppLog.e(TAG, "Failed to load conversation", e)
@@ -57,11 +57,7 @@ class ConversationViewModel(
                         AppLog.e(TAG, "Messages flow error", e)
                     }
                     .collect { list ->
-                        AppLog.i(TAG, "Messages loaded: ${list.size} for phone='$phone'")
-                        if (list.isEmpty()) {
-                            val allMsgs = repo.messageDao.getAllMessages()
-                            AppLog.w(TAG, "0 messages for '$phone'. Total messages in DB: ${allMsgs.size}. Phones: ${allMsgs.map { it.conversationPhone }.distinct()}")
-                        }
+                        AppLog.i(TAG, "Messages loaded: ${list.size} for ${maskPhone(phone)}")
                         _messages.postValue(list.map { m ->
                             ChatItem(text = m.body, sender = m.sender, timestamp = m.timestamp)
                         })

--- a/android-app/app/src/main/java/com/proteros/smsai/util/AppLog.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/AppLog.kt
@@ -18,6 +18,8 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 
+fun maskPhone(phone: String): String = "***${phone.takeLast(4)}"
+
 object AppLog {
     private val logs = CopyOnWriteArrayList<String>()
     private val pendingSheetLogs = CopyOnWriteArrayList<List<Any>>()

--- a/android-app/app/src/main/java/com/proteros/smsai/util/ContactLookup.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/ContactLookup.kt
@@ -22,7 +22,7 @@ object ContactLookup {
                 } else null
             }
         } catch (e: Exception) {
-            AppLog.e("ContactLookup", "Failed to lookup $phone", e)
+            AppLog.e("ContactLookup", "Failed to lookup ${maskPhone(phone)}", e)
             null
         }
     }

--- a/android-app/app/src/main/java/com/proteros/smsai/util/SmsSender.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/SmsSender.kt
@@ -43,8 +43,8 @@ class SmsSender(private val context: Context) {
                 override fun onReceive(ctx: Context, intent: Intent) {
                     try { context.unregisterReceiver(this) } catch (_: Exception) {}
                     when (resultCode) {
-                        Activity.RESULT_OK -> Log.i("SmsSender", "SMS sent OK to $phone")
-                        else -> Log.e("SmsSender", "SMS send failed to $phone, code=$resultCode")
+                        Activity.RESULT_OK -> Log.i("SmsSender", "SMS sent OK to ${maskPhone(phone)}")
+                        else -> Log.e("SmsSender", "SMS send failed to ${maskPhone(phone)}, code=$resultCode")
                     }
                 }
             }
@@ -64,10 +64,10 @@ class SmsSender(private val context: Context) {
                     }, null)
             }
 
-            Log.i("SmsSender", "SMS dispatched to $phone (${text.length} chars, ${parts.size} parts)")
+            Log.i("SmsSender", "SMS dispatched to ${maskPhone(phone)} (${text.length} chars, ${parts.size} parts)")
             Result.success(Unit)
         } catch (e: Exception) {
-            Log.e("SmsSender", "SMS exception for $phone", e)
+            Log.e("SmsSender", "SMS exception for ${maskPhone(phone)}", e)
             Result.failure(e)
         }
     }
@@ -75,7 +75,7 @@ class SmsSender(private val context: Context) {
     suspend fun sendWithRetry(phone: String, text: String): Result<Unit> {
         val first = sendFireAndForget(phone, text)
         if (first.isSuccess) return first
-        Log.i("SmsSender", "Retrying SMS to $phone in 3s...")
+        Log.i("SmsSender", "Retrying SMS to ${maskPhone(phone)} in 3s...")
         kotlinx.coroutines.delay(3000)
         return sendFireAndForget(phone, text)
     }


### PR DESCRIPTION
## Summary\n- Replace full phone numbers with `maskPhone()` (`***XXXX`) in all log statements across 8 files\n- Remove excessive debug logging from ConversationViewModel (byte arrays, all-phones-in-DB dumps)\n- SMS pokalbių Sheet (full conversations) unchanged — only logcat + Logai Sheet tab anonymized\n\n## Test plan\n- [ ] Verify app sends/receives SMS normally\n- [ ] Check Logai Sheet tab shows `***XXXX` instead of full numbers\n- [ ] Confirm SMS Sheet tab still shows full conversation data\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_