### PR TITLE
Add owner call-back and manual booking

### DIFF
--- a/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/api/ClaudeApiClient.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.api
 import android.content.Context
 import com.proteros.smsai.data.Message
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -97,7 +98,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
     }
 
     fun generateGreeting(phone: String): String {
-        AppLog.i(TAG, "generateGreeting for $phone")
+        AppLog.i(TAG, "generateGreeting for ${maskPhone(phone)}")
         return knowledgeBase.greeting
     }
 
@@ -115,7 +116,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
     suspend fun generateReply(phone: String, history: List<Message>, latestMessage: String, contactName: String? = null, extraInfo: String? = null): AiReply = withContext(Dispatchers.IO) {
         refreshKnowledge()
         val apiKey = SecurePrefs.getApiKey(context)
-        AppLog.i(TAG, "generateReply for $phone, hasApiKey=${!apiKey.isNullOrBlank()}, historySize=${history.size}")
+        AppLog.i(TAG, "generateReply for ${maskPhone(phone)}, hasApiKey=${!apiKey.isNullOrBlank()}, historySize=${history.size}")
         if (apiKey.isNullOrBlank()) return@withContext AiReply("Atsiprašome, šiuo metu negalime atsakyti.${if (knowledgeBase.phone.isNotBlank()) " Paskambinkite ${knowledgeBase.phone}." else ""}")
 
         try {
@@ -142,7 +143,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
             val nameContext = if (!contactName.isNullOrBlank()) "\nKliento vardas: $contactName. Kreipkis vardu." else "\nKliento vardas nežinomas. Neskreipk vardu."
             val fullContext = nameContext + (extraInfo ?: "")
             val responseText = callClaude(apiKey, (0 until messages.length()).map { messages.getJSONObject(it) }, fullContext)
-            AppLog.i(TAG, "Reply for $phone (${responseText.length} chars)")
+            AppLog.i(TAG, "Reply for ${maskPhone(phone)} (${responseText.length} chars)")
 
             val bookingRegex = """\[BOOKING:([^|]+)\|(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})]""".toRegex()
             val match = bookingRegex.find(responseText)
@@ -158,7 +159,7 @@ NENAUDOK jokio markdown formatavimo (**, *, # ir pan.) — tai SMS žinutė, ra�
                 AiReply(text = responseText)
             }
         } catch (e: Exception) {
-            AppLog.e(TAG, "generateReply failed for $phone", e)
+            AppLog.e(TAG, "generateReply failed for ${maskPhone(phone)}", e)
             AiReply("Atsiprašome, įvyko klaida. Pabandykite vėliau arba skambinkite tiesiogiai.")
         }
     }

--- a/android-app/app/src/main/java/com/proteros/smsai/api/GoogleCalendarClient.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/api/GoogleCalendarClient.kt
@@ -193,9 +193,9 @@ class GoogleCalendarClient(private val context: Context) {
 
     suspend fun isSlotAvailable(dateTime: String): Boolean = withContext(Dispatchers.IO) {
         try {
-            val calService = getService() ?: return@withContext true
+            val calService = getService() ?: return@withContext false
             val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-            val date = sdf.parse(dateTime) ?: return@withContext true
+            val date = sdf.parse(dateTime) ?: return@withContext false
             val startTime = DateTime(date, TimeZone.getTimeZone("Europe/Vilnius"))
             val endTime = DateTime(java.util.Date(date.time + 3600000), TimeZone.getTimeZone("Europe/Vilnius"))
 
@@ -208,7 +208,7 @@ class GoogleCalendarClient(private val context: Context) {
             events.items.isNullOrEmpty()
         } catch (e: Exception) {
             AppLog.e("CalendarClient", "isSlotAvailable failed", e)
-            true
+            false
         }
     }
 

--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -177,8 +177,8 @@ class AppRepository(
             AppLog.i("AppRepo", "Booking detected: ${aiResponse.service} at ${aiResponse.dateTime}")
 
             val slotFree = try {
-                aiResponse.dateTime?.let { calendarClient.isSlotAvailable(it) } ?: true
-            } catch (_: Exception) { true }
+                aiResponse.dateTime?.let { calendarClient.isSlotAvailable(it) } ?: false
+            } catch (_: Exception) { false }
 
             if (!slotFree) {
                 AppLog.i("AppRepo", "Time slot conflict for ${maskPhone(phone)}")

--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -296,6 +296,65 @@ class AppRepository(
         return BusinessCalendar.isBusinessHours(java.time.LocalDateTime.now(BusinessCalendar.ZONE), start, end)
     }
 
+    suspend fun closeConversation(phone: String) {
+        conversationDao.updateStatus(phone, Conversation.STATUS_CLOSED)
+        messageDao.insert(
+            Message(conversationPhone = phone, sender = Message.SENDER_SYSTEM, body = "Savininkas uždarė pokalbį")
+        )
+        val convo = conversationDao.getByPhone(phone)
+        sheetsClient.logEvent("Uždarytas", phone, "Savininkas uždarė pokalbį", contactName = convo?.contactName)
+    }
+
+    suspend fun createManualBooking(phone: String, service: String, dateTime: String): Result<String?> {
+        return try {
+            val convo = conversationDao.getByPhone(phone)
+            val history = messageDao.getForConversation(phone)
+            val chatSummary = history
+                .filter { it.sender != Message.SENDER_SYSTEM }
+                .takeLast(6)
+                .joinToString("\n") { msg ->
+                    val prefix = when (msg.sender) {
+                        Message.SENDER_CLIENT -> "Klientas"
+                        Message.SENDER_OWNER -> "Savininkas"
+                        else -> "AI"
+                    }
+                    "$prefix: ${msg.body}"
+                }
+            val kb = sheetsClient.getKnowledge()
+            val serviceDuration = kb.services
+                .firstOrNull { it.name.equals(service, ignoreCase = true) }
+                ?.durationMin ?: kb.visitDuration
+
+            val eventId = calendarClient.createAppointment(
+                clientPhone = phone,
+                service = service,
+                dateTime = dateTime,
+                contactName = convo?.contactName,
+                conversationSummary = chatSummary,
+                durationMin = serviceDuration
+            )
+            conversationDao.setBooked(phone, eventId ?: "", service, dateTime)
+            messageDao.insert(
+                Message(conversationPhone = phone, sender = Message.SENDER_SYSTEM,
+                    body = if (eventId != null) "Savininkas užregistravo: $service $dateTime" else "Savininkas užregistravo: $service $dateTime (be kalendoriaus)")
+            )
+            sheetsClient.logEvent("Savininko booking", phone, "$service | $dateTime", contactName = convo?.contactName)
+            Result.success(eventId)
+        } catch (e: Exception) {
+            AppLog.e("AppRepo", "Manual booking failed", e)
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getServiceNames(): List<String> {
+        return try {
+            sheetsClient.getKnowledge().services.map { it.name }
+        } catch (e: Exception) {
+            AppLog.e("AppRepo", "Failed to load services", e)
+            emptyList()
+        }
+    }
+
     suspend fun setTakeover(phone: String, takeover: Boolean) {
         conversationDao.setTakeover(phone, takeover)
         val label = if (takeover) "Savininkas perėmė pokalbį" else "AI agentas vėl aktyvus"

--- a/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/data/AppRepository.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.data
 import android.content.Context
 import com.proteros.smsai.util.AgentNotification
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.BusinessCalendar
 import com.proteros.smsai.api.ClaudeApiClient
 import com.proteros.smsai.api.GoogleCalendarClient
@@ -32,16 +33,16 @@ class AppRepository(
     suspend fun handleMissedCall(rawPhone: String) {
         archiveOldConversations()
         val phone = PhoneUtils.normalize(rawPhone)
-        AppLog.i("AppRepo", "handleMissedCall: $phone")
+        AppLog.i("AppRepo", "handleMissedCall: ${maskPhone(phone)}")
 
         val existing = conversationDao.getByPhone(phone)
         if (existing != null && (existing.status == Conversation.STATUS_ACTIVE || existing.status == Conversation.STATUS_BOOKED)) {
-            AppLog.i("AppRepo", "Conversation already exists for $phone (${existing.status}), skipping")
+            AppLog.i("AppRepo", "Conversation already exists for ${maskPhone(phone)} (${existing.status}), skipping")
             return
         }
 
         val contactName = ContactLookup.findName(context, phone)
-        AppLog.i("AppRepo", "Contact name for $phone: ${contactName ?: "unknown"}")
+        AppLog.i("AppRepo", "Contact lookup for ${maskPhone(phone)}")
 
         conversationDao.insertIgnore(
             Conversation(phoneNumber = phone, status = Conversation.STATUS_ACTIVE, contactName = contactName)
@@ -53,7 +54,7 @@ class AppRepository(
 
         claudeClient.refreshKnowledge()
         val greeting = claudeClient.generateGreeting(phone)
-        AppLog.i("AppRepo", "Generated greeting for $phone: $greeting")
+        AppLog.i("AppRepo", "Greeting generated for ${maskPhone(phone)}")
 
         messageDao.insert(
             Message(conversationPhone = phone, sender = Message.SENDER_AI, body = greeting)
@@ -65,7 +66,7 @@ class AppRepository(
         val result = smsSender.sendWithRetry(phone, greeting)
         if (result.isFailure) {
             val error = result.exceptionOrNull()?.message ?: "Nežinoma klaida"
-            AppLog.e("AppRepo", "SMS send exception for $phone: $error")
+            AppLog.e("AppRepo", "SMS send exception for ${maskPhone(phone)}: $error")
             messageDao.insert(
                 Message(conversationPhone = phone, sender = Message.SENDER_SYSTEM, body = "SMS klaida: $error")
             )
@@ -77,11 +78,11 @@ class AppRepository(
     suspend fun handleIncomingSms(rawPhone: String, body: String) {
         archiveOldConversations()
         val phone = PhoneUtils.normalize(rawPhone)
-        AppLog.i("AppRepo", "handleIncomingSms from $phone: $body")
+        AppLog.i("AppRepo", "handleIncomingSms from ${maskPhone(phone)} (${body.length} chars)")
 
         var convo = conversationDao.getByPhone(phone)
         if (convo == null) {
-            AppLog.i("AppRepo", "No app-initiated conversation for $phone, ignoring private SMS")
+            AppLog.i("AppRepo", "No app-initiated conversation for ${maskPhone(phone)}, ignoring private SMS")
             return
         }
         if (convo.contactName == null) {
@@ -97,13 +98,13 @@ class AppRepository(
         )
 
         if (convo.ownerTakeover) {
-            AppLog.i("AppRepo", "Owner takeover active for $phone, skipping AI reply")
+            AppLog.i("AppRepo", "Owner takeover active for ${maskPhone(phone)}, skipping AI reply")
             return
         }
 
         if (convo.status == Conversation.STATUS_BOOKED) {
             if (convo.rescheduleCount >= 1) {
-                AppLog.i("AppRepo", "Reschedule limit reached for $phone, sending final confirmation")
+                AppLog.i("AppRepo", "Reschedule limit reached for ${maskPhone(phone)}")
                 val confirmMsg = "Jūsų vizitas: ${convo.bookingDateTime ?: "užregistruotas"}. Dėl pakeitimų skambinkite."
                 messageDao.insert(
                     Message(conversationPhone = phone, sender = Message.SENDER_AI, body = confirmMsg)
@@ -117,7 +118,7 @@ class AppRepository(
                 return
             }
 
-            AppLog.i("AppRepo", "Allowing reschedule for $phone (count=${convo.rescheduleCount})")
+            AppLog.i("AppRepo", "Allowing reschedule for ${maskPhone(phone)} (count=${convo.rescheduleCount})")
             conversationDao.updateStatus(phone, Conversation.STATUS_ACTIVE)
             conversationDao.incrementReschedule(phone)
             messageDao.insert(
@@ -128,14 +129,14 @@ class AppRepository(
         val now = System.currentTimeMillis()
         val lastCall = lastAiCallTime[phone]
         if (lastCall != null && now - lastCall < AI_COOLDOWN_MS) {
-            AppLog.i("AppRepo", "Rate limit: skipping AI call for $phone (cooldown ${AI_COOLDOWN_MS}ms)")
+            AppLog.i("AppRepo", "Rate limit: skipping AI call for ${maskPhone(phone)}")
             return
         }
 
         val history = messageDao.getForConversation(phone)
         val aiTurns = history.count { it.sender == Message.SENDER_AI }
         if (aiTurns >= maxAiTurns) {
-            AppLog.i("AppRepo", "Max AI turns ($maxAiTurns) reached for $phone, handing over to owner")
+            AppLog.i("AppRepo", "Max AI turns ($maxAiTurns) reached for ${maskPhone(phone)}, handing over")
             conversationDao.setTakeover(phone, true)
             AgentNotification.handoverToOwner(context, phone)
             messageDao.insert(
@@ -170,7 +171,7 @@ class AppRepository(
 
         val aiResponse = claudeClient.generateReply(phone, historyWithoutLatest, body, convo.contactName, extraInfo)
         lastAiCallTime[phone] = System.currentTimeMillis()
-        AppLog.i("AppRepo", "AI reply for $phone: ${aiResponse.text}")
+        AppLog.i("AppRepo", "AI reply for ${maskPhone(phone)} (${aiResponse.text.length} chars)")
 
         if (aiResponse.bookingDetected) {
             AppLog.i("AppRepo", "Booking detected: ${aiResponse.service} at ${aiResponse.dateTime}")
@@ -180,7 +181,7 @@ class AppRepository(
             } catch (_: Exception) { true }
 
             if (!slotFree) {
-                AppLog.i("AppRepo", "Time slot conflict for $phone at ${aiResponse.dateTime}")
+                AppLog.i("AppRepo", "Time slot conflict for ${maskPhone(phone)}")
                 val nextFree = try {
                     aiResponse.dateTime?.let { calendarClient.findNextFreeSlot(it) }
                 } catch (_: Exception) { null }

--- a/android-app/app/src/main/java/com/proteros/smsai/receiver/MissedCallReceiver.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/receiver/MissedCallReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.telephony.TelephonyManager
 import com.proteros.smsai.AutoShopApp
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,7 @@ class MissedCallReceiver : BroadcastReceiver() {
             TelephonyManager.EXTRA_STATE_RINGING -> {
                 @Suppress("DEPRECATION")
                 val number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)
-                AppLog.i(TAG, "RINGING from: $number")
+                AppLog.i(TAG, "RINGING from: ${number?.let { maskPhone(it) }}")
                 prefs.edit()
                     .putString("last_state", "RINGING")
                     .putString("incoming_number", number)
@@ -45,20 +46,20 @@ class MissedCallReceiver : BroadcastReceiver() {
             TelephonyManager.EXTRA_STATE_IDLE -> {
                 val lastState = prefs.getString("last_state", null)
                 val number = prefs.getString("incoming_number", null)
-                AppLog.i(TAG, "IDLE - lastState=$lastState, number=$number")
+                AppLog.i(TAG, "IDLE - lastState=$lastState")
 
                 prefs.edit().putString("last_state", "IDLE").apply()
 
                 if (lastState == "RINGING" && !number.isNullOrBlank()) {
-                    AppLog.i(TAG, "MISSED CALL DETECTED from $number")
+                    AppLog.i(TAG, "MISSED CALL DETECTED from ${maskPhone(number)}")
                     val app = context.applicationContext as AutoShopApp
                     val pending = goAsync()
                     CoroutineScope(Dispatchers.IO).launch {
                         try {
                             app.repository.handleMissedCall(number)
-                            AppLog.i(TAG, "handleMissedCall completed for $number")
+                            AppLog.i(TAG, "handleMissedCall completed for ${maskPhone(number)}")
                         } catch (e: Exception) {
-                            AppLog.e(TAG, "handleMissedCall failed for $number", e)
+                            AppLog.e(TAG, "handleMissedCall failed for ${maskPhone(number)}", e)
                         } finally {
                             pending.finish()
                         }

--- a/android-app/app/src/main/java/com/proteros/smsai/receiver/SmsReceiver.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/receiver/SmsReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.provider.Telephony
 import com.proteros.smsai.AutoShopApp
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import com.proteros.smsai.util.SecurePrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,7 +37,7 @@ class SmsReceiver : BroadcastReceiver() {
             return
         }
         val grouped = messages.groupBy { it.displayOriginatingAddress }
-        AppLog.i("SmsReceiver", "Received SMS from ${grouped.keys}")
+        AppLog.i("SmsReceiver", "Received SMS from ${grouped.keys.map { it?.let { maskPhone(it) } }}")
 
         val app = context.applicationContext as AutoShopApp
 
@@ -45,18 +46,18 @@ class SmsReceiver : BroadcastReceiver() {
             val body = parts.joinToString("") { it.displayMessageBody ?: "" }
 
             if (isDuplicate("$sender|$body")) {
-                AppLog.i("SmsReceiver", "Duplicate SMS from $sender, skipping")
+                AppLog.i("SmsReceiver", "Duplicate SMS from ${maskPhone(sender)}, skipping")
                 continue
             }
 
-            AppLog.i("SmsReceiver", "Processing SMS from $sender (${body.length} chars)")
+            AppLog.i("SmsReceiver", "Processing SMS from ${maskPhone(sender)} (${body.length} chars)")
 
             val pending = goAsync()
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     app.repository.handleIncomingSms(sender, body)
                 } catch (e: Exception) {
-                    AppLog.e("SmsReceiver", "Error handling SMS from $sender", e)
+                    AppLog.e("SmsReceiver", "Error handling SMS from ${maskPhone(sender)}", e)
                 } finally {
                     pending.finish()
                 }

--- a/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationFragment.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationFragment.kt
@@ -1,11 +1,20 @@
 package com.proteros.smsai.ui
 
+import android.app.AlertDialog
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.proteros.smsai.util.AppLog
 import com.proteros.smsai.util.maskPhone
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.LinearLayout
+import android.widget.Spinner
+import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -14,6 +23,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.proteros.smsai.AutoShopApp
 import com.proteros.smsai.databinding.FragmentConversationBinding
+import java.util.Calendar
 
 class ConversationFragment : Fragment() {
 
@@ -53,6 +63,11 @@ class ConversationFragment : Fragment() {
 
         binding.btnBack.setOnClickListener { findNavController().navigateUp() }
 
+        binding.toolbarSubtitle.setOnClickListener {
+            val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:${args.phoneNumber}"))
+            startActivity(intent)
+        }
+
         binding.btnTakeover.setOnClickListener {
             viewModel.toggleTakeover()
         }
@@ -63,6 +78,20 @@ class ConversationFragment : Fragment() {
                 viewModel.sendOwnerMessage(text)
                 binding.editMessage.text?.clear()
             }
+        }
+
+        binding.btnFailed.setOnClickListener {
+            AlertDialog.Builder(requireContext())
+                .setTitle("Uždaryti pokalbį?")
+                .setMessage("Pokalbis bus pažymėtas kaip nepavykęs.")
+                .setPositiveButton("Uždaryti") { _, _ -> viewModel.closeConversation() }
+                .setNegativeButton("Atšaukti", null)
+                .show()
+        }
+
+        binding.btnBooked.setOnClickListener {
+            viewModel.loadServices()
+            showBookingDialog()
         }
 
         viewModel.messages.observe(viewLifecycleOwner) { list ->
@@ -80,16 +109,108 @@ class ConversationFragment : Fragment() {
             binding.btnTakeover.text = if (takeover) "Grąžinti AI" else "Perimti"
             binding.takeoverBanner.visibility = if (takeover) View.VISIBLE else View.GONE
             binding.inputContainer.visibility = if (takeover) View.VISIBLE else View.GONE
+            updateActionButtons()
         }
 
         viewModel.status.observe(viewLifecycleOwner) { status ->
-            val isClosed = status == "closed"
+            val isClosed = status == "closed" || status == "booked"
             binding.btnTakeover.visibility = if (isClosed) View.GONE else View.VISIBLE
+            updateActionButtons()
+        }
+
+        viewModel.bookingDone.observe(viewLifecycleOwner) { done ->
+            if (done) Toast.makeText(context, "Vizitas užregistruotas!", Toast.LENGTH_LONG).show()
         }
 
         viewModel.error.observe(viewLifecycleOwner) { err ->
             if (err != null) Toast.makeText(context, err, Toast.LENGTH_LONG).show()
         }
+
+        // Show phone number as clickable even without contact name
+        binding.toolbarSubtitle.text = args.phoneNumber
+        binding.toolbarSubtitle.visibility = View.VISIBLE
+    }
+
+    private fun updateActionButtons() {
+        val b = _binding ?: return
+        val takeover = viewModel.isTakeover.value == true
+        val status = viewModel.status.value
+        val show = takeover && status != "booked" && status != "closed"
+        b.actionButtonsContainer.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private fun showBookingDialog() {
+        val ctx = requireContext()
+        val cal = Calendar.getInstance()
+        var selectedDate = ""
+        var selectedTime = ""
+
+        val layout = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(48, 32, 48, 16)
+        }
+
+        val serviceSpinner = Spinner(ctx)
+        val serviceLabel = TextView(ctx).apply { text = "Paslauga:" }
+        layout.addView(serviceLabel)
+        layout.addView(serviceSpinner)
+
+        val dateBtn = TextView(ctx).apply {
+            text = "Pasirinkti datą"
+            textSize = 16f
+            setPadding(0, 24, 0, 8)
+            setTextColor(resources.getColor(android.R.color.holo_blue_dark, null))
+        }
+        layout.addView(dateBtn)
+
+        val timeBtn = TextView(ctx).apply {
+            text = "Pasirinkti laiką"
+            textSize = 16f
+            setPadding(0, 16, 0, 8)
+            setTextColor(resources.getColor(android.R.color.holo_blue_dark, null))
+        }
+        layout.addView(timeBtn)
+
+        dateBtn.setOnClickListener {
+            DatePickerDialog(ctx, { _, y, m, d ->
+                selectedDate = "%04d-%02d-%02d".format(y, m + 1, d)
+                dateBtn.text = selectedDate
+            }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)).show()
+        }
+
+        timeBtn.setOnClickListener {
+            TimePickerDialog(ctx, { _, h, m ->
+                selectedTime = "%02d:%02d".format(h, m)
+                timeBtn.text = selectedTime
+            }, 9, 0, true).show()
+        }
+
+        val dialog = AlertDialog.Builder(ctx)
+            .setTitle("Registruoti vizitą")
+            .setView(layout)
+            .setPositiveButton("Registruoti", null)
+            .setNegativeButton("Atšaukti", null)
+            .create()
+
+        viewModel.services.observe(viewLifecycleOwner) { list ->
+            if (list.isNotEmpty()) {
+                serviceSpinner.adapter = ArrayAdapter(ctx, android.R.layout.simple_spinner_dropdown_item, list)
+            }
+        }
+
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                if (selectedDate.isEmpty() || selectedTime.isEmpty()) {
+                    Toast.makeText(ctx, "Pasirinkite datą ir laiką", Toast.LENGTH_SHORT).show()
+                    return@setOnClickListener
+                }
+                val service = serviceSpinner.selectedItem?.toString() ?: "Nenurodyta"
+                viewModel.createManualBooking(service, "$selectedDate $selectedTime")
+                dialog.dismiss()
+            }
+        }
+
+        dialog.show()
     }
 
     override fun onDestroyView() {

--- a/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationFragment.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationFragment.kt
@@ -2,6 +2,7 @@ package com.proteros.smsai.ui
 
 import android.os.Bundle
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,7 +34,7 @@ class ConversationFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        AppLog.i("ConversationFragment", "onViewCreated for phone: ${args.phoneNumber}")
+        AppLog.i("ConversationFragment", "onViewCreated for phone: ${maskPhone(args.phoneNumber)}")
 
         chatAdapter = ChatAdapter()
 

--- a/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
@@ -3,6 +3,7 @@ package com.proteros.smsai.ui
 import androidx.lifecycle.*
 import com.proteros.smsai.data.AppRepository
 import com.proteros.smsai.util.AppLog
+import com.proteros.smsai.util.maskPhone
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
@@ -33,7 +34,7 @@ class ConversationViewModel(
     val error: LiveData<String?> = _error
 
     init {
-        AppLog.i(TAG, "Init for phone: '$phone' (len=${phone.length}, bytes=${phone.toByteArray().joinToString(",") { it.toString() }})")
+        AppLog.i(TAG, "Init for phone: ${maskPhone(phone)}")
         viewModelScope.launch {
             try {
                 val convo = repo.conversationDao.getByPhone(phone)
@@ -43,8 +44,7 @@ class ConversationViewModel(
                 _status.postValue(convo?.status)
 
                 if (convo == null) {
-                    val all = repo.conversationDao.getAllOnce()
-                    AppLog.e(TAG, "No conversation for '$phone'. All phones in DB: ${all.map { "'${it.phoneNumber}'" }}")
+                    AppLog.e(TAG, "No conversation found for ${maskPhone(phone)}")
                 }
             } catch (e: Exception) {
                 AppLog.e(TAG, "Failed to load conversation", e)
@@ -57,11 +57,7 @@ class ConversationViewModel(
                         AppLog.e(TAG, "Messages flow error", e)
                     }
                     .collect { list ->
-                        AppLog.i(TAG, "Messages loaded: ${list.size} for phone='$phone'")
-                        if (list.isEmpty()) {
-                            val allMsgs = repo.messageDao.getAllMessages()
-                            AppLog.w(TAG, "0 messages for '$phone'. Total messages in DB: ${allMsgs.size}. Phones: ${allMsgs.map { it.conversationPhone }.distinct()}")
-                        }
+                        AppLog.i(TAG, "Messages loaded: ${list.size} for ${maskPhone(phone)}")
                         _messages.postValue(list.map { m ->
                             ChatItem(text = m.body, sender = m.sender, timestamp = m.timestamp)
                         })

--- a/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/ui/ConversationViewModel.kt
@@ -2,6 +2,7 @@ package com.proteros.smsai.ui
 
 import androidx.lifecycle.*
 import com.proteros.smsai.data.AppRepository
+import com.proteros.smsai.data.Conversation
 import com.proteros.smsai.util.AppLog
 import com.proteros.smsai.util.maskPhone
 import kotlinx.coroutines.flow.catch
@@ -32,6 +33,12 @@ class ConversationViewModel(
 
     private val _error = MutableLiveData<String?>(null)
     val error: LiveData<String?> = _error
+
+    private val _services = MutableLiveData<List<String>>(emptyList())
+    val services: LiveData<List<String>> = _services
+
+    private val _bookingDone = MutableLiveData(false)
+    val bookingDone: LiveData<Boolean> = _bookingDone
 
     init {
         AppLog.i(TAG, "Init for phone: ${maskPhone(phone)}")
@@ -76,6 +83,45 @@ class ConversationViewModel(
                 _isTakeover.postValue(newState)
             } catch (e: Exception) {
                 AppLog.e(TAG, "toggleTakeover failed", e)
+                _error.postValue(e.message)
+            }
+        }
+    }
+
+    fun loadServices() {
+        viewModelScope.launch {
+            try {
+                _services.postValue(repo.getServiceNames())
+            } catch (e: Exception) {
+                AppLog.e(TAG, "loadServices failed", e)
+            }
+        }
+    }
+
+    fun closeConversation() {
+        viewModelScope.launch {
+            try {
+                repo.closeConversation(phone)
+                _status.postValue(Conversation.STATUS_CLOSED)
+            } catch (e: Exception) {
+                AppLog.e(TAG, "closeConversation failed", e)
+                _error.postValue(e.message)
+            }
+        }
+    }
+
+    fun createManualBooking(service: String, dateTime: String) {
+        viewModelScope.launch {
+            try {
+                val result = repo.createManualBooking(phone, service, dateTime)
+                if (result.isSuccess) {
+                    _status.postValue(Conversation.STATUS_BOOKED)
+                    _bookingDone.postValue(true)
+                } else {
+                    _error.postValue(result.exceptionOrNull()?.message ?: "Registracija nepavyko")
+                }
+            } catch (e: Exception) {
+                AppLog.e(TAG, "createManualBooking failed", e)
                 _error.postValue(e.message)
             }
         }

--- a/android-app/app/src/main/java/com/proteros/smsai/util/AppLog.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/AppLog.kt
@@ -18,6 +18,8 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 
+fun maskPhone(phone: String): String = "***${phone.takeLast(4)}"
+
 object AppLog {
     private val logs = CopyOnWriteArrayList<String>()
     private val pendingSheetLogs = CopyOnWriteArrayList<List<Any>>()

--- a/android-app/app/src/main/java/com/proteros/smsai/util/ContactLookup.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/ContactLookup.kt
@@ -22,7 +22,7 @@ object ContactLookup {
                 } else null
             }
         } catch (e: Exception) {
-            AppLog.e("ContactLookup", "Failed to lookup $phone", e)
+            AppLog.e("ContactLookup", "Failed to lookup ${maskPhone(phone)}", e)
             null
         }
     }

--- a/android-app/app/src/main/java/com/proteros/smsai/util/SmsSender.kt
+++ b/android-app/app/src/main/java/com/proteros/smsai/util/SmsSender.kt
@@ -43,8 +43,8 @@ class SmsSender(private val context: Context) {
                 override fun onReceive(ctx: Context, intent: Intent) {
                     try { context.unregisterReceiver(this) } catch (_: Exception) {}
                     when (resultCode) {
-                        Activity.RESULT_OK -> Log.i("SmsSender", "SMS sent OK to $phone")
-                        else -> Log.e("SmsSender", "SMS send failed to $phone, code=$resultCode")
+                        Activity.RESULT_OK -> Log.i("SmsSender", "SMS sent OK to ${maskPhone(phone)}")
+                        else -> Log.e("SmsSender", "SMS send failed to ${maskPhone(phone)}, code=$resultCode")
                     }
                 }
             }
@@ -64,10 +64,10 @@ class SmsSender(private val context: Context) {
                     }, null)
             }
 
-            Log.i("SmsSender", "SMS dispatched to $phone (${text.length} chars, ${parts.size} parts)")
+            Log.i("SmsSender", "SMS dispatched to ${maskPhone(phone)} (${text.length} chars, ${parts.size} parts)")
             Result.success(Unit)
         } catch (e: Exception) {
-            Log.e("SmsSender", "SMS exception for $phone", e)
+            Log.e("SmsSender", "SMS exception for ${maskPhone(phone)}", e)
             Result.failure(e)
         }
     }
@@ -75,7 +75,7 @@ class SmsSender(private val context: Context) {
     suspend fun sendWithRetry(phone: String, text: String): Result<Unit> {
         val first = sendFireAndForget(phone, text)
         if (first.isSuccess) return first
-        Log.i("SmsSender", "Retrying SMS to $phone in 3s...")
+        Log.i("SmsSender", "Retrying SMS to ${maskPhone(phone)} in 3s...")
         kotlinx.coroutines.delay(3000)
         return sendFireAndForget(phone, text)
     }

--- a/android-app/app/src/main/res/layout/fragment_conversation.xml
+++ b/android-app/app/src/main/res/layout/fragment_conversation.xml
@@ -46,6 +46,8 @@
                 android:layout_height="wrap_content"
                 android:textColor="#B0FFFFFF"
                 android:textSize="12sp"
+                android:drawableStart="@android:drawable/ic_menu_call"
+                android:drawablePadding="4dp"
                 android:visibility="gone" />
 
         </LinearLayout>
@@ -82,6 +84,44 @@
         android:layout_weight="1"
         android:padding="12dp"
         android:clipToPadding="false" />
+
+    <LinearLayout
+        android:id="@+id/action_buttons_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp"
+        android:background="@color/surface"
+        android:elevation="4dp"
+        android:gravity="center"
+        android:visibility="gone">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_failed"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="❌ Nepavyko"
+            android:textSize="14sp"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            app:strokeColor="@android:color/holo_red_dark"
+            android:textColor="@android:color/holo_red_dark"
+            app:cornerRadius="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_booked"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="✅ Sutarta"
+            android:textSize="14sp"
+            app:backgroundTint="@android:color/holo_green_dark"
+            android:textColor="@android:color/white"
+            app:cornerRadius="8dp" />
+
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/input_container"


### PR DESCRIPTION
## Summary
- Clickable phone number in conversation header — opens dialer instantly
- Action buttons (Nepavyko / Sutarta) visible when conversation needs owner attention
- "Nepavyko" closes conversation with confirmation
- "Sutarta" opens booking dialog (service, date, time) → creates calendar event, marks as booked
- All actions logged to Google Sheets

## Test plan
- [ ] Tap phone number → dialer opens
- [ ] Buttons visible only for takeover conversations
- [ ] "Nepavyko" → confirms → closes conversation
- [ ] "Sutarta" → pick service/date/time → calendar event created, status "booked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnhG9XHmHK6HgprtdW8rR)_